### PR TITLE
Manually locking a vault in the main app

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4A1EB0D5268A5AA3006D072B /* VaultDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0D4268A5AA3006D072B /* VaultDetector.swift */; };
 		4A1EB0D8268A6DE1006D072B /* AddLocalVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0D7268A6DE1006D072B /* AddLocalVaultViewController.swift */; };
 		4A2245DC24A5E1C600DBA437 /* MetadataManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2245DB24A5E1C600DBA437 /* MetadataManagerTests.swift */; };
+		4A24001A26AE9F3A009DBC2E /* VaultLockingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */; };
 		4A248221266B8D37002D9F59 /* FileProviderAdapterImportDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A248220266B8D37002D9F59 /* FileProviderAdapterImportDocumentTests.swift */; };
 		4A248223266E266E002D9F59 /* FolderCreationTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A248222266E266E002D9F59 /* FolderCreationTask.swift */; };
 		4A248225266E26D7002D9F59 /* FolderCreationTaskExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A248224266E26D7002D9F59 /* FolderCreationTaskExecutor.swift */; };
@@ -122,7 +123,6 @@
 		4A8F14A2266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8F14A1266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift */; };
 		4A9172822619F17C003C4043 /* CryptomatorCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 4A9172812619F17C003C4043 /* CryptomatorCommon */; };
 		4A91728B2619F1D0003C4043 /* CryptomatorCommonCore in Frameworks */ = {isa = PBXBuildFile; productRef = 4A91728A2619F1D0003C4043 /* CryptomatorCommonCore */; };
-		4A9BED62268F1A2500721BAA /* VaultUnlocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BED61268F1A2400721BAA /* VaultUnlocking.swift */; };
 		4A9BED64268F1DB000721BAA /* VaultUnlockingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */; };
 		4A9BED66268F2D9D00721BAA /* UnlockVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */; };
 		4A9BED67268F379300721BAA /* libCryptomatorFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */; };
@@ -329,6 +329,7 @@
 		4A2245D024A5E16300DBA437 /* CryptomatorFileProviderTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CryptomatorFileProviderTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A2245D424A5E16300DBA437 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4A2245DB24A5E1C600DBA437 /* MetadataManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataManagerTests.swift; sourceTree = "<group>"; };
+		4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLockingServiceSource.swift; sourceTree = "<group>"; };
 		4A248220266B8D37002D9F59 /* FileProviderAdapterImportDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterImportDocumentTests.swift; sourceTree = "<group>"; };
 		4A248222266E266E002D9F59 /* FolderCreationTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderCreationTask.swift; sourceTree = "<group>"; };
 		4A248224266E26D7002D9F59 /* FolderCreationTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderCreationTaskExecutor.swift; sourceTree = "<group>"; };
@@ -427,7 +428,6 @@
 		4A8F149D266A2A8200ADBCE4 /* FileProviderAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapter.swift; sourceTree = "<group>"; };
 		4A8F149F266A2FD500ADBCE4 /* FileProviderAdapterGetItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterGetItemTests.swift; sourceTree = "<group>"; };
 		4A8F14A1266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterTestCase.swift; sourceTree = "<group>"; };
-		4A9BED61268F1A2400721BAA /* VaultUnlocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlocking.swift; sourceTree = "<group>"; };
 		4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockingServiceSource.swift; sourceTree = "<group>"; };
 		4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockVaultViewController.swift; sourceTree = "<group>"; };
 		4A9CD5612699C23D00E6C104 /* VaultPasswordKeychainManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultPasswordKeychainManagerTests.swift; sourceTree = "<group>"; };
@@ -932,6 +932,7 @@
 				4AD0F61B24AF203F0026B765 /* FileProvider+Actions.swift */,
 				4AA621DC249A6A8400A0BCBD /* FileProviderEnumerator.swift */,
 				4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */,
+				4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */,
 				4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */,
 				4AFD8C102693204900F77BA6 /* ErrorWrapper.swift */,
 			);
