### PR TITLE
Bugfix: prevent vault and cloud provider account duplicates

### DIFF
--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/cryptomator/cloud-access-swift.git",
         "state": {
           "branch": null,
-          "revision": "e5d7a3b3e9dec236c893214bb75df1eb95f8b49f",
-          "version": "0.13.3"
+          "revision": "15fcc6dc713481aae0cc25968da261b32d7a87dd",
+          "version": "0.13.4"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/phil1995/dropbox-sdk-obj-c.git",
         "state": {
           "branch": null,
-          "revision": "9560ecda2271a7fc3a653c388a3387f81d7862ab",
-          "version": "5.0.3-fork"
+          "revision": "f74da6cf58dfe078e1ddafa0673b69fa9d32de1a",
+          "version": "6.2.0-fork"
         }
       },
       {

--- a/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
+++ b/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
@@ -52,7 +52,7 @@ class AccountListViewModel: AccountListViewModelProtocol {
 			let credential = DropboxCredential(tokenUID: accountInfo.accountUID)
 			return createAccountCellContentPlaceholder(for: credential)
 		case .googleDrive:
-			let credential = GoogleDriveCredential(tokenUID: accountInfo.accountUID)
+			let credential = GoogleDriveCredential(userID: accountInfo.accountUID)
 			return try createAccountCellContent(for: credential)
 		case .oneDrive:
 			let credential = try OneDriveCredential(with: accountInfo.accountUID)

--- a/Cryptomator/Common/CloudAuthenticator.swift
+++ b/Cryptomator/Common/CloudAuthenticator.swift
@@ -32,9 +32,9 @@ class CloudAuthenticator {
 	}
 
 	func authenticateGoogleDrive(from viewController: UIViewController) -> Promise<CloudProviderAccount> {
-		let credential = GoogleDriveCredential(tokenUID: UUID().uuidString)
+		let credential = GoogleDriveCredential()
 		return GoogleDriveAuthenticator.authenticate(credential: credential, from: viewController).then { () -> CloudProviderAccount in
-			let account = CloudProviderAccount(accountUID: credential.tokenUID, cloudProviderType: .googleDrive)
+			let account = CloudProviderAccount(accountUID: try credential.getAccountID(), cloudProviderType: .googleDrive)
 			try self.accountManager.saveNewAccount(account)
 			return account
 		}
@@ -77,7 +77,7 @@ class CloudAuthenticator {
 			let credential = DropboxCredential(tokenUID: account.accountUID)
 			credential.deauthenticate()
 		case .googleDrive:
-			let credential = GoogleDriveCredential(tokenUID: account.accountUID)
+			let credential = GoogleDriveCredential(userID: account.accountUID)
 			credential.deauthenticate()
 		case .oneDrive:
 			let credential = try OneDriveCredential(with: account.accountUID)

--- a/Cryptomator/VaultDetail/VaultDetailInfoFooterViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailInfoFooterViewModel.swift
@@ -50,7 +50,7 @@ class VaultDetailInfoFooterViewModel: AttributedTextHeaderFooterViewModel {
 			getUsername(for: credential)
 			return "(…)"
 		case .googleDrive:
-			let credential = GoogleDriveCredential(tokenUID: vault.delegateAccountUID)
+			let credential = GoogleDriveCredential(userID: vault.delegateAccountUID)
 			return try? credential.getUsername()
 		case .oneDrive:
 			let credential = try? OneDriveCredential(with: vault.delegateAccountUID)

--- a/Cryptomator/VaultDetail/VaultDetailViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewModel.swift
@@ -189,7 +189,7 @@ class VaultDetailViewModel: VaultDetailViewModelProtocol {
 	}
 
 	private func getSwitchCellViewModel(biometryTypeName: String) -> SwitchCellViewModel {
-		if let switchCellViewModel = self.switchCellViewModel {
+		if let switchCellViewModel = switchCellViewModel {
 			switchCellViewModel.isOn.value = biometricalUnlockEnabled
 			return switchCellViewModel
 		}

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
@@ -38,7 +38,7 @@ class WebDAVAuthenticationViewModel: WebDAVAuthenticationViewModelProtocol {
 			return WebDAVAuthenticator.verifyClient(client: client)
 		}.then { _ -> WebDAVCredential in
 			self.client = nil
-			try WebDAVAuthenticator.saveCredentialToKeychain(credential, with: credential.identifier)
+			try WebDAVAuthenticator.saveCredentialToKeychain(credential)
 			return credential
 		}
 	}

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
@@ -23,6 +23,7 @@ protocol WebDAVAuthenticationViewModelProtocol {
 
 class WebDAVAuthenticationViewModel: WebDAVAuthenticationViewModelProtocol {
 	private var client: WebDAVClient?
+
 	func addAccount(url: String?, username: String?, password: String?, allowedCertificate: Data?) -> Promise<WebDAVCredential> {
 		// TODO: Add Input Validation
 		guard let url = url, let username = username, let password = password, let baseURL = URL(string: url) else {
@@ -40,6 +41,17 @@ class WebDAVAuthenticationViewModel: WebDAVAuthenticationViewModelProtocol {
 			self.client = nil
 			try WebDAVAuthenticator.saveCredentialToKeychain(credential)
 			return credential
+		}.recover { error -> WebDAVCredential in
+			guard case let WebDAVAuthenticatorKeychainError.credentialDuplicate(identifier) = error else {
+				throw error
+			}
+			let updatedCredential = WebDAVCredential(baseURL: credential.baseURL,
+			                                         username: credential.username,
+			                                         password: credential.password,
+			                                         allowedCertificate: credential.allowedCertificate,
+			                                         identifier: identifier)
+			try WebDAVAuthenticator.saveCredentialToKeychain(updatedCredential)
+			return updatedCredential
 		}
 	}
 

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
@@ -53,6 +53,7 @@ public class CryptomatorDatabase {
 			table.column("delegateAccountUID", .text).notNull().references("cloudProviderAccounts", onDelete: .cascade)
 			table.column("vaultPath", .text).notNull()
 			table.column("vaultName", .text).notNull()
+			table.uniqueKey(["delegateAccountUID", "vaultPath"])
 		}
 		try db.create(table: "cachedVaults") { table in
 			table.column("vaultUID", .text).primaryKey().references("vaultAccounts", onDelete: .cascade)

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
@@ -36,7 +36,7 @@ public class CloudProviderDBManager: CloudProviderManager {
 		let provider: CloudProvider
 		switch cloudProviderType {
 		case .googleDrive:
-			let credential = GoogleDriveCredential(tokenUID: accountUID)
+			let credential = GoogleDriveCredential(userID: accountUID)
 			provider = try GoogleDriveCloudProvider(credential: credential, useBackgroundSession: useBackgroundSession)
 		case .dropbox:
 			let credential = DropboxCredential(tokenUID: accountUID)

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/VaultAccountManagerError+Localization.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/VaultAccountManagerError+Localization.swift
@@ -1,0 +1,18 @@
+//
+//  VaultAccountManagerError+Localization.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 08.10.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+
+extension VaultAccountManagerError: LocalizedError {
+	public var errorDescription: String? {
+		switch self {
+		case .vaultAccountAlreadyExists:
+			return LocalizedString.getValue("vaultAccountManager.error.vaultAccountAlreadyExists")
+		}
+	}
+}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/WebDAV/WebDAVAuthenticator+Keychain.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/WebDAV/WebDAVAuthenticator+Keychain.swift
@@ -28,7 +28,7 @@ public extension WebDAVAuthenticator {
 	 */
 	static func saveCredentialToKeychain(_ credential: WebDAVCredential) throws {
 		let existingCredentials = try CryptomatorKeychain.webDAV.getAllWebDAVCredentials()
-		if let existingCredential = existingCredentials.first(where: { $0.baseURL == credential.baseURL && $0.username == credential.username && $0.identifier != credential.identifier }) {
+		if let existingCredential = existingCredentials.first(where: { $0 == credential && $0.identifier != credential.identifier }) {
 			throw WebDAVAuthenticatorKeychainError.credentialDuplicate(existingIdentifier: existingCredential.identifier)
 		}
 
@@ -39,6 +39,12 @@ public extension WebDAVAuthenticator {
 
 	static func removeCredentialFromKeychain(with accountUID: String) throws {
 		try CryptomatorKeychain.webDAV.delete(accountUID)
+	}
+}
+
+extension WebDAVCredential: Equatable {
+	public static func == (lhs: WebDAVCredential, rhs: WebDAVCredential) -> Bool {
+		return lhs.baseURL == rhs.baseURL && lhs.username == rhs.username
 	}
 }
 

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/WebDAV/WebDAVAuthenticator+Keychain.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/WebDAV/WebDAVAuthenticator+Keychain.swift
@@ -9,15 +9,30 @@
 import CryptomatorCloudAccessCore
 import Foundation
 
+public enum WebDAVAuthenticatorKeychainError: Error {
+	case credentialDuplicate
+}
+
 public extension WebDAVAuthenticator {
 	static func getCredentialFromKeychain(with accountUID: String) -> WebDAVCredential? {
 		return CryptomatorKeychain.webDAV.get(accountUID)
 	}
 
-	static func saveCredentialToKeychain(_ credential: WebDAVCredential, with accountUID: String) throws {
+	/**
+	 Saves a WebDAV credential to the keychain.
+
+	 Checks for duplicates before saving the passed credential to the keychain.
+	 A duplicate is defined as any other WebDAV credential with the same `baseURL` and `username`.
+	 */
+	static func saveCredentialToKeychain(_ credential: WebDAVCredential) throws {
+		let existingCredentials = try CryptomatorKeychain.webDAV.getAllWebDAVCredentials()
+		if existingCredentials.contains(where: { $0.baseURL == credential.baseURL && $0.username == credential.username && $0.identifier != credential.identifier }) {
+			throw WebDAVAuthenticatorKeychainError.credentialDuplicate
+		}
+
 		let jsonEnccoder = JSONEncoder()
 		let encodedCredential = try jsonEnccoder.encode(credential)
-		try CryptomatorKeychain.webDAV.set(accountUID, value: encodedCredential)
+		try CryptomatorKeychain.webDAV.set(credential.identifier, value: encodedCredential)
 	}
 
 	static func removeCredentialFromKeychain(with accountUID: String) throws {
@@ -36,5 +51,23 @@ private extension CryptomatorKeychain {
 		} catch {
 			return nil
 		}
+	}
+
+	func getAllWebDAVCredentials() throws -> [WebDAVCredential] {
+		let query = queryWithDict([
+			kSecReturnData as String: kCFBooleanTrue,
+			kSecMatchLimit as String: kSecMatchLimitAll
+		])
+		var dataResult: AnyObject?
+		let status = SecItemCopyMatching(query as CFDictionary, &dataResult)
+		if status == errSecItemNotFound {
+			return []
+		}
+		guard status == noErr else {
+			throw CryptomatorKeychainError.unhandledError(status: status)
+		}
+		let results = dataResult as? [Data] ?? []
+		let jsonDecoder = JSONDecoder()
+		return try results.map { try jsonDecoder.decode(WebDAVCredential.self, from: $0) }
 	}
 }

--- a/CryptomatorCommonHostedTests/Keychain/WebDAVKeychainTests.swift
+++ b/CryptomatorCommonHostedTests/Keychain/WebDAVKeychainTests.swift
@@ -17,20 +17,47 @@ class WebDAVKeychainTests: XCTestCase {
 		let username = "user"
 		let password = "pass"
 		let certificate = "CertificateData".data(using: .utf8)
-		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate)
-		let accountUID = UUID().uuidString
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential, with: accountUID))
+		let identifier = UUID().uuidString
+		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate, identifier: identifier)
 
-		guard let fetchedCredential = WebDAVAuthenticator.getCredentialFromKeychain(with: accountUID) else {
-			XCTFail("No Credential found in Keychain for accountUID: \(accountUID)")
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential))
+
+		guard let fetchedCredential = WebDAVAuthenticator.getCredentialFromKeychain(with: identifier) else {
+			XCTFail("No Credential found in Keychain for accountUID: \(identifier)")
 			return
 		}
 		XCTAssertEqual(baseURL, fetchedCredential.baseURL)
 		XCTAssertEqual(username, fetchedCredential.username)
 		XCTAssertEqual(password, fetchedCredential.password)
 		XCTAssertEqual(certificate, fetchedCredential.allowedCertificate)
+		XCTAssertEqual(identifier, fetchedCredential.identifier)
 
-		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: accountUID))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: identifier))
+	}
+
+	func testSaveCredentialDuplicatesToKeychain() throws {
+		let baseURL = URL(string: "www.testurl.com")!
+		let username = "user"
+		let password = "pass"
+		let certificate = "CertificateData".data(using: .utf8)
+		let identifier = UUID().uuidString
+		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate, identifier: identifier)
+
+		try WebDAVAuthenticator.saveCredentialToKeychain(credential)
+
+		// Different Identifier is a duplicate if baseURL and username already exists in the keychain
+		let duplicateCredential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate, identifier: UUID().uuidString)
+		checkSaveThrowsDuplicateErrorAndKeychainDidNotChange(for: duplicateCredential)
+
+		// Different Password is still a duplicate if baseURL and username already exists in the keychain and the identifier does not match
+		checkSaveThrowsDuplicateErrorAndKeychainDidNotChange(for: WebDAVCredential(baseURL: baseURL, username: username, password: password + "Foo", allowedCertificate: certificate, identifier: UUID().uuidString))
+
+		// Different Certificate is still a duplicate if baseURL and username already exists in the keychain and the identifier does not match
+		checkSaveThrowsDuplicateErrorAndKeychainDidNotChange(for: WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: "CertificateData1".data(using: .utf8), identifier: UUID().uuidString))
+
+		// Missing Certificate is still a duplicate if baseURL and username already exists in the keychain and the identifier does not match
+		checkSaveThrowsDuplicateErrorAndKeychainDidNotChange(for: WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: nil, identifier: UUID().uuidString))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: identifier))
 	}
 
 	func testRemoveCredentialFromKeychain() {
@@ -38,12 +65,12 @@ class WebDAVKeychainTests: XCTestCase {
 		let username = "user"
 		let password = "pass"
 		let certificate = "CertificateData".data(using: .utf8)
-		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate)
-		let accountUID = UUID().uuidString
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential, with: accountUID))
+		let identifier = UUID().uuidString
+		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate, identifier: identifier)
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential))
 
