### PR TITLE
Feature: Allow HTTP for WebDAV connection

### DIFF
--- a/Cryptomator/Common/Cells/TextFieldCell.swift
+++ b/Cryptomator/Common/Cells/TextFieldCell.swift
@@ -58,6 +58,9 @@ class TextFieldCell: TableViewCell, UITextFieldDelegate {
 			.receive(on: RunLoop.main)
 			.assign(to: \.input.value, on: viewModel)
 			.store(in: &subscribers)
+		viewModel.input.$value.sink { [weak self] inputValue in
+			self?.textField.text = inputValue
+		}.store(in: &subscribers)
 	}
 
 	// MARK: - UITextFieldDelegate

--- a/Cryptomator/WebDAV/WebDAVAuthenticating.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticating.swift
@@ -13,5 +13,6 @@ import UIKit
 protocol WebDAVAuthenticating: AnyObject {
 	func authenticated(with credential: WebDAVCredential)
 	func handleUntrustedCertificate(_ certificate: TLSCertificate, url: URL, for viewController: WebDAVAuthenticationViewController, viewModel: WebDAVAuthenticationViewModelProtocol)
+	func handleInsecureConnection(for viewController: WebDAVAuthenticationViewController, viewModel: WebDAVAuthenticationViewModelProtocol)
 	func cancel()
 }

--- a/Cryptomator/WebDAV/WebDAVAuthenticationCoordinator.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationCoordinator.swift
@@ -47,9 +47,25 @@ class WebDAVAuthenticationCoordinator: NSObject, Coordinator, WebDAVAuthenticati
 	func handleUntrustedCertificate(_ certificate: TLSCertificate, url: URL, for viewController: WebDAVAuthenticationViewController, viewModel: WebDAVAuthenticationViewModelProtocol) {
 		let alertController = UIAlertController(title: LocalizedString.getValue("untrustedTLSCertificate.title"), message: String(format: LocalizedString.getValue("untrustedTLSCertificate.message"), url.absoluteString, certificate.fingerprint), preferredStyle: .alert)
 		alertController.addAction(UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.add"), style: .default, handler: { _ in
-			viewController.addAccount(allowedCertificate: certificate.data)
+			viewController.addAccount(allowedCertificate: certificate.data, allowHTTPConnection: false)
 		}))
 		alertController.addAction(UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.dismiss"), style: .cancel))
+		viewController.present(alertController, animated: true)
+	}
+
+	func handleInsecureConnection(for viewController: WebDAVAuthenticationViewController, viewModel: WebDAVAuthenticationViewModelProtocol) {
+		let alertController = UIAlertController(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.title"),
+		                                        message: LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.message"),
+		                                        preferredStyle: .alert)
+		let changeToHTTPSAction = UIAlertAction(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.change"), style: .default, handler: { _ in
+			self.addAccountWithTransformedURL(for: viewController, viewModel: viewModel)
+		})
+
+		alertController.addAction(changeToHTTPSAction)
+		alertController.preferredAction = changeToHTTPSAction
+		alertController.addAction(UIAlertAction(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.continue"), style: .destructive, handler: { _ in
+			viewController.addAccount(allowedCertificate: nil, allowHTTPConnection: true)
+		}))
 		viewController.present(alertController, animated: true)
 	}
 
@@ -63,5 +79,15 @@ class WebDAVAuthenticationCoordinator: NSObject, Coordinator, WebDAVAuthenticati
 	func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
 		// User has canceled the authentication by closing the modal via swipe
 		pendingAuthentication.reject(WebDAVAuthenticationError.userCanceled)
+	}
+
+	private func addAccountWithTransformedURL(for viewController: WebDAVAuthenticationViewController, viewModel: WebDAVAuthenticationViewModelProtocol) {
+		do {
+			try viewModel.transformURLToHTTPS()
+		} catch {
+			handleError(error, for: viewController)
+			return
+		}
+		viewController.addAccount(allowedCertificate: nil, allowHTTPConnection: false)
 	}
 }

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
@@ -35,15 +35,15 @@ class WebDAVAuthenticationViewController: SingleSectionStaticUITableViewControll
 	}
 
 	@objc func done() {
-		addAccount(allowedCertificate: nil)
+		addAccount(allowedCertificate: nil, allowHTTPConnection: false)
 	}
 
-	func addAccount(allowedCertificate: Data?) {
+	func addAccount(allowedCertificate: Data?, allowHTTPConnection: Bool) {
 		let credential: WebDAVCredential
 		do {
-			credential = try viewModel.createWebDAVCredentialFromInput(allowedCertificate: allowedCertificate)
+			credential = try viewModel.createWebDAVCredentialFromInput(allowedCertificate: allowedCertificate, allowHTTPConnection: allowHTTPConnection)
 		} catch {
-			coordinator?.handleError(error, for: self)
+			handleError(error)
 			return
 		}
 
@@ -77,6 +77,8 @@ class WebDAVAuthenticationViewController: SingleSectionStaticUITableViewControll
 	private func handleError(_ error: Error) {
 		if case let WebDAVAuthenticationError.untrustedCertificate(certificate: certificate, url: url) = error {
 			coordinator?.handleUntrustedCertificate(certificate, url: url, for: self, viewModel: viewModel)
+		} else if case WebDAVAuthenticationError.httpConnection = error {
+			coordinator?.handleInsecureConnection(for: self, viewModel: viewModel)
 		} else {
 			coordinator?.handleError(error, for: self)
 		}
@@ -93,7 +95,9 @@ class WebDAVAuthenticationViewModelMock: SingleSectionTableViewModel, WebDAVAuth
 		PassthroughSubject<Void, Never>().eraseToAnyPublisher()
 	}
 
-	func createWebDAVCredentialFromInput(allowedCertificate: Data?) throws -> WebDAVCredential {
+	func transformURLToHTTPS() throws {}
+
+	func createWebDAVCredentialFromInput(allowedCertificate: Data?, allowHTTPConnection: Bool) throws -> WebDAVCredential {
 		WebDAVCredential(baseURL: URL(string: ".")!, username: "", password: "", allowedCertificate: nil)
 	}
 

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -159,3 +159,9 @@
 
 "webDAVAuthentication.title" = "WebDAV";
 "webDAVAuthentication.progress" = "Authenticating…";
+
+"webDAVAuthentication.httpConnection.alert.title" = "Use HTTPS?";
+"webDAVAuthentication.httpConnection.alert.message" = "The usage of HTTP is insecure. We recommend to use HTTPS instead. If you know the risks, you can continue with HTTP.";
+"webDAVAuthentication.httpConnection.change" = "Change to HTTPS";
+"webDAVAuthentication.httpConnection.continue" = "Keep HTTP";
+


### PR DESCRIPTION
Allows the user to connect via HTTP to a WebDAV service.
The user must explicitly agree that they are aware of the risks of using an HTTP connection. In addition, the user has the option to directly change the URL scheme from HTTP to HTTPS. 
This fixes #109.