@@ -1065,7 +1066,6 @@
 				740375F42587AEB50023FF53 /* ItemStatus.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
 				740375F52587AEB50023FF53 /* URL+NameCollisionExtension.swift */,
-				4A9BED61268F1A2400721BAA /* VaultUnlocking.swift */,
 				4AE0D8D82653D8F200DF5D22 /* CloudTask */,
 				740376022587AEB60023FF53 /* DB */,
 				740375FD2587AEB60023FF53 /* Locks */,
@@ -1559,6 +1559,7 @@
 				4AFD8C112693204900F77BA6 /* ErrorWrapper.swift in Sources */,
 				4AE7D79525826A0900C5E1D8 /* FileProviderValidationServiceSource.m in Sources */,
 				4AA621D9249A6A8400A0BCBD /* FileProviderExtension.swift in Sources */,
+				4A24001A26AE9F3A009DBC2E /* VaultLockingServiceSource.swift in Sources */,
 				4A9BED64268F1DB000721BAA /* VaultUnlockingServiceSource.swift in Sources */,
 				4AD0F61C24AF203F0026B765 /* FileProvider+Actions.swift in Sources */,
 				4AA621DD249A6A8400A0BCBD /* FileProviderEnumerator.swift in Sources */,
@@ -1736,7 +1737,6 @@
 				4A2482352671110A002D9F59 /* DBManagerError.swift in Sources */,
 				4A511D5B26668E0C000A0E01 /* UploadTaskRecord.swift in Sources */,
 				4A511D5F26668E68000A0E01 /* DeletionTaskRecord.swift in Sources */,
-				4A9BED62268F1A2500721BAA /* VaultUnlocking.swift in Sources */,
 				4A248223266E266E002D9F59 /* FolderCreationTask.swift in Sources */,
 				747F2F2A2587BC250072FB30 /* DatabaseHelper.swift in Sources */,
 				4AEBE8BE2653F4280031487F /* UploadTaskExecutor.swift in Sources */,

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		4A797F8F24AC6731007DDBE1 /* FileProviderItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */; };
 		4A797F9624AC9936007DDBE1 /* CloudProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A797F9524AC9936007DDBE1 /* CloudProviderMock.swift */; };
 		4A797F9824AC9A1B007DDBE1 /* CloudProviderMockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A797F9724AC9A1B007DDBE1 /* CloudProviderMockTests.swift */; };
+		4A79E26926B16993008C9959 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A79E26826B16993008C9959 /* ActionButton.swift */; };
 		4A7B97C225B6F7200044B7FB /* AccountListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B97C125B6F7200044B7FB /* AccountListViewController.swift */; };
 		4A7B97D325B6F7520044B7FB /* AccountListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B97D225B6F7520044B7FB /* AccountListViewModel.swift */; };
 		4A7B97DC25B6F80A0044B7FB /* AccountInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B97DB25B6F80A0044B7FB /* AccountInfo.swift */; };
@@ -412,6 +413,7 @@
 		4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemTests.swift; sourceTree = "<group>"; };
 		4A797F9524AC9936007DDBE1 /* CloudProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudProviderMock.swift; sourceTree = "<group>"; };
 		4A797F9724AC9A1B007DDBE1 /* CloudProviderMockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudProviderMockTests.swift; sourceTree = "<group>"; };
+		4A79E26826B16993008C9959 /* ActionButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
 		4A7B97C125B6F7200044B7FB /* AccountListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListViewController.swift; sourceTree = "<group>"; };
 		4A7B97D225B6F7520044B7FB /* AccountListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListViewModel.swift; sourceTree = "<group>"; };
 		4A7B97DB25B6F80A0044B7FB /* AccountInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountInfo.swift; sourceTree = "<group>"; };
@@ -842,6 +844,7 @@
 		4A8195E325ADB92600F7DDA1 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				4A79E26826B16993008C9959 /* ActionButton.swift */,
 				4A6A521C268B7C8F006F7368 /* BaseNavigationController.swift */,
 				4A644B56267C958F008CBB9A /* ChildCoordinator.swift */,
 				4AFCE53925B9D6A60069C4FC /* CloudAuthenticator.swift */,
