### PR TITLE
Feature: Use return button to navigate through UITextFields

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		4A6A5219268B6D32006F7368 /* OnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A5218268B6D31006F7368 /* OnboardingViewController.swift */; };
 		4A6A521B268B7147006F7368 /* FileProviderCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A521A268B7147006F7368 /* FileProviderCoordinator.swift */; };
 		4A6A521D268B7C8F006F7368 /* BaseNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6A521C268B7C8F006F7368 /* BaseNavigationController.swift */; };
+		4A6C36D6274525E100F247A9 /* ReturnButtonSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6C36D5274525E100F247A9 /* ReturnButtonSupport.swift */; };
 		4A6CF80027428CCB0061380A /* VaultCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A6CF7FF27428CCB0061380A /* VaultCellViewModel.swift */; };
 		4A717CD924C835740048E08F /* ReparentTaskManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A717CD824C835740048E08F /* ReparentTaskManagerTests.swift */; };
 		4A753DB92678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A753DB82678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift */; };
@@ -522,6 +523,7 @@
 		4A6A5218268B6D31006F7368 /* OnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewController.swift; sourceTree = "<group>"; };
 		4A6A521A268B7147006F7368 /* FileProviderCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderCoordinator.swift; sourceTree = "<group>"; };
 		4A6A521C268B7C8F006F7368 /* BaseNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseNavigationController.swift; sourceTree = "<group>"; };
+		4A6C36D5274525E100F247A9 /* ReturnButtonSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReturnButtonSupport.swift; sourceTree = "<group>"; };
 		4A6CF7FF27428CCB0061380A /* VaultCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultCellViewModel.swift; sourceTree = "<group>"; };
 		4A717CD824C835740048E08F /* ReparentTaskManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReparentTaskManagerTests.swift; sourceTree = "<group>"; };
 		4A753DB82678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenExistingLegacyVaultPasswordViewModel.swift; sourceTree = "<group>"; };
@@ -1126,14 +1128,15 @@
 		4AA22C25261CA96600A17486 /* Cells */ = {
 			isa = PBXGroup;
 			children = (
+				4A4B7E4326B2B1A5009BFDB1 /* BindableTableViewCellViewModel.swift */,
 				4A4B7E4926B2C071009BFDB1 /* ButtonCellViewModel.swift */,
 				4A1673E0270C43AF0075C724 /* LoadingWithLabelCell.swift */,
 				4A1673E2270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift */,
 				4A66F58125C487C9001BE15E /* PasswordFieldCell.swift */,
+				4A6C36D5274525E100F247A9 /* ReturnButtonSupport.swift */,
 				4A4B7E4726B2BAFB009BFDB1 /* SwitchCell.swift */,
 				4A4B7E4526B2B6A0009BFDB1 /* SwitchCellViewModel.swift */,
 				4A4B7E4B26B2FF41009BFDB1 /* TableViewCell.swift */,
-				4A4B7E4326B2B1A5009BFDB1 /* BindableTableViewCellViewModel.swift */,
 				4A66F57825C47BB2001BE15E /* TextFieldCell.swift */,
 				4A3C5DD9272BF52600EB7C7A /* TextFieldCellViewModel.swift */,
 				4AA22C15261CA8D800A17486 /* URLFieldCell.swift */,
@@ -1964,6 +1967,7 @@
 				4A7B97DC25B6F80A0044B7FB /* AccountInfo.swift in Sources */,
 				4AA8614825C1C670002A59F5 /* OpenExistingVaultChooseFolderViewController.swift in Sources */,
 				4A4B7E4826B2BAFB009BFDB1 /* SwitchCell.swift in Sources */,
+				4A6C36D6274525E100F247A9 /* ReturnButtonSupport.swift in Sources */,
 				4A1673E1270C43AF0075C724 /* LoadingWithLabelCell.swift in Sources */,
 				4A447E5625BF1F6A00D9520D /* CloudItemCell.swift in Sources */,
 				4A5F48EE272AA02A0084135F /* MaintenanceModeError+Localization.swift in Sources */,

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewController.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewController.swift
@@ -6,12 +6,14 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCommonCore
 import UIKit
 
 class CreateNewVaultPasswordViewController: StaticUITableViewController<CreateNewVaultPasswordSection> {
 	weak var coordinator: (Coordinator & VaultInstalling)?
 	private let viewModel: CreateNewVaultPasswordViewModelProtocol
+	private var lastReturnButtonPressedSubscriber: AnyCancellable?
 
 	init(viewModel: CreateNewVaultPasswordViewModelProtocol) {
 		self.viewModel = viewModel
@@ -23,6 +25,9 @@ class CreateNewVaultPasswordViewController: StaticUITableViewController<CreateNe
 		let createButton = UIBarButtonItem(title: LocalizedString.getValue("common.button.create"), style: .done, target: self, action: #selector(createNewVault))
 		navigationItem.rightBarButtonItem = createButton
 		tableView.rowHeight = 44
+		lastReturnButtonPressedSubscriber = viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.createNewVault()
+		}
 	}
 
 	@objc func createNewVault() {

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewModel.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewModel.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
 import Foundation
 import Promises
 
-protocol CreateNewVaultPasswordViewModelProtocol: TableViewModel<CreateNewVaultPasswordSection> {
+protocol CreateNewVaultPasswordViewModelProtocol: TableViewModel<CreateNewVaultPasswordSection>, ReturnButtonSupport {
 	var vaultUID: String { get }
 	var vaultName: String { get }
 	func validatePassword() throws
@@ -24,6 +25,10 @@ enum CreateNewVaultPasswordSection: Int {
 }
 
 class CreateNewVaultPasswordViewModel: TableViewModel<CreateNewVaultPasswordSection>, CreateNewVaultPasswordViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [passwordCellViewModel, confirmPasswordCellViewModel], subscribers: &subscribers)
+	}
+
 	var vaultName: String {
 		return vaultPath.lastPathComponent
 	}
@@ -46,6 +51,7 @@ class CreateNewVaultPasswordViewModel: TableViewModel<CreateNewVaultPasswordSect
 	private static let minimumPasswordLength = 8
 	private lazy var passwordCellViewModel = TextFieldCellViewModel(type: .password, isInitialFirstResponder: true)
 	private lazy var confirmPasswordCellViewModel = TextFieldCellViewModel(type: .password)
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	private var password: String {
 		return passwordCellViewModel.input.value

--- a/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewController.swift
+++ b/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewController.swift
@@ -6,12 +6,14 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCommonCore
 import UIKit
 
 class SetVaultNameViewController: SingleSectionStaticUITableViewController {
 	weak var coordinator: (VaultNaming & Coordinator)?
 	private var viewModel: SetVaultNameViewModelProtocol
+	private var lastReturnButtonPressedSubscriber: AnyCancellable?
 
 	init(viewModel: SetVaultNameViewModelProtocol) {
 		self.viewModel = viewModel
@@ -23,6 +25,9 @@ class SetVaultNameViewController: SingleSectionStaticUITableViewController {
 		let doneButton = UIBarButtonItem(title: LocalizedString.getValue("common.button.next"), style: .done, target: self, action: #selector(nextButtonClicked))
 		navigationItem.rightBarButtonItem = doneButton
 		tableView.rowHeight = 44
+		lastReturnButtonPressedSubscriber = viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.lastReturnButtonPressedAction()
+		}
 	}
 
 	@objc func nextButtonClicked() {
@@ -31,6 +36,10 @@ class SetVaultNameViewController: SingleSectionStaticUITableViewController {
 		} catch {
 			coordinator?.handleError(error, for: self)
 		}
+	}
+
+	func lastReturnButtonPressedAction() {
+		nextButtonClicked()
 	}
 }
 

--- a/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewModel.swift
+++ b/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewModel.swift
@@ -6,14 +6,19 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCommonCore
 import Foundation
 
-protocol SetVaultNameViewModelProtocol: SingleSectionTableViewModel {
+protocol SetVaultNameViewModelProtocol: SingleSectionTableViewModel, ReturnButtonSupport {
 	func getValidatedVaultName() throws -> String
 }
 
 class SetVaultNameViewModel: SingleSectionTableViewModel, SetVaultNameViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [vaultNameCellViewModel], subscribers: &subscribers)
+	}
+
 	override var cells: [TableViewCellViewModel] {
 		return [vaultNameCellViewModel]
 	}
@@ -32,6 +37,8 @@ class SetVaultNameViewModel: SingleSectionTableViewModel, SetVaultNameViewModelP
 	// cannot end with .
 	// swiftlint:disable:next force_try
 	private let regex = try! NSRegularExpression(pattern: "[\\\\/:\\*\\?\"<>\\|]|\\.$")
+
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	func getValidatedVaultName() throws -> String {
 		guard !trimmedVaultName.isEmpty else {

--- a/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultPasswordViewModel.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultPasswordViewModel.swift
@@ -12,7 +12,7 @@ import CryptomatorCommonCore
 import Foundation
 import Promises
 
-protocol OpenExistingVaultPasswordViewModelProtocol: SingleSectionTableViewModel {
+protocol OpenExistingVaultPasswordViewModelProtocol: SingleSectionTableViewModel, ReturnButtonSupport {
 	var vaultName: String { get }
 	var vaultUID: String { get }
 	var enableVerifyButton: AnyPublisher<Bool, Never> { get }
@@ -21,6 +21,10 @@ protocol OpenExistingVaultPasswordViewModelProtocol: SingleSectionTableViewModel
 }
 
 class OpenExistingVaultPasswordViewModel: SingleSectionTableViewModel, OpenExistingVaultPasswordViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [passwordCellViewModel], subscribers: &subscribers)
+	}
+
 	override var title: String? {
 		return LocalizedString.getValue("addVault.openExistingVault.title")
 	}
@@ -48,6 +52,8 @@ class OpenExistingVaultPasswordViewModel: SingleSectionTableViewModel, OpenExist
 	var password: String {
 		return passwordCellViewModel.input.value
 	}
+
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	init(provider: CloudProvider, account: CloudProviderAccount, vault: VaultItem, vaultUID: String) {
 		self.provider = provider

--- a/Cryptomator/Common/Cells/ReturnButtonSupport.swift
+++ b/Cryptomator/Common/Cells/ReturnButtonSupport.swift
@@ -1,0 +1,29 @@
+//
+//  ReturnButtonSupport.swift
+//  Cryptomator
+//
+//  Created by Philipp Schmid on 17.11.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Combine
+import Foundation
+
+protocol ReturnButtonSupport {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> { get }
+}
+
+extension ReturnButtonSupport where Self: AnyObject {
+	func setupReturnButtonSupport(for cellViewModels: [TextFieldCellViewModel], subscribers: inout Set<AnyCancellable>) -> AnyPublisher<Void, Never> {
+		let publisher = PassthroughSubject<Void, Never>()
+		for (i, viewModel) in cellViewModels.dropLast().enumerated() {
+			viewModel.startListeningToReturnButtonPressedEvents().sink {
+				cellViewModels[i + 1].becomeFirstResponder()
+			}.store(in: &subscribers)
+		}
+		cellViewModels.last?.startListeningToReturnButtonPressedEvents().sink {
+			publisher.send()
+		}.store(in: &subscribers)
+		return publisher.eraseToAnyPublisher()
+	}
+}

--- a/Cryptomator/Common/Cells/TextFieldCellViewModel.swift
+++ b/Cryptomator/Common/Cells/TextFieldCellViewModel.swift
@@ -34,11 +34,29 @@ class TextFieldCellViewModel: BindableTableViewCellViewModel {
 	let input: Bindable<String>
 	let placeholder: String?
 	let isInitialFirstResponder: Bool
+	private lazy var returnButtonPressedPublisher = PassthroughSubject<Void, Never>()
+	private lazy var becomeFirstResponderPublisher = PassthroughSubject<Void, Never>()
 
 	init(type: TextFieldCellType, text: String = "", placeholder: String? = nil, isInitialFirstResponder: Bool = false) {
 		self.textFielCellType = type
 		self.input = Bindable(text)
 		self.placeholder = placeholder
 		self.isInitialFirstResponder = isInitialFirstResponder
+	}
+
+	func returnButtonPressed() {
+		returnButtonPressedPublisher.send()
+	}
+
+	func startListeningToReturnButtonPressedEvents() -> AnyPublisher<Void, Never> {
+		return returnButtonPressedPublisher.eraseToAnyPublisher()
+	}
+
+	func becomeFirstResponder() {
+		becomeFirstResponderPublisher.send()
+	}
+
+	func startListeningToBecomeFirstResponder() -> AnyPublisher<Void, Never> {
+		return becomeFirstResponderPublisher.eraseToAnyPublisher()
 	}
 }

--- a/Cryptomator/Common/ChooseFolder/CreateNewFolderViewController.swift
+++ b/Cryptomator/Common/ChooseFolder/CreateNewFolderViewController.swift
@@ -6,12 +6,14 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCommonCore
 import UIKit
 
 class CreateNewFolderViewController: SingleSectionStaticUITableViewController {
 	weak var coordinator: (FolderCreating & Coordinator)?
 	private var viewModel: CreateNewFolderViewModelProtocol
+	private var lastReturnButtonPressedSubscriber: AnyCancellable?
 
 	init(viewModel: CreateNewFolderViewModelProtocol) {
 		self.viewModel = viewModel
@@ -25,6 +27,9 @@ class CreateNewFolderViewController: SingleSectionStaticUITableViewController {
 		navigationItem.leftBarButtonItem = cancelButton
 		navigationItem.rightBarButtonItem = createButton
 		tableView.rowHeight = 44
+		lastReturnButtonPressedSubscriber = viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.createButtonClicked()
+		}
 	}
 
 	override func configureDataSource() {
@@ -67,6 +72,10 @@ import Promises
 import SwiftUI
 
 private class CreateNewFolderViewModelMock: SingleSectionTableViewModel, CreateNewFolderViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		PassthroughSubject<Void, Never>().eraseToAnyPublisher()
+	}
+
 	override var cells: [TableViewCellViewModel] {
 		return [folderNameCellViewModel]
 	}

--- a/Cryptomator/Common/ChooseFolder/CreateNewFolderViewModel.swift
+++ b/Cryptomator/Common/ChooseFolder/CreateNewFolderViewModel.swift
@@ -6,16 +6,21 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
 import Foundation
 import Promises
 
-protocol CreateNewFolderViewModelProtocol: SingleSectionTableViewModel {
+protocol CreateNewFolderViewModelProtocol: SingleSectionTableViewModel, ReturnButtonSupport {
 	func createFolder() -> Promise<CloudPath>
 }
 
 class CreateNewFolderViewModel: SingleSectionTableViewModel, CreateNewFolderViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [folderNameCellViewModel], subscribers: &subscribers)
+	}
+
 	override var cells: [TableViewCellViewModel] {
 		return [folderNameCellViewModel]
 	}
@@ -31,6 +36,7 @@ class CreateNewFolderViewModel: SingleSectionTableViewModel, CreateNewFolderView
 
 	private let parentPath: CloudPath
 	private let provider: CloudProvider
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	init(parentPath: CloudPath, provider: CloudProvider) {
 		self.parentPath = parentPath

--- a/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewController.swift
+++ b/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewController.swift
@@ -24,6 +24,9 @@ class ChangePasswordViewController: StaticUITableViewController<ChangePasswordSe
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		navigationItem.rightBarButtonItem = changePasswordButton
+		viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.changePassword()
+		}.store(in: &subscriber)
 	}
 
 	@objc func changePassword() {

--- a/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewModel.swift
+++ b/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewModel.swift
@@ -14,7 +14,7 @@ import CryptomatorFileProvider
 import Foundation
 import Promises
 
-protocol ChangePasswordViewModelProtocol: TableViewModel<ChangePasswordSection> {
+protocol ChangePasswordViewModelProtocol: TableViewModel<ChangePasswordSection>, ReturnButtonSupport {
 	func changePassword() -> Promise<Void>
 	func validatePasswords() throws
 }
@@ -50,6 +50,10 @@ enum ChangePasswordSection: Int {
 class ChangePasswordViewModel: TableViewModel<ChangePasswordSection>, ChangePasswordViewModelProtocol {
 	override var title: String? {
 		return vaultAccount.vaultName
+	}
+
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [oldPasswordCellViewModel, newPasswordCellViewModel, newPasswordConfirmationCellViewModel], subscribers: &subscribers)
 	}
 
 	override var sections: [Section<ChangePasswordSection>] {
@@ -94,11 +98,14 @@ class ChangePasswordViewModel: TableViewModel<ChangePasswordSection>, ChangePass
 		return newPasswordConfirmationCellViewModel.input.value
 	}
 
+	private lazy var subscribers = Set<AnyCancellable>()
+
 	init(vaultAccount: VaultAccount, maintenanceManager: MaintenanceManager, vaultManager: VaultManager = VaultDBManager.shared, fileProviderConnector: FileProviderConnector = FileProviderXPCConnector.shared) {
 		self.vaultAccount = vaultAccount
 		self.maintenanceManager = maintenanceManager
 		self.vaultManager = vaultManager
 		self.fileProviderConnector = fileProviderConnector
+		super.init()
 	}
 
 	func changePassword() -> Promise<Void> {

--- a/Cryptomator/VaultDetail/RenameVault/RenameVaultViewController.swift
+++ b/Cryptomator/VaultDetail/RenameVault/RenameVaultViewController.swift
@@ -23,6 +23,10 @@ class RenameVaultViewController: SetVaultNameViewController {
 		navigationItem.rightBarButtonItem = renameButton
 	}
 
+	override func lastReturnButtonPressedAction() {
+		renameButtonClicked()
+	}
+
 	@objc private func renameButtonClicked() {
 		let hud = ProgressHUD()
 		hud.text = LocalizedString.getValue("vaultDetail.renameVault.progress")

--- a/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewController.swift
+++ b/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewController.swift
@@ -25,7 +25,7 @@ class VaultDetailUnlockVaultViewController: SingleSectionStaticUITableViewContro
 		return navigationController?.view.superview // shake the whole modal dialog
 	}
 
-	private var verifyButtonEnabledSubscriber: AnyCancellable?
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	init(viewModel: VaultDetailUnlockVaultViewModel) {
 		self.viewModel = viewModel
@@ -38,9 +38,12 @@ class VaultDetailUnlockVaultViewController: SingleSectionStaticUITableViewContro
 		navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
 		navigationItem.rightBarButtonItem = enableButton
 		tableView.rowHeight = 44
-		verifyButtonEnabledSubscriber = viewModel.enableVerifyButton.sink { [weak self] isEnabled in
+		viewModel.enableVerifyButton.sink { [weak self] isEnabled in
 			self?.enableButton.isEnabled = isEnabled
-		}
+		}.store(in: &subscribers)
+		viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.verify()
+		}.store(in: &subscribers)
 	}
 
 	override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {

--- a/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewModel.swift
@@ -11,7 +11,11 @@ import CryptomatorCommonCore
 import CryptomatorCryptoLib
 import Foundation
 
-class VaultDetailUnlockVaultViewModel: SingleSectionTableViewModel {
+class VaultDetailUnlockVaultViewModel: SingleSectionTableViewModel, ReturnButtonSupport {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [passwordCellViewModel], subscribers: &subscribers)
+	}
+
 	override var title: String? {
 		return vault.vaultName
 	}
@@ -34,6 +38,7 @@ class VaultDetailUnlockVaultViewModel: SingleSectionTableViewModel {
 	private let vault: VaultInfo
 	private let biometryTypeName: String
 	private let passwordManager: VaultPasswordManager
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	init(vault: VaultInfo, biometryTypeName: String, passwordManager: VaultPasswordManager) {
 		self.vault = vault

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
 import UIKit
@@ -13,6 +14,7 @@ import UIKit
 class WebDAVAuthenticationViewController: SingleSectionStaticUITableViewController {
 	weak var coordinator: (Coordinator & WebDAVAuthenticating)?
 	private var viewModel: WebDAVAuthenticationViewModelProtocol
+	private var lastReturnButtonPressedSubscriber: AnyCancellable?
 
 	init(viewModel: WebDAVAuthenticationViewModelProtocol) {
 		self.viewModel = viewModel
@@ -27,6 +29,9 @@ class WebDAVAuthenticationViewController: SingleSectionStaticUITableViewControll
 		navigationItem.leftBarButtonItem = cancelButton
 		let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
 		navigationItem.rightBarButtonItem = doneButton
+		lastReturnButtonPressedSubscriber = viewModel.lastReturnButtonPressed.sink { [weak self] in
+			self?.done()
+		}
 	}
 
 	@objc func done() {
@@ -84,6 +89,10 @@ import Promises
 import SwiftUI
 
 class WebDAVAuthenticationViewModelMock: SingleSectionTableViewModel, WebDAVAuthenticationViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		PassthroughSubject<Void, Never>().eraseToAnyPublisher()
+	}
+
 	func createWebDAVCredentialFromInput(allowedCertificate: Data?) throws -> WebDAVCredential {
 		WebDAVCredential(baseURL: URL(string: ".")!, username: "", password: "", allowedCertificate: nil)
 	}

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
 import Foundation
@@ -17,12 +18,16 @@ enum WebDAVAuthenticationError: Error {
 	case userCanceled
 }
 
-protocol WebDAVAuthenticationViewModelProtocol: SingleSectionTableViewModel {
+protocol WebDAVAuthenticationViewModelProtocol: SingleSectionTableViewModel, ReturnButtonSupport {
 	func createWebDAVCredentialFromInput(allowedCertificate: Data?) throws -> WebDAVCredential
 	func addAccount(credential: WebDAVCredential) -> Promise<WebDAVCredential>
 }
 
 class WebDAVAuthenticationViewModel: SingleSectionTableViewModel, WebDAVAuthenticationViewModelProtocol {
+	var lastReturnButtonPressed: AnyPublisher<Void, Never> {
+		return setupReturnButtonSupport(for: [urlCellViewModel, usernameCellViewModel, passwordCellViewModel], subscribers: &subscribers)
+	}
+
 	override var cells: [TableViewCellViewModel] {
 		[
 			urlCellViewModel,
@@ -48,6 +53,7 @@ class WebDAVAuthenticationViewModel: SingleSectionTableViewModel, WebDAVAuthenti
 	}
 
 	private var client: WebDAVClient?
+	private lazy var subscribers = Set<AnyCancellable>()
 
 	func createWebDAVCredentialFromInput(allowedCertificate: Data?) throws -> WebDAVCredential {
 		// TODO: Add Input Validation

--- a/CryptomatorTests/CreateNewFolderViewModelTests.swift
+++ b/CryptomatorTests/CreateNewFolderViewModelTests.swift
@@ -51,6 +51,14 @@ class CreateNewFolderViewModelTests: XCTestCase {
 		wait(for: [expectation], timeout: 1.0)
 	}
 
+	func testReturnButtonSupport() {
+		let folderNameCellViewModel = viewModel.folderNameCellViewModel
+		XCTAssert(folderNameCellViewModel.isInitialFirstResponder)
+		let lastReturnButtonPressedRecorder = viewModel.lastReturnButtonPressed.recordNext(1)
+		folderNameCellViewModel.returnButtonPressed()
+		wait(for: lastReturnButtonPressedRecorder)
+	}
+
 	func setFolderName(_ name: String) {
 		viewModel.folderNameCellViewModel.input.value = name
 	}

--- a/CryptomatorTests/SetVaultNameViewModelTests.swift
+++ b/CryptomatorTests/SetVaultNameViewModelTests.swift
@@ -81,6 +81,14 @@ class SetVaultNameViewModelTests: XCTestCase {
 		getValidatedVaultNameThrowsInvalidInputError()
 	}
 
+	func testReturnButtonSupport() {
+		let vaultNameCellViewModel = viewModel.vaultNameCellViewModel
+		XCTAssert(vaultNameCellViewModel.isInitialFirstResponder)
+		let lastReturnButtonPressedRecorder = viewModel.lastReturnButtonPressed.recordNext(1)
+		vaultNameCellViewModel.returnButtonPressed()
+		wait(for: lastReturnButtonPressedRecorder)
+	}
+
 	func setVaultName(_ name: String, viewModel: SetVaultNameViewModel) {
 		viewModel.vaultNameCellViewModel.input.value = name
 	}

--- a/FileProviderExtensionUI/UnlockVaultViewController.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewController.swift
@@ -19,6 +19,7 @@ class UnlockVaultViewController: UITableViewController {
 		let cell = PasswordFieldCell()
 		cell.textField.becomeFirstResponder()
 		cell.textField.tintColor = UIColor(named: "primary")
+		cell.textField.delegate = self
 		cell.selectionStyle = .none
 		return cell
 	}()
@@ -149,6 +150,13 @@ class UnlockVaultViewController: UITableViewController {
 		case .unknown:
 			return UITableViewCell()
 		}
+	}
+}
+
+extension UnlockVaultViewController: UITextFieldDelegate {
+	func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+		unlock()
+		return false
 	}
 }
 


### PR DESCRIPTION
This PR adds the feature to navigate through the different `UITextFields` within a ViewModel using the return button.
If the return button is pressed at the last `UITextField`, this is communicated to the respective `UIViewController` via the `lastReturnButtonPressed` publisher, so that it can execute the same method as when the `rightBarButtonItem` is pressed.