### PR TITLE
remove authors from copyright statement in Localizable.strings

### DIFF
--- a/Cryptomator/en.lproj/Localizable.strings
+++ b/Cryptomator/en.lproj/Localizable.strings
@@ -2,7 +2,6 @@
   Localizable.strings
   Cryptomator
 
-  Created by Tobias Hagemann on 19.02.21.
   Copyright © 2021 Skymatic GmbH. All rights reserved.
 */
 

--- a/FileProviderExtensionUI/en.lproj/Localizable.strings
+++ b/FileProviderExtensionUI/en.lproj/Localizable.strings
@@ -2,7 +2,6 @@
   Localizable.strings
   Cryptomator
 
-  Created by Philipp Schmid on 29.06.21.
   Copyright © 2021 Skymatic GmbH. All rights reserved.
 */
 


### PR DESCRIPTION
Localizable.strings contains (as most files created by Xcode) an autogenerated comment containing the name of the author who created this file.

These comments are replicated in translated files, which is kind of misleading, since the translation is most likely done by somebody else.

I didn't edit `de.lproj`, as this should get updated by crowdin automatically.