-		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: accountUID))
-		XCTAssertNil(WebDAVAuthenticator.getCredentialFromKeychain(with: accountUID))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: identifier))
+		XCTAssertNil(WebDAVAuthenticator.getCredentialFromKeychain(with: identifier))
 	}
 
 	func testSaveUpdatesOverwritesCredentialInKeychain() {
@@ -51,18 +78,18 @@ class WebDAVKeychainTests: XCTestCase {
 		let username = "user"
 		let password = "pass"
 		let certificate = "CertificateData".data(using: .utf8)
-		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate)
-		let accountUID = UUID().uuidString
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential, with: accountUID))
+		let identifier = UUID().uuidString
+		let credential = WebDAVCredential(baseURL: baseURL, username: username, password: password, allowedCertificate: certificate, identifier: identifier)
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(credential))
 
 		let updatedBaseURL = URL(string: "www.updated-testurl.com")!
 		let updatedUsername = "updatedUser"
 		let updatedPassword = "updatedPass"
-		let updatedCredential = WebDAVCredential(baseURL: updatedBaseURL, username: updatedUsername, password: updatedPassword, allowedCertificate: nil)
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(updatedCredential, with: accountUID))
+		let updatedCredential = WebDAVCredential(baseURL: updatedBaseURL, username: updatedUsername, password: updatedPassword, allowedCertificate: nil, identifier: identifier)
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(updatedCredential))
 