@@ -1592,6 +1595,7 @@
 				4A53CC17267CDBFF00853BB3 /* CreateNewVaultChooseFolderViewModel.swift in Sources */,
 				4A6A521D268B7C8F006F7368 /* BaseNavigationController.swift in Sources */,
 				4ADD2342267383BE00374E4E /* AddVaultSuccessViewModel.swift in Sources */,
+				4A79E26926B16993008C9959 /* ActionButton.swift in Sources */,
 				4AF91CD925A722A600ACF01E /* VaultInfo.swift in Sources */,
 				74D365BA268B5DB0005ECD69 /* FilesAppUtil.swift in Sources */,
 				4A644B4D267B55E4008CBB9A /* CreateNewVaultCoordinator.swift in Sources */,

--- a/Cryptomator/Common/ActionButton.swift
+++ b/Cryptomator/Common/ActionButton.swift
@@ -1,0 +1,26 @@
+//
+//  ActionButton.swift
+//  Cryptomator
+//
+//  Created by Philipp Schmid on 28.07.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import UIKit
+class ActionButton: UIButton {
+	var primaryAction: ((UIButton) -> Void)?
+
+	init() {
+		super.init(frame: .zero)
+		addTarget(self, action: #selector(primaryActionTriggered(sender:)), for: .primaryActionTriggered)
+	}
+
+	@available(*, unavailable)
+	required init?(coder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
+	}
+
+	@objc private func primaryActionTriggered(sender: UIButton) {
+		primaryAction?(sender)
+	}
+}

--- a/Cryptomator/Common/ListViewModel.swift
+++ b/Cryptomator/Common/ListViewModel.swift
@@ -8,6 +8,7 @@
 
 import CryptomatorCommonCore
 import Foundation
+import Promises
 
 protocol ListViewModel {
 	func moveRow(at sourceIndex: Int, to destinationIndex: Int) throws
@@ -17,6 +18,8 @@ protocol ListViewModel {
 
 protocol VaultListViewModelProtocol: ListViewModel {
 	var vaults: [VaultInfo] { get }
+	func lockVault(_ vaultInfo: VaultInfo) -> Promise<Void>
+	func refreshVaultLockStates() -> Promise<Void>
 }
 
 protocol AccountListViewModelProtocol: ListViewModel {

--- a/Cryptomator/VaultList/VaultCell.swift
+++ b/Cryptomator/VaultList/VaultCell.swift
@@ -26,7 +26,6 @@ class VaultCell: UITableViewCell {
 			guard isUnlocked != oldValue else {
 				return
 			}
-			print(isUnlocked)
 			lockButton.isHidden = !isUnlocked
 		}
 	}

--- a/Cryptomator/VaultList/VaultCell.swift
+++ b/Cryptomator/VaultList/VaultCell.swift
@@ -11,10 +11,29 @@ import UIKit
 
 class VaultCell: UITableViewCell {
 	var vault: VaultInfo?
+	lazy var lockButton: ActionButton = {
+		let button = ActionButton()
+		let lockSymbol = UIImage(systemName: "lock.open.fill",
+		                         withConfiguration: UIImage.SymbolConfiguration(pointSize: 26, weight: .regular, scale: .default))
+		button.setImage(lockSymbol, for: .normal)
+		button.sizeToFit()
+		button.isHidden = true
+		return button
+	}()
+
+	var isUnlocked: Bool = false {
+		didSet {
+			guard isUnlocked != oldValue else {
+				return
+			}
+			print(isUnlocked)
+			lockButton.isHidden = !isUnlocked
+		}
+	}
 
 	override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
 		super.init(style: style, reuseIdentifier: reuseIdentifier)
-		accessoryType = .disclosureIndicator
+		setCustomAccessoryView()
 	}
 
 	@available(*, unavailable)
@@ -45,5 +64,18 @@ class VaultCell: UITableViewCell {
 		content.secondaryText = vault.vaultPath.path
 		content.secondaryTextProperties.color = .secondaryLabel
 		contentConfiguration = content
+	}
+
+	private func setCustomAccessoryView() {
+		let detailDisclosureIndicator = UIImageView(image: UIImage(systemName: "chevron.forward",
+		                                                           withConfiguration: UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold, scale: .default)))
+		detailDisclosureIndicator.tintColor = .tertiaryLabel
+		detailDisclosureIndicator.contentMode = .right
+		let containerView = UIStackView(arrangedSubviews: [lockButton, detailDisclosureIndicator])
+		let spacing: CGFloat = 10
+		containerView.spacing = spacing
+		let width = lockButton.bounds.width + detailDisclosureIndicator.bounds.width + spacing
+		containerView.frame = CGRect(x: 0, y: 0, width: width, height: frame.height)
+		accessoryView = containerView
 	}
 }

--- a/Cryptomator/VaultList/VaultInfo.swift
+++ b/Cryptomator/VaultList/VaultInfo.swift
@@ -11,10 +11,17 @@ import CryptomatorCommonCore
 import Foundation
 import GRDB
 
-public struct VaultInfo: Decodable, FetchableRecord {
+public class VaultInfo: Decodable, FetchableRecord {
 	let vaultAccount: VaultAccount
 	let cloudProviderAccount: CloudProviderAccount
 	private(set) var vaultListPosition: VaultListPosition
+	var vaultIsUnlocked = false
+
+	enum CodingKeys: String, CodingKey {
+		case vaultAccount
+		case cloudProviderAccount
+		case vaultListPosition
+	}
 
 	init(vaultAccount: VaultAccount, cloudProviderAccount: CloudProviderAccount, vaultListPosition: VaultListPosition) {
 		self.vaultAccount = vaultAccount

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/FileProviderConnector.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/FileProviderConnector.swift
@@ -1,0 +1,78 @@
+//
+//  File.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 26.07.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import FileProvider
+import Foundation
+import Promises
+
+public protocol FileProviderConnector {
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domainIdentifier: NSFileProviderDomainIdentifier) -> Promise<T>
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domain: NSFileProviderDomain?) -> Promise<T>
+}
+
+public enum FileProviderXPCConnectorError: Error {
+	case serviceNotSupported
+	case connectionIsNil
+	case rawProxyCastingFailed
+	case typeMismatch
+	case domainNotFound
+}
+
+public class FileProviderXPCConnector: FileProviderConnector {
+	public static let shared = FileProviderXPCConnector()
+
+	public func getProxy<T>(serviceName: NSFileProviderServiceName, domainIdentifier: NSFileProviderDomainIdentifier) -> Promise<T> {
+		return NSFileProviderManager.getDomains().then { domains in
+			guard let domain = domains.first(where: { $0.identifier == domainIdentifier }) else {
+				throw FileProviderXPCConnectorError.domainNotFound
+			}
+			return self.getProxy(serviceName: serviceName, domain: domain)
+		}
+	}
+
+	public func getProxy<T>(serviceName: NSFileProviderServiceName, domain: NSFileProviderDomain?) -> Promise<T> {
+		var url = NSFileProviderManager.default.documentStorageURL
+		if let domain = domain {
+			url.appendPathComponent(domain.pathRelativeToDocumentStorage)
+		}
+		return wrap { handler in
+			FileManager.default.getFileProviderServicesForItem(at: url, completionHandler: handler)
+		}.then { services -> Promise<NSXPCConnection?> in
+			if let desiredService = services?[serviceName] {
+				return desiredService.getFileProviderConnection()
+			} else {
+				return Promise(FileProviderXPCConnectorError.serviceNotSupported)
+			}
+		}.then { connection -> T in
+			guard let connection = connection else {
+				throw FileProviderXPCConnectorError.connectionIsNil
+			}
+			guard let type = T.self as AnyObject as? Protocol else {
+				throw FileProviderXPCConnectorError.typeMismatch
+			}
+			connection.remoteObjectInterface = NSXPCInterface(with: type)
+			connection.resume()
+			let rawProxy = connection.remoteObjectProxyWithErrorHandler { errorAccessingRemoteObject in
+				DDLogError("remoteObjectProxyWithErrorHandler failed with: \(errorAccessingRemoteObject)")
+			}
+			guard let proxy = rawProxy as? T else {
+				throw FileProviderXPCConnectorError.rawProxyCastingFailed
+			}
+			return proxy
+		}
+	}
+}
+
+extension NSFileProviderService {
+	func getFileProviderConnection() -> Promise<NSXPCConnection?> {
+		return wrap { handler in
+			self.getFileProviderConnection(completionHandler: handler)
+		}
+	}
+}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/VaultLocking.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/VaultLocking.swift
@@ -1,0 +1,21 @@
+//
+//  VaultLocking.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 23.07.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@objc public protocol VaultLocking: NSFileProviderServiceSource {
+	func lockVault(domainIdentifier: NSFileProviderDomainIdentifier)
+	func getIsUnlockedVault(domainIdentifier: NSFileProviderDomainIdentifier, reply: @escaping (Bool) -> Void)
+	func getUnlockedVaultDomainIdentifiers(reply: @escaping ([NSFileProviderDomainIdentifier]) -> Void)
+}
+
+public enum VaultLockingService {
+	public static var name: NSFileProviderServiceName {
+		return NSFileProviderServiceName("org.cryptomator.ios.vault-locking")
+	}
+}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/VaultUnlocking.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/VaultUnlocking.swift
@@ -1,6 +1,6 @@
 //
 //  VaultUnlocking.swift
-//  CryptomatorFileProvider
+//  CryptomatorCommonCore
 //
 //  Created by Philipp Schmid on 02.07.21.
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.

--- a/CryptomatorFileProvider/FileProviderAdapterManager.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterManager.swift
@@ -44,6 +44,24 @@ public enum FileProviderAdapterManager {
 		}
 		semaphore.signal()
 	}
