### PR TITLE
Added Screen: Settings

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -193,6 +193,9 @@
 		4AEBE8C726540EBF0031487F /* MovingItemPathLockHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEBE8C626540EBF0031487F /* MovingItemPathLockHandler.swift */; };
 		4AEE468F25263B2E0045DA9F /* FileProviderExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4AEE469225263B2E0045DA9F /* FileProviderExtensionUI.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621E4249A6A8400A0BCBD /* FileProviderExtensionUI.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4AEFF7F227145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */; };
+		4AEFF7F427145CB500D6CB99 /* LogLevelUpdatingServiceSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */; };
+		4AEFF7F627145F5A00D6CB99 /* FileProviderConnectorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F527145F5A00D6CB99 /* FileProviderConnectorMock.swift */; };
 		4AF91CBE25A63FD600ACF01E /* VaultListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CBD25A63FD600ACF01E /* VaultListViewModel.swift */; };
 		4AF91CC725A6437000ACF01E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AF91CC625A6437000ACF01E /* Colors.xcassets */; };
 		4AF91CD025A71C5800ACF01E /* UIImage+CloudProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CCF25A71C5800ACF01E /* UIImage+CloudProviderType.swift */; };
@@ -547,6 +550,9 @@
 		4AEBE8BD2653F4280031487F /* UploadTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTaskExecutor.swift; sourceTree = "<group>"; };
 		4AEBE8C12653FAD40031487F /* WorkflowMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowMiddleware.swift; sourceTree = "<group>"; };
 		4AEBE8C626540EBF0031487F /* MovingItemPathLockHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingItemPathLockHandler.swift; sourceTree = "<group>"; };
+		4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelUpdatingServiceSource.swift; sourceTree = "<group>"; };
+		4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelUpdatingServiceSourceTests.swift; sourceTree = "<group>"; };
+		4AEFF7F527145F5A00D6CB99 /* FileProviderConnectorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderConnectorMock.swift; sourceTree = "<group>"; };
 		4AF91CBD25A63FD600ACF01E /* VaultListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultListViewModel.swift; sourceTree = "<group>"; };
 		4AF91CC625A6437000ACF01E /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		4AF91CCF25A71C5800ACF01E /* UIImage+CloudProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+CloudProviderType.swift"; sourceTree = "<group>"; };
@@ -724,6 +730,7 @@
 				4A123EA724BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift */,
 				4A1673E7270C675B0075C724 /* FileProviderCacheManagerTests.swift */,
 				4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */,
+				4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */,
 				4A4F47F224B875070033328B /* URL+NameCollisionExtensionTests.swift */,
 				4AF69E2924ACCED000A7174C /* DB */,
 				4A8F14A3266A302E00ADBCE4 /* FileProviderAdapter */,
@@ -1144,6 +1151,7 @@
 				4A644B48267B40C3008CBB9A /* SetVaultNameViewModelTests.swift */,
 				4AF91CF325A8BB0D00ACF01E /* VaultListViewModelTests.swift */,
 				4A6A5209268B2B7B006F7368 /* AddLocalVault */,
+				4AEFF7F527145F5A00D6CB99 /* FileProviderConnectorMock.swift */,
 			);
 			path = CryptomatorTests;
 			sourceTree = "<group>";
@@ -1190,6 +1198,7 @@
 				740375FB2587AEB50023FF53 /* FileProviderNetworkTask.swift */,
 				740375F02587AEB40023FF53 /* FileProviderNotificator.swift */,
 				740375F42587AEB50023FF53 /* ItemStatus.swift */,
+				4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
 				740375F52587AEB50023FF53 /* URL+NameCollisionExtension.swift */,
 				4AE0D8D82653D8F200DF5D22 /* CloudTask */,
@@ -1652,6 +1661,7 @@
 				4A24822B266E362C002D9F59 /* FileProviderAdapterMoveItemTests.swift in Sources */,
 				4A24822D266F85FD002D9F59 /* FileProviderAdapterDeleteItemTests.swift in Sources */,
 				4A09E54C27071F3C0056D32A /* ErrorMapperTests.swift in Sources */,