-		guard let fetchedCredential = WebDAVAuthenticator.getCredentialFromKeychain(with: accountUID) else {
-			XCTFail("No Credential found in Keychain for accountUID: \(accountUID)")
+		guard let fetchedCredential = WebDAVAuthenticator.getCredentialFromKeychain(with: identifier) else {
+			XCTFail("No Credential found in Keychain for identifier: \(identifier)")
 			return
 		}
 		XCTAssertEqual(updatedBaseURL, fetchedCredential.baseURL)
@@ -70,7 +97,7 @@ class WebDAVKeychainTests: XCTestCase {
 		XCTAssertEqual(updatedPassword, fetchedCredential.password)
 		XCTAssertNil(fetchedCredential.allowedCertificate)
 
-		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: accountUID))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: identifier))
 	}
 
 	func testMultipleCredentialSupport() {
@@ -78,18 +105,20 @@ class WebDAVKeychainTests: XCTestCase {
 		let firstUsername = "user"
 		let firstPassword = "pass"
 		let certificate = "CertificateData".data(using: .utf8)
-		let firstCredential = WebDAVCredential(baseURL: baseURL, username: firstUsername, password: firstPassword, allowedCertificate: certificate)
-		let firstAccountUID = UUID().uuidString
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(firstCredential, with: firstAccountUID))
+		let firstIdentifier = UUID().uuidString
+		let firstCredential = WebDAVCredential(baseURL: baseURL, username: firstUsername, password: firstPassword, allowedCertificate: certificate, identifier: firstIdentifier)
+
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(firstCredential))
 
 		let secondUsername = "user-2"
 		let secondPassword = "pass-2"