+
+	public static func lockVault(with domainIdentifier: NSFileProviderDomainIdentifier) {
+		queue.sync(flags: .barrier) {
+			cachedAdapters[domainIdentifier] = nil
+		}
+	}
+
+	public static func vaultIsUnLocked(domainIdentifier: NSFileProviderDomainIdentifier) -> Bool {
+		queue.sync(flags: .barrier) {
+			return cachedAdapters[domainIdentifier] != nil
+		}
+	}
+
+	public static func getDomainIdentifiersOfUnlockedVaults() -> [NSFileProviderDomainIdentifier] {
+		queue.sync(flags: .barrier) {
+			return cachedAdapters.map { $0.key }
+		}
+	}
 }
 
 public class BiometricalUnlockSemaphore {

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -253,6 +253,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		serviceSources.append(FileProviderValidationServiceSource(fileProviderExtension: self, itemIdentifier: itemIdentifier))
 		#endif
 		serviceSources.append(VaultUnlockingServiceSource(fileprovider: self))
+		serviceSources.append(VaultLockingServiceSource())
 		return serviceSources
 	}
 

--- a/FileProviderExtension/VaultLockingServiceSource.swift
+++ b/FileProviderExtension/VaultLockingServiceSource.swift
@@ -9,7 +9,6 @@
 import CryptomatorCommonCore
 import CryptomatorFileProvider
 import Foundation