+				4AEFF7F427145CB500D6CB99 /* LogLevelUpdatingServiceSourceTests.swift in Sources */,
 				4A248231266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift in Sources */,
 				4A8F14A0266A2FD500ADBCE4 /* FileProviderAdapterGetItemTests.swift in Sources */,
 				4A24822F266FACF1002D9F59 /* FileProviderAdapterEnumerateItemTests.swift in Sources */,
@@ -1847,6 +1857,7 @@
 				4A3D6554267CF17B000DA764 /* CreateNewVaultPasswordViewModelTests.swift in Sources */,
 				4AF91CEB25A7306E00ACF01E /* DatabaseManagerTests.swift in Sources */,
 				4A644B49267B40C3008CBB9A /* SetVaultNameViewModelTests.swift in Sources */,
+				4AEFF7F627145F5A00D6CB99 /* FileProviderConnectorMock.swift in Sources */,
 				4AFCE56A25BAEE890069C4FC /* AccountListViewModelTests.swift in Sources */,
 				4A644B59267CA3AD008CBB9A /* CreateNewFolderViewModelTests.swift in Sources */,
 				4A6A5206268B2B24006F7368 /* MockError.swift in Sources */,
@@ -1889,6 +1900,7 @@
 				747F2F262587BC250072FB30 /* UploadTask.swift in Sources */,
 				4ADD233E2672376500374E4E /* WorkflowConstraint.swift in Sources */,
 				4A511D572662924C000A0E01 /* ItemEnumerationTask.swift in Sources */,
+				4AEFF7F227145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift in Sources */,
 				4A511D5D26668E47000A0E01 /* ReparentTaskRecord.swift in Sources */,
 				747F2F272587BC250072FB30 /* ReparentTask.swift in Sources */,
 				747F2F282587BC250072FB30 /* ReparentTaskDBManager.swift in Sources */,

--- a/Cryptomator/Common/CloudAccountList/AccountListViewController.swift
+++ b/Cryptomator/Common/CloudAccountList/AccountListViewController.swift
@@ -127,6 +127,7 @@ class AccountListViewController: SingleSectionTableViewController {
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		tableView.deselectRow(at: indexPath, animated: true)
 		let accountInfo = viewModel.accountInfos[indexPath.row]
 		do {
 			try coordinator?.selectedAccont(accountInfo)

--- a/Cryptomator/Settings/SettingsCoordinator.swift
+++ b/Cryptomator/Settings/SettingsCoordinator.swift
@@ -47,8 +47,37 @@ class SettingsCoordinator: Coordinator {
 		navigationController.present(activityController, animated: true)
 	}
 
-	func close() {
+	func showCloudServices() {
+		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV], headerTitle: "")
+		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
+		chooseCloudVC.title = LocalizedString.getValue("settings.cloudServices")
+		chooseCloudVC.coordinator = self
+		chooseCloudVC.navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(close))
+		navigationController.pushViewController(chooseCloudVC, animated: true)
+	}
+
+	@objc func close() {
 		navigationController.dismiss(animated: true)
 		parentCoordinator?.childDidFinish(self)
 	}
+}
+
+extension SettingsCoordinator: CloudChoosing {
+	func showAccountList(for cloudProviderType: CloudProviderType) {
+		let viewModel = AccountListViewModel(with: cloudProviderType)
+		let accountListVC = AccountListViewController(with: viewModel)
+		accountListVC.coordinator = self
+		navigationController.pushViewController(accountListVC, animated: true)
+	}
+}
+
+extension SettingsCoordinator: AccountListing {
+	func showAddAccount(for cloudProviderType: CloudProviderType, from viewController: UIViewController) {
+		let authenticator = CloudAuthenticator(accountManager: CloudProviderAccountDBManager.shared)
+		_ = authenticator.authenticate(cloudProviderType, from: viewController)
+	}
+
+	func selectedAccont(_ account: AccountInfo) throws {}
+
+	func showEdit(for account: AccountInfo) {}
 }