-		let secondCredential = WebDAVCredential(baseURL: baseURL, username: secondUsername, password: secondPassword, allowedCertificate: nil)
-		let secondAccountUID = UUID().uuidString
-		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(secondCredential, with: secondAccountUID))
+		let secondIdentifier = UUID().uuidString
+		let secondCredential = WebDAVCredential(baseURL: baseURL, username: secondUsername, password: secondPassword, allowedCertificate: nil, identifier: secondIdentifier)
 
-		guard let fetchedCredentialForFirstAccount = WebDAVAuthenticator.getCredentialFromKeychain(with: firstAccountUID) else {
-			XCTFail("No Credential found in Keychain for accountUID: \(firstAccountUID)")
+		XCTAssertNoThrow(try WebDAVAuthenticator.saveCredentialToKeychain(secondCredential))
+
+		guard let fetchedCredentialForFirstAccount = WebDAVAuthenticator.getCredentialFromKeychain(with: firstIdentifier) else {
+			XCTFail("No Credential found in Keychain for identifier: \(firstIdentifier)")
 			return
 		}
 		XCTAssertEqual(baseURL, fetchedCredentialForFirstAccount.baseURL)
@@ -97,8 +126,8 @@ class WebDAVKeychainTests: XCTestCase {
 		XCTAssertEqual(firstPassword, fetchedCredentialForFirstAccount.password)
 		XCTAssertEqual(certificate, fetchedCredentialForFirstAccount.allowedCertificate)
 
-		guard let fetchedCredentialForSecondAccount = WebDAVAuthenticator.getCredentialFromKeychain(with: secondAccountUID) else {
-			XCTFail("No Credential found in Keychain for accountUID: \(secondAccountUID)")
+		guard let fetchedCredentialForSecondAccount = WebDAVAuthenticator.getCredentialFromKeychain(with: secondIdentifier) else {
+			XCTFail("No Credential found in Keychain for identifier: \(secondIdentifier)")
 			return
 		}
 		XCTAssertEqual(baseURL, fetchedCredentialForSecondAccount.baseURL)
@@ -106,7 +135,21 @@ class WebDAVKeychainTests: XCTestCase {
 		XCTAssertEqual(secondPassword, fetchedCredentialForSecondAccount.password)
 		XCTAssertNil(fetchedCredentialForSecondAccount.allowedCertificate)
 
-		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: firstAccountUID))
-		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: secondAccountUID))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: firstIdentifier))
+		XCTAssertNoThrow(try WebDAVAuthenticator.removeCredentialFromKeychain(with: secondIdentifier))
+	}
+
+	private func checkSaveThrowsDuplicateError(for credential: WebDAVCredential) {
+		XCTAssertThrowsError(try WebDAVAuthenticator.saveCredentialToKeychain(credential)) { error in
+			guard case WebDAVAuthenticatorKeychainError.credentialDuplicate = error else {
+				XCTFail("Throws the wrong error: \(error)")
+				return
+			}
+		}
+	}
+
+	private func checkSaveThrowsDuplicateErrorAndKeychainDidNotChange(for credential: WebDAVCredential) {
+		checkSaveThrowsDuplicateError(for: credential)
+		XCTAssertNil(WebDAVAuthenticator.getCredentialFromKeychain(with: credential.identifier))
 	}
 }

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -229,7 +229,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		 */
 		// TODO: Change error handling here
 		DDLogDebug("FPExt: enumerator(for: \(containerItemIdentifier)) called")