-import OSLog
 class VaultLockingServiceSource: NSObject, NSFileProviderServiceSource, NSXPCListenerDelegate, VaultLocking {
 	var serviceName: NSFileProviderServiceName {
 		VaultLockingService.name
@@ -42,7 +41,6 @@ class VaultLockingServiceSource: NSObject, NSFileProviderServiceSource, NSXPCLis
 	// MARK: - VaultLocking
 
 	func lockVault(domainIdentifier: NSFileProviderDomainIdentifier) {
-		os_log("lockVault called")
 		FileProviderAdapterManager.lockVault(with: domainIdentifier)
 	}
 

--- a/FileProviderExtension/VaultLockingServiceSource.swift
+++ b/FileProviderExtension/VaultLockingServiceSource.swift
@@ -1,0 +1,56 @@
+//
+//  VaultLockingServiceSource.swift
+//  FileProviderExtension
+//
+//  Created by Philipp Schmid on 26.07.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import CryptomatorFileProvider
+import Foundation
+import OSLog
+class VaultLockingServiceSource: NSObject, NSFileProviderServiceSource, NSXPCListenerDelegate, VaultLocking {
+	var serviceName: NSFileProviderServiceName {
+		VaultLockingService.name
+	}
+
+	private lazy var listener: NSXPCListener = {
+		let listener = NSXPCListener.anonymous()
+		listener.delegate = self
+		listener.resume()
+		return listener
+	}()
+
+	func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
+		return listener.endpoint
+	}
+
+	// MARK: - NSXPCListenerDelegate
+
+	func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+		newConnection.exportedInterface = NSXPCInterface(with: VaultLocking.self)
+		newConnection.exportedObject = self
+		newConnection.resume()
+		weak var weakConnection = newConnection
+		newConnection.interruptionHandler = {
+			weakConnection?.invalidate()
+		}
+		return true
+	}
+
+	// MARK: - VaultLocking
+
+	func lockVault(domainIdentifier: NSFileProviderDomainIdentifier) {
+		os_log("lockVault called")
+		FileProviderAdapterManager.lockVault(with: domainIdentifier)
+	}
+
+	func getIsUnlockedVault(domainIdentifier: NSFileProviderDomainIdentifier, reply: @escaping (Bool) -> Void) {
+		reply(FileProviderAdapterManager.vaultIsUnLocked(domainIdentifier: domainIdentifier))
+	}
+
+	func getUnlockedVaultDomainIdentifiers(reply: @escaping ([NSFileProviderDomainIdentifier]) -> Void) {
+		reply(FileProviderAdapterManager.getDomainIdentifiersOfUnlockedVaults())
+	}
+}