--- a/Cryptomator/Settings/SettingsCoordinator.swift
+++ b/Cryptomator/Settings/SettingsCoordinator.swift
@@ -56,6 +56,18 @@ class SettingsCoordinator: Coordinator {
 		navigationController.pushViewController(chooseCloudVC, animated: true)
 	}
 
+	func openContact() {
+		if let contactURL = URL(string: "https://cryptomator.org/contact/") {
+			UIApplication.shared.open(contactURL)
+		}
+	}
+
+	func openRateApp() {
+		if let rateAppURL = URL(string: "https://apps.apple.com/app/cryptomator/id953086535?action=write-review") {
+			UIApplication.shared.open(rateAppURL)
+		}
+	}
+
 	@objc func close() {
 		navigationController.dismiss(animated: true)
 		parentCoordinator?.childDidFinish(self)

--- a/Cryptomator/Settings/SettingsViewController.swift
+++ b/Cryptomator/Settings/SettingsViewController.swift
@@ -77,6 +77,10 @@ class SettingsViewController: UITableViewController {
 		}
 	}
 
+	func showCloudServices() {
+		coordinator?.showCloudServices()
+	}
+
 	// MARK: - UITableViewDelegate
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -91,6 +95,8 @@ class SettingsViewController: UITableViewController {
 			sendLogFile(sender: cell)
 		case .clearCache:
 			clearCache()
+		case .showCloudServices:
+			showCloudServices()
 		case .unknown:
 			break
 		}

--- a/Cryptomator/Settings/SettingsViewController.swift
+++ b/Cryptomator/Settings/SettingsViewController.swift
@@ -81,6 +81,14 @@ class SettingsViewController: UITableViewController {
 		coordinator?.showCloudServices()
 	}
 