-		guard let manager = self.manager, let domain = self.domain, let dbPath = dbPath, let notificator = notificator else {
+		guard let manager = manager, let domain = domain, let dbPath = dbPath, let notificator = notificator else {
 			// no domain ==> no installed vault
 			DDLogError("enumerator(for: \(containerItemIdentifier)) failed as the extension is not initialized")
 			throw NSFileProviderError(.notAuthenticated)
@@ -238,7 +238,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 	}
 
 	func setUp() throws {
-		if let domain = self.domain {
+		if let domain = domain {
 			guard let manager = NSFileProviderManager(for: domain) else {
 				throw FileProviderDecoratorSetupError.fileProviderManagerIsNil
 			}
@@ -289,7 +289,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		if let cachedAdapter = adapter {
 			return cachedAdapter
 		}
-		guard let domain = self.domain, let dbPath = self.dbPath, let notificator = self.notificator else {
+		guard let domain = domain, let dbPath = dbPath, let notificator = notificator else {
 			throw FileProviderDecoratorSetupError.domainIsNil
 		}
 		return try FileProviderAdapterManager.getAdapter(for: domain, dbPath: dbPath, delegate: self, notificator: notificator)

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -110,6 +110,8 @@
 "urlSession.error.httpError.default" = "Network connection failed with status code %ld.";
 "urlSession.error.unexpectedResponse" = "There was an unexpected network response.";
 
+"vaultAccountManager.error.vaultAccountAlreadyExists" = "You have already added this vault.";
+
 "vaultDetail.button.lock" = "Lock Now";
 "vaultDetail.button.removeVault" = "Remove from Vault List";
 "vaultDetail.disabledBiometricalUnlock.footer" = "If you enable %@, your vault password will be stored in the iOS keychain.";


### PR DESCRIPTION
This PR fixes #41 by preventing the creation of vault duplicates and cloud provider account duplicates.
A vault duplicate is a vault that has the same vault path and the same cloud provider account as an already added vault.
This has been fixed by changing the database scheme.

Most cloud providers have already handled it correctly when the user logs into the same account, i.e. no error is displayed to the user and he can continue the process (e.g. add a vault) but no new cloud provider account is created in the database.
Now this is also the case with WebDAV and Google Drive, where previously a new cloud provider account has been created in the database.
We define a WebDAV credential duplicate as a WebDAV credential with the same `baseURL` and `username`.