--- a/FileProviderExtension/VaultUnlockingServiceSource.swift
+++ b/FileProviderExtension/VaultUnlockingServiceSource.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import CryptomatorCommonCore
 import CryptomatorFileProvider
 import FileProvider
 import Foundation

--- a/FileProviderExtensionUI/FileProviderCoordinator.swift
+++ b/FileProviderExtensionUI/FileProviderCoordinator.swift
@@ -43,7 +43,6 @@ class FileProviderCoordinator {
 			let domain = NSFileProviderDomain(identifier: domainIdentifier, displayName: vaultName, pathRelativeToDocumentStorage: pathRelativeToDocumentStorage)
 			showPasswordScreen(for: domain)
 		default:
-			print(internalError)
 			showOnboarding()
 		}
 	}

--- a/FileProviderExtensionUI/FileProviderCoordinator.swift
+++ b/FileProviderExtensionUI/FileProviderCoordinator.swift
@@ -11,12 +11,20 @@ import FileProviderUI
 import UIKit
 
 class FileProviderCoordinator {
-	let navigationController: UINavigationController
-	let extensionContext: FPUIActionExtensionContext
+	private let extensionContext: FPUIActionExtensionContext
+	private weak var hostViewController: UIViewController?
+	private lazy var navigationController: UINavigationController = {
+		let navigationController = UINavigationController()
+		navigationController.navigationBar.barTintColor = UIColor(named: "primary")
+		navigationController.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]
+		navigationController.navigationBar.tintColor = .white
+		addViewControllerAsChildToHost(navigationController)
+		return navigationController
+	}()
 
