### PR TITLE
Added additional confirmation of enabling debug mode

### DIFF
--- a/Cryptomator/Common/Cells/SwitchCell.swift
+++ b/Cryptomator/Common/Cells/SwitchCell.swift
@@ -22,11 +22,14 @@ class SwitchCell: TableViewCell {
 		guard let switchCellViewModel = viewModel as? SwitchCellViewModel else {
 			return
 		}
+		switchControl.setOn(switchCellViewModel.isOn.value, animated: false)
 		twoWayBinding(viewModel: switchCellViewModel)
 	}
 
 	private func twoWayBinding(viewModel: SwitchCellViewModel) {
-		viewModel.isOn.$value.receive(on: DispatchQueue.main).assign(to: \.isOn, on: switchControl).store(in: &subscribers)
+		viewModel.isOn.$value.receive(on: DispatchQueue.main).sink { [weak self] value in
+			self?.switchControl.setOn(value, animated: true)
+		}.store(in: &subscribers)
 		switchControl.publisher(for: .valueChanged)
 			.sink(receiveValue: {
 				viewModel.isOnButtonPublisher.send($0)

--- a/Cryptomator/Settings/SettingsViewController.swift
+++ b/Cryptomator/Settings/SettingsViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import CocoaLumberjackSwift
+import Combine
 import CryptomatorCommonCore
 import Foundation
 import UIKit
@@ -16,6 +17,7 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 
 	private let viewModel: SettingsViewModel
 	private var observer: NSObjectProtocol?
+	private var subscriber: AnyCancellable?
 
 	init(viewModel: SettingsViewModel) {
 		self.viewModel = viewModel
@@ -29,6 +31,9 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 		refreshCacheSize()
 		observer = NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: .main) { [weak self] _ in
 			self?.refreshCacheSize()
+		}
+		subscriber = viewModel.showDebugModeWarning.sink { [weak self] in
+			self?.showDebugModeAlert()
 		}
 	}
 
@@ -71,6 +76,20 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 
 	func showRateApp() {
 		coordinator?.openRateApp()
+	}
+
+	func showDebugModeAlert() {
+		let alertController = UIAlertController(title: LocalizedString.getValue("common.alert.attention.title"), message: LocalizedString.getValue("settings.debugMode.alert.message"), preferredStyle: .alert)
+		let okAction = UIAlertAction(title: LocalizedString.getValue("common.button.enable"), style: .default) { _ in
+			self.viewModel.enableDebugMode()
+		}
+		let cancelAction = UIAlertAction(title: LocalizedString.getValue("common.button.cancel"), style: .cancel) { _ in
+			self.viewModel.disableDebugMode()
+		}
+		alertController.addAction(okAction)
+		alertController.addAction(cancelAction)
+
+		present(alertController, animated: true, completion: nil)
 	}
 
 	// MARK: - UITableViewDelegate

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -39,6 +39,10 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 		return _sections
 	}
 
+	var showDebugModeWarning: AnyPublisher<Void, Never> {
+		return showDebugModeWarningPublisher.eraseToAnyPublisher()
+	}
+
 	private lazy var _sections: [Section<SettingsSection>] = {
 		return [
 			Section(id: .cloudServiceSection, elements: [
@@ -75,6 +79,7 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 
 	private let fileProviderConnector: FileProviderConnector
 	private var subscribers = Set<AnyCancellable>()
+	private lazy var showDebugModeWarningPublisher = PassthroughSubject<Void, Never>()
 
 	init(cacheManager: FileProviderCacheManager = FileProviderCacheManager(), cryptomatorSetttings: CryptomatorSettings = CryptomatorUserDefaults.shared, fileProviderConnector: FileProviderConnector = FileProviderXPCConnector.shared) {
 		self.cacheManager = cacheManager
@@ -113,11 +118,28 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 		}
 	}
 
+	func enableDebugMode() {
+		setDebugMode(enabled: true)
+	}
+
+	func disableDebugMode() {
+		setDebugMode(enabled: false)
+		debugModeViewModel.isOn.value = false
+	}
+
+	private func setDebugMode(enabled: Bool) {
+		cryptomatorSettings.debugModeEnabled = enabled
+		LoggerSetup.setDynamicLogLevel(debugModeEnabled: enabled)
+		notifyFileProviderAboutLogLevelUpdate()
+	}
+
 	private func bindDebugModeViewModel(_ viewModel: SwitchCellViewModel) {
 		viewModel.isOnButtonPublisher.sink { [weak self] isOn in
-			self?.cryptomatorSettings.debugModeEnabled = isOn
-			LoggerSetup.setDynamicLogLevel(debugModeEnabled: isOn)
-			self?.notifyFileProviderAboutLogLevelUpdate()
+			if isOn {
+				self?.showDebugModeWarningPublisher.send()
+			} else {
+				self?.setDebugMode(enabled: false)
+			}
 		}.store(in: &subscribers)
 	}
 

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -6,6 +6,7 @@
 */
 
 "common.alert.error.title" = "Error";
+"common.alert.attention.title" = "Attention";
 "common.button.cancel" = "Cancel";
 "common.button.change" = "Change";
 "common.button.choose" = "Choose";
@@ -103,6 +104,7 @@
 "settings.cloudServices" = "Cloud Services";
 "settings.contact" = "Contact";
 "settings.debugMode" = "Debug Mode";
+"settings.debugMode.alert.message" = "In this mode, sensitive data may be written to a log file on your device (e.g., filenames and paths). Passwords, cookies, etc. are explicitly excluded.\n\nRemember to disable debug mode as soon as possible.";
 "settings.rateApp" = "Rate App";
 "settings.sendLogFile" = "Send Log File";
 


### PR DESCRIPTION
In the settings screen an alert is now displayed if the user wants to activate the debug mode and he has to explicitly confirm it again to actually activate the debug mode. 
The alert informs the user that sensitive data like filenames and paths (but no passwords or cookies) may be written to the log files.