+	func showContact() {
+		coordinator?.openContact()
+	}
+
+	func showRateApp() {
+		coordinator?.openRateApp()
+	}
+
 	// MARK: - UITableViewDelegate
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
@@ -97,6 +105,10 @@ class SettingsViewController: UITableViewController {
 			clearCache()
 		case .showCloudServices:
 			showCloudServices()
+		case .showContact:
+			showContact()
+		case .showRateApp:
+			showRateApp()
 		case .unknown:
 			break
 		}

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -16,19 +16,24 @@ enum SettingsButtonAction: String {
 	case showAbout
 	case sendLogFile
 	case clearCache
+	case showCloudServices
 	case unknown
 }
 
 enum SettingsSection: Int {
-	case cacheSection = 0
+	case cloudServiceSection = 0
+	case cacheSection
 	case aboutSection
 	case debugSection
 }
 
 class SettingsViewModel {
-	var sections: [SettingsSection] = [.cacheSection, .aboutSection, .debugSection]
+	var sections: [SettingsSection] = [.cloudServiceSection, .cacheSection, .aboutSection, .debugSection]
 	lazy var cells: [SettingsSection: [TableViewCellViewModel]] = {
 		[
+			.cloudServiceSection: [
+				ButtonCellViewModel.createDisclosureButton(action: SettingsButtonAction.showCloudServices, title: LocalizedString.getValue("settings.cloudServices"))
+			],
 			.cacheSection: [
 				cacheSizeCellViewModel,
 				clearCacheButtonCellViewModel

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -11,13 +11,14 @@ import CryptomatorCommonCore
 import CryptomatorFileProvider
 import Foundation
 import Promises
-import UIKit
 
 enum SettingsButtonAction: String {
 	case showAbout
 	case sendLogFile
 	case clearCache
 	case showCloudServices
+	case showContact
+	case showRateApp
 	case unknown
 }
 
@@ -26,10 +27,11 @@ enum SettingsSection: Int {
 	case cacheSection
 	case aboutSection
 	case debugSection
+	case miscSection
 }
 
 class SettingsViewModel {
-	var sections: [SettingsSection] = [.cloudServiceSection, .cacheSection, .aboutSection, .debugSection]
+	var sections: [SettingsSection] = [.cloudServiceSection, .cacheSection, .aboutSection, .debugSection, .miscSection]
 	lazy var cells: [SettingsSection: [TableViewCellViewModel]] = {
 		[
 			.cloudServiceSection: [
@@ -45,6 +47,10 @@ class SettingsViewModel {
 			.debugSection: [
 				debugModeViewModel,
 				ButtonCellViewModel<SettingsButtonAction>(action: .sendLogFile, title: LocalizedString.getValue("settings.sendLogFile"))
+			],
+			.miscSection: [
+				ButtonCellViewModel(action: SettingsButtonAction.showContact, title: LocalizedString.getValue("settings.contact")),
+				ButtonCellViewModel(action: SettingsButtonAction.showRateApp, title: LocalizedString.getValue("settings.rateApp"))
 			]
 		]
 	}()

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
@@ -18,6 +18,12 @@ public class CryptomatorUserDefaults {
 
 	private var defaults = UserDefaults(suiteName: CryptomatorConstants.appGroupName)!
 
+	#if DEBUG
+	private static let debugModeEnabledDefaultValue = true
+	#else
+	private static let debugModeEnabledDefaultValue = false
+	#endif
+
 	private func read<T>(property: String = #function) -> T? {
 		defaults.object(forKey: property) as? T
 	}
@@ -30,13 +36,7 @@ public class CryptomatorUserDefaults {
 
 extension CryptomatorUserDefaults: CryptomatorSettings {
 	public var debugModeEnabled: Bool {
-		get {
-			#if DEBUG
-			true
-			#else
-			read() ?? false
-			#endif
-		}
+		get { read() ?? CryptomatorUserDefaults.debugModeEnabledDefaultValue }
 		set { write(value: newValue) }
 	}
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
@@ -1,0 +1,42 @@
+//
+//  CryptomatorSettings.swift
+//  CryptomatorCommonCore
+//
+//  Created by Tobias Hagemann on 22.09.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import Foundation
+
+public protocol CryptomatorSettings {
+	var debugModeEnabled: Bool { get set }
+}
+
+public class CryptomatorUserDefaults {
+	public static let shared = CryptomatorUserDefaults()
+
+	private var defaults = UserDefaults(suiteName: CryptomatorConstants.appGroupName)!
+
+	private func read<T>(property: String = #function) -> T? {
+		defaults.object(forKey: property) as? T
+	}
+
+	private func write<T>(value: T, to property: String = #function) {
+		defaults.set(value, forKey: property)
+		DDLogDebug("Setting \(property) was written with value \(value)")
+	}
+}
+
+extension CryptomatorUserDefaults: CryptomatorSettings {
+	public var debugModeEnabled: Bool {
+		get {
+			#if DEBUG
+			true
+			#else
+			read() ?? false
+			#endif
+		}
+		set { write(value: newValue) }
+	}
+}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/LogLevelUpdating.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/LogLevelUpdating.swift
@@ -1,0 +1,19 @@
+//
+//  LogLevelUpdating.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 11.10.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@objc public protocol LogLevelUpdating: NSFileProviderServiceSource {
+	func logLevelUpdated()
+}
+
+public enum LogLevelUpdatingService {
+	public static var name: NSFileProviderServiceName {
+		return NSFileProviderServiceName("org.cryptomator.ios.log-level-updating")
+	}
+}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/LoggerSetup.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/LoggerSetup.swift
@@ -16,8 +16,13 @@ public enum LoggerSetup {
 		fileLogger.logFileManager.maximumNumberOfLogFiles = 7
 		DDLog.add(DDOSLogger.sharedInstance)
 		DDLog.add(fileLogger)
+		setDynamicLogLevel(debugModeEnabled: CryptomatorUserDefaults.shared.debugModeEnabled)
 		return {}
 	}()
+
+	public static func setDynamicLogLevel(debugModeEnabled: Bool) {
+		dynamicLogLevel = debugModeEnabled ? .debug : .error
+	}
 }
 
 public extension DDFileLogger {

--- a/CryptomatorFileProvider/LogLevelUpdatingServiceSource.swift
+++ b/CryptomatorFileProvider/LogLevelUpdatingServiceSource.swift
@@ -1,0 +1,58 @@
+//
+//  LogLevelUpdatingServiceSource.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 11.10.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import CryptomatorCommonCore
+import FileProvider
+import Foundation
+
+public class LogLevelUpdatingServiceSource: NSObject, NSFileProviderServiceSource, NSXPCListenerDelegate, LogLevelUpdating {
+	public var serviceName: NSFileProviderServiceName {
+		LogLevelUpdatingService.name
+	}
+
+	private lazy var listener: NSXPCListener = {
+		let listener = NSXPCListener.anonymous()
+		listener.delegate = self
+		listener.resume()
+		return listener
+	}()
+
+	private let cryptomatorSettings: CryptomatorSettings
+
+	init(cryptomatorSettings: CryptomatorSettings) {
+		self.cryptomatorSettings = cryptomatorSettings
+	}
+
+	override public convenience init() {
+		self.init(cryptomatorSettings: CryptomatorUserDefaults.shared)
+	}
+
+	public func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
+		return listener.endpoint
+	}
+
+	// MARK: - NSXPCListenerDelegate
+
+	public func listener(_ listener: NSXPCListener, shouldAcceptNewConnection newConnection: NSXPCConnection) -> Bool {
+		newConnection.exportedInterface = NSXPCInterface(with: LogLevelUpdating.self)
+		newConnection.exportedObject = self
+		newConnection.resume()
+		weak var weakConnection = newConnection
+		newConnection.interruptionHandler = {
+			weakConnection?.invalidate()
+		}
+		return true
+	}
+
+	// MARK: - LogLevelUpdating
+
+	public func logLevelUpdated() {
+		LoggerSetup.setDynamicLogLevel(debugModeEnabled: cryptomatorSettings.debugModeEnabled)
+	}
+}

--- a/CryptomatorFileProviderTests/LogLevelUpdatingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/LogLevelUpdatingServiceSourceTests.swift
@@ -1,0 +1,36 @@
+//
+//  LogLevelUpdatingServiceSourceTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 11.10.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import XCTest
+@testable import CryptomatorCommonCore
+@testable import CryptomatorFileProvider
+
+class LogLevelUpdatingServiceSourceTests: XCTestCase {
+	private var cryptomatorSettingsMock: CryptomatorSettingsMock!
+	private var serviceSouce: LogLevelUpdatingServiceSource!
+
+	override func setUpWithError() throws {
+		cryptomatorSettingsMock = CryptomatorSettingsMock()
+		serviceSouce = LogLevelUpdatingServiceSource(cryptomatorSettings: cryptomatorSettingsMock)
+	}
+
+	func testLogLevelUpdated() throws {
+		cryptomatorSettingsMock.debugModeEnabled = false
+		serviceSouce.logLevelUpdated()
+		XCTAssertEqual(.error, dynamicLogLevel)
+
+		cryptomatorSettingsMock.debugModeEnabled = true
+		serviceSouce.logLevelUpdated()
+		XCTAssertEqual(.debug, dynamicLogLevel)
+	}
+}
+
+private class CryptomatorSettingsMock: CryptomatorSettings {
+	var debugModeEnabled: Bool = false
+}

--- a/CryptomatorTests/FileProviderConnectorMock.swift
+++ b/CryptomatorTests/FileProviderConnectorMock.swift
@@ -1,0 +1,38 @@
+//
+//  FileProviderConnectorMock.swift
+//  CryptomatorTests
+//
+//  Created by Philipp Schmid on 11.10.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import FileProvider
+import Foundation
+import Promises
+
+class FileProviderConnectorMock: FileProviderConnector {
+	var proxy: Any?
+	var passedServiceName: NSFileProviderServiceName?
+	var passedDomainIdentifier: NSFileProviderDomainIdentifier?
+	var passedDomain: NSFileProviderDomain?
+
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domainIdentifier: NSFileProviderDomainIdentifier) -> Promise<T> {
+		passedServiceName = serviceName
+		passedDomainIdentifier = domainIdentifier
+		return getCastedProxy()
+	}
+
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domain: NSFileProviderDomain?) -> Promise<T> {
+		passedServiceName = serviceName
+		passedDomain = domain
+		return getCastedProxy()
+	}
+
+	private func getCastedProxy<T>() -> Promise<T> {
+		guard let castedProxy = proxy as? T else {
+			return Promise(FileProviderXPCConnectorError.typeMismatch)
+		}
+		return Promise(castedProxy)
+	}
+}

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -250,29 +250,3 @@ private class VaultLockingMock: VaultLocking {
 		throw MockError.notMocked
 	}
 }
-
-private class FileProviderConnectorMock: FileProviderConnector {
-	var proxy: Any?
-	var passedServiceName: NSFileProviderServiceName?
-	var passedDomainIdentifier: NSFileProviderDomainIdentifier?
-	var passedDomain: NSFileProviderDomain?
-
-	func getProxy<T>(serviceName: NSFileProviderServiceName, domainIdentifier: NSFileProviderDomainIdentifier) -> Promise<T> {
-		passedServiceName = serviceName
-		passedDomainIdentifier = domainIdentifier
-		return getCastedProxy()
-	}
-
-	func getProxy<T>(serviceName: NSFileProviderServiceName, domain: NSFileProviderDomain?) -> Promise<T> {
-		passedServiceName = serviceName
-		passedDomain = domain
-		return getCastedProxy()
-	}
-
-	private func getCastedProxy<T>() -> Promise<T> {
-		guard let castedProxy = proxy as? T else {
-			return Promise(FileProviderXPCConnectorError.typeMismatch)
-		}
-		return Promise(castedProxy)
-	}
-}

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -262,6 +262,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		#endif
 		serviceSources.append(VaultUnlockingServiceSource(fileprovider: self))
 		serviceSources.append(VaultLockingServiceSource())
+		serviceSources.append(LogLevelUpdatingServiceSource())
 		return serviceSources
 	}
 

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -90,6 +90,7 @@
 "settings.cacheSize" = "Cache Size";
 "settings.clearCache" = "Clear Cache";
 "settings.cloudServices" = "Cloud Services";
+"settings.debugMode" = "Debug Mode";
 "settings.sendLogFile" = "Send Log File";
 
 "unlockVault.button.unlock" = "Unlock";

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -89,6 +89,7 @@
 "settings.aboutCryptomator.title" = "Version %@ (%@)";
 "settings.cacheSize" = "Cache Size";
 "settings.clearCache" = "Clear Cache";
+"settings.cloudServices" = "Cloud Services";
 "settings.sendLogFile" = "Send Log File";
 
 "unlockVault.button.unlock" = "Unlock";

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -90,7 +90,9 @@
 "settings.cacheSize" = "Cache Size";
 "settings.clearCache" = "Clear Cache";
 "settings.cloudServices" = "Cloud Services";
+"settings.contact" = "Contact";
 "settings.debugMode" = "Debug Mode";
+"settings.rateApp" = "Rate App";
 "settings.sendLogFile" = "Send Log File";
 
 "unlockVault.button.unlock" = "Unlock";


### PR DESCRIPTION
The settings screen was created as specified in #9, with the exception that iCloud Drive is not listed under "Cloud Services".
This is because we cannot log the user out of their Apple ID directly from the app, moreover it is questionable whether the user would be aware of the implications of this decision.

Debug mode is automatically enabled for debug builds, so to test disabling debug mode, the preprocessor macro block in `CryptomatorUserDefaults` must be commented out.