-	init(extensionContext: FPUIActionExtensionContext, navigationController: UINavigationController) {
+	init(extensionContext: FPUIActionExtensionContext, hostViewController: UIViewController) {
 		self.extensionContext = extensionContext
-		self.navigationController = navigationController
+		self.hostViewController = hostViewController
 	}
 
 	func userCancelled() {
@@ -46,6 +54,10 @@ class FileProviderCoordinator {
 		viewController.present(alertController, animated: true)
 	}
 
+	func done() {
+		extensionContext.completeRequest()
+	}
+
 	// MARK: - Onboarding
 
 	func showOnboarding() {
@@ -72,7 +84,14 @@ class FileProviderCoordinator {
 		navigationController.pushViewController(unlockVaultVC, animated: false)
 	}
 
-	func unlocked() {
-		extensionContext.completeRequest()
+	// MARK: - Internal
+
+	private func addViewControllerAsChildToHost(_ viewController: UIViewController) {
+		guard let hostViewController = hostViewController else {
+			return
+		}
+		hostViewController.addChild(viewController)
+		hostViewController.view.addSubview(viewController.view)
+		viewController.didMove(toParent: hostViewController)
 	}
 }

--- a/FileProviderExtensionUI/Info.plist
+++ b/FileProviderExtensionUI/Info.plist
@@ -22,17 +22,6 @@
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
-		<key>NSExtensionFileProviderActions</key>
-		<array>
-			<dict>
-				<key>NSExtensionFileProviderActionActivationRule</key>
-				<string>TRUEPREDICATE</string>
-				<key>NSExtensionFileProviderActionIdentifier</key>
-				<string>com.mycompany.FileProviderUI.CustomAction</string>
-				<key>NSExtensionFileProviderActionName</key>
-				<string>Custom Action</string>
-			</dict>
-		</array>
 		<key>NSExtensionPrincipalClass</key>
 		<string>$(PRODUCT_MODULE_NAME).RootViewController</string>
 		<key>NSExtensionPointIdentifier</key>

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -11,7 +11,9 @@ import CryptomatorCommonCore
 import FileProviderUI
 import UIKit
 class RootViewController: FPUIActionExtensionViewController {
-	private var coordinator: FileProviderCoordinator?
+	private lazy var coordinator: FileProviderCoordinator = {
+		return FileProviderCoordinator(extensionContext: extensionContext, hostViewController: self)
+	}()
 
 	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
@@ -35,19 +37,7 @@ class RootViewController: FPUIActionExtensionViewController {
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		let navigationController = UINavigationController()
-		navigationController.navigationBar.barTintColor = UIColor(named: "primary")
-		navigationController.navigationBar.titleTextAttributes = [.foregroundColor: UIColor.white]
-		navigationController.navigationBar.tintColor = .white
-		addChild(navigationController)
-		view.addSubview(navigationController.view)
-		navigationController.didMove(toParent: self)
 		RootViewController.oneTimeSetup()
-		coordinator = FileProviderCoordinator(extensionContext: extensionContext, navigationController: navigationController)
-	}
-
-	override func prepare(forError error: Error) {
-		coordinator?.startWith(error: error)
 	}
 
 	@objc func cancel() {
@@ -75,4 +65,10 @@ class RootViewController: FPUIActionExtensionViewController {
 		}
 		return {}
 	}()
+
+	// MARK: - FPUIActionExtensionViewController
+
+	override func prepare(forError error: Error) {
+		coordinator.startWith(error: error)
+	}
 }

--- a/FileProviderExtensionUI/UnlockVaultViewController.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewController.swift
@@ -70,13 +70,13 @@ class UnlockVaultViewController: UITableViewController {
 
 	private func biometricalUnlock() {
 		viewModel.biometricalUnlock().then { [weak self] in
-			self?.coordinator?.unlocked()
+			self?.coordinator?.done()
 		}
 	}
 
 	@objc func unlock() {
 		viewModel.unlock(withPassword: passwordCell.textField.text ?? "", storePasswordInKeychain: enableBiometricalUnlockSwitch.isOn).then { [weak self] in
-			self?.coordinator?.unlocked()
+			self?.coordinator?.done()
 		}.catch { [weak self] error in
 			guard let self = self else { return }
 			switch error {


### PR DESCRIPTION
This introduces the feature to manually lock a vault in the main app (in the vault list). 

This is done analogously to the unlocking in the `FileProviderExtensionUI` (see #59), via an XPC connection with the `FileProviderExtension`.