### PR TITLE
Feature: iCloud Drive as option in the `ChooseCloud` screen

### DIFF
--- a/Cryptomator/AddVault/ChooseCloudViewController.swift
+++ b/Cryptomator/AddVault/ChooseCloudViewController.swift
@@ -65,7 +65,7 @@ import SwiftUI
 
 struct ChooseCloudVCPreview: PreviewProvider {
 	static var previews: some View {
-		ChooseCloudViewController(viewModel: ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .webDAV, .localFileSystem], headerTitle: "Preview Header Title")).toPreview()
+		ChooseCloudViewController(viewModel: ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .webDAV(type: .custom), .localFileSystem(type: .iCloudDrive)], headerTitle: "Preview Header Title")).toPreview()
 	}
 }
 #endif

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
@@ -24,7 +24,7 @@ class CreateNewVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func start() {
-		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV, .localFileSystem], headerTitle: LocalizedString.getValue("addVault.createNewVault.chooseCloud.header"))
+		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .iCloudDrive), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.createNewVault.chooseCloud.header"))
 		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
 		chooseCloudVC.title = LocalizedString.getValue("addVault.createNewVault.title")
 		chooseCloudVC.coordinator = self
@@ -32,8 +32,8 @@ class CreateNewVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func showAccountList(for cloudProviderType: CloudProviderType) {
-		if cloudProviderType == .localFileSystem {
-			startLocalFileSystemAuthenticationFlow()
+		if case let CloudProviderType.localFileSystem(localFileSystemType) = cloudProviderType {
+			startLocalFileSystemAuthenticationFlow(for: localFileSystemType)
 		} else {
 			let viewModel = AccountListViewModel(with: cloudProviderType)
 			let accountListVC = AccountListViewController(with: viewModel)
@@ -71,8 +71,8 @@ class CreateNewVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 
 	// MARK: - LocalFileSystemProvider Flow
 
-	private func startLocalFileSystemAuthenticationFlow() {
-		let child = CreateNewLocalVaultCoordinator(vaultName: vaultName, navigationController: navigationController)
+	private func startLocalFileSystemAuthenticationFlow(for localFileSystemType: LocalFileSystemType) {
+		let child = CreateNewLocalVaultCoordinator(vaultName: vaultName, navigationController: navigationController, selectedLocalFileSystem: localFileSystemType)
 		childCoordinators.append(child)
 		child.parentCoordinator = self
 		child.start()

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
@@ -24,7 +24,7 @@ class CreateNewVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func start() {
-		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .iCloudDrive), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.createNewVault.chooseCloud.header"))
+		let viewModel = ChooseCloudViewModel(clouds: [.localFileSystem(type: .iCloudDrive), .dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.createNewVault.chooseCloud.header"))
 		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
 		chooseCloudVC.title = LocalizedString.getValue("addVault.createNewVault.title")
 		chooseCloudVC.coordinator = self

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewController.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultPasswordViewController.swift
@@ -69,7 +69,7 @@ import SwiftUI
 
 struct CreateNewVaultPasswordVC_Preview: PreviewProvider {
 	static var previews: some View {
-		CreateNewVaultPasswordViewController(viewModel: CreateNewVaultPasswordViewModel(vaultPath: CloudPath("/"), account: CloudProviderAccount(accountUID: "123", cloudProviderType: .webDAV), vaultUID: "456")).toPreview()
+		CreateNewVaultPasswordViewController(viewModel: CreateNewVaultPasswordViewModel(vaultPath: CloudPath("/"), account: CloudProviderAccount(accountUID: "123", cloudProviderType: .webDAV(type: .custom)), vaultUID: "456")).toPreview()
 	}
 }
 #endif

--- a/Cryptomator/AddVault/CreateNewVault/LocalVault/CreateNewLocalVaultCoordinator.swift
+++ b/Cryptomator/AddVault/CreateNewVault/LocalVault/CreateNewLocalVaultCoordinator.swift
@@ -14,14 +14,16 @@ class CreateNewLocalVaultCoordinator: LocalVaultAdding, LocalFileSystemAuthentic
 	var navigationController: UINavigationController
 	weak var parentCoordinator: CreateNewVaultCoordinator?
 	private let vaultName: String
+	private let selectedLocalFileSystem: LocalFileSystemType
 
-	init(vaultName: String, navigationController: UINavigationController) {
+	init(vaultName: String, navigationController: UINavigationController, selectedLocalFileSystem: LocalFileSystemType) {
 		self.vaultName = vaultName
+		self.selectedLocalFileSystem = selectedLocalFileSystem
 		self.navigationController = navigationController
 	}
 
 	func start() {
-		let viewModel = CreateNewLocalVaultViewModel(vaultName: vaultName)
+		let viewModel = CreateNewLocalVaultViewModel(vaultName: vaultName, selectedLocalFileSystemType: selectedLocalFileSystem)
 		let localFSAuthVC = AddLocalVaultViewController(viewModel: viewModel)
 		localFSAuthVC.coordinator = self
 		navigationController.pushViewController(localFSAuthVC, animated: true)

--- a/Cryptomator/AddVault/CreateNewVault/LocalVault/CreateNewLocalVaultViewModel.swift
+++ b/Cryptomator/AddVault/CreateNewVault/LocalVault/CreateNewLocalVaultViewModel.swift
@@ -14,11 +14,11 @@ import Promises
 class CreateNewLocalVaultViewModel: LocalFileSystemAuthenticationViewModel, LocalFileSystemVaultInstallingViewModelProtocol {
 	private let vaultName: String
 
-	init(vaultName: String, accountManager: CloudProviderAccountManager = CloudProviderAccountDBManager.shared) {
+	init(vaultName: String, selectedLocalFileSystemType: LocalFileSystemType, accountManager: CloudProviderAccountManager = CloudProviderAccountDBManager.shared) {
 		let documentPickerButtonText = LocalizedString.getValue("localFileSystemAuthentication.createNewVault.button")
 		let headerText = LocalizedString.getValue("localFileSystemAuthentication.createNewVault.header")
 		self.vaultName = vaultName
-		super.init(documentPickerButtonText: documentPickerButtonText, headerText: headerText, validationLogic: CreateNewLocalVaultValidationLogic(vaultName: vaultName), accountManager: accountManager)
+		super.init(documentPickerButtonText: documentPickerButtonText, headerText: headerText, selectedLocalFileSystemType: selectedLocalFileSystemType, validationLogic: CreateNewLocalVaultValidationLogic(vaultName: vaultName), accountManager: accountManager)
 	}
 
 	func addVault(for credential: LocalFileSystemCredential) -> Promise<LocalFileSystemAuthenticationResult> {

--- a/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewController.swift
+++ b/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewController.swift
@@ -31,6 +31,7 @@ class LocalFileSystemAuthenticationViewController: SingleSectionStaticUITableVie
 		}
 		documentPicker.allowsMultipleSelection = false
 		documentPicker.delegate = self
+		documentPicker.directoryURL = viewModel.documentPickerStartDirectoryURL
 		present(documentPicker, animated: true)
 	}
 

--- a/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewModel.swift
+++ b/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewModel.swift
@@ -39,8 +39,8 @@ class LocalFileSystemAuthenticationViewModel: SingleSectionTableViewModel, Local
 		}
 	}
 
-	public static let iCloudDriveRootDirectory = URL(fileURLWithPath: "\(iCloudDrivePrefix)/com~apple~CloudDocs/")
-	private static let iCloudDrivePrefix = "/private/var/mobile/Library/Mobile Documents"
+	public static let iCloudDriveRootDirectory = URL(fileURLWithPath: "\(iCloudDrivePrefix)com~apple~CloudDocs/")
+	private static let iCloudDrivePrefix = "/private/var/mobile/Library/Mobile Documents/"
 	let documentPickerButtonText: String
 	let headerText: String
 	lazy var openDocumentPickerCellViewModel = ButtonCellViewModel(action: "openDocumentPicker", title: documentPickerButtonText)

--- a/Cryptomator/AddVault/OpenExistingVault/LocalVault/OpenExistingLocalVaultCoordinator.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/LocalVault/OpenExistingLocalVaultCoordinator.swift
@@ -6,19 +6,22 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import CryptomatorCommonCore
 import UIKit
 
 class OpenExistingLocalVaultCoordinator: LocalVaultAdding, LocalFileSystemAuthenticating, Coordinator {
 	var childCoordinators = [Coordinator]()
 	var navigationController: UINavigationController
 	weak var parentCoordinator: OpenExistingVaultCoordinator?
+	private let selectedLocalFileSystem: LocalFileSystemType
 
-	init(navigationController: UINavigationController) {
+	init(navigationController: UINavigationController, selectedLocalFileSystem: LocalFileSystemType) {
 		self.navigationController = navigationController
+		self.selectedLocalFileSystem = selectedLocalFileSystem
 	}
 
 	func start() {
-		let viewModel = OpenExistingLocalVaultViewModel()
+		let viewModel = OpenExistingLocalVaultViewModel(selectedLocalFileSystemType: selectedLocalFileSystem)
 		let localFSAuthVC = AddLocalVaultViewController(viewModel: viewModel)
 		localFSAuthVC.coordinator = self
 		navigationController.pushViewController(localFSAuthVC, animated: true)

--- a/Cryptomator/AddVault/OpenExistingVault/LocalVault/OpenExistingLocalVaultViewModel.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/LocalVault/OpenExistingLocalVaultViewModel.swift
@@ -13,11 +13,11 @@ import Promises
 
 class OpenExistingLocalVaultViewModel: LocalFileSystemAuthenticationViewModel, LocalFileSystemVaultInstallingViewModelProtocol {
 	private let validator: OpenExistingLocalVaultValidationLogic
-	init(accountManager: CloudProviderAccountManager = CloudProviderAccountDBManager.shared) {
+	init(selectedLocalFileSystemType: LocalFileSystemType, accountManager: CloudProviderAccountManager = CloudProviderAccountDBManager.shared) {
 		let documentPickerButtonText = LocalizedString.getValue("localFileSystemAuthentication.openExistingVault.button")
 		let headerText = LocalizedString.getValue("localFileSystemAuthentication.openExistingVault.header")
 		self.validator = OpenExistingLocalVaultValidationLogic()
-		super.init(documentPickerButtonText: documentPickerButtonText, headerText: headerText, validationLogic: validator, accountManager: accountManager)
+		super.init(documentPickerButtonText: documentPickerButtonText, headerText: headerText, selectedLocalFileSystemType: selectedLocalFileSystemType, validationLogic: validator, accountManager: accountManager)
 	}
 
 	func addVault(for credential: LocalFileSystemCredential) -> Promise<LocalFileSystemAuthenticationResult> {

--- a/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
@@ -22,7 +22,7 @@ class OpenExistingVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func start() {
-		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV, .localFileSystem], headerTitle: LocalizedString.getValue("addVault.openExistingVault.chooseCloud.header"))
+		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .iCloudDrive), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.openExistingVault.chooseCloud.header"))
 		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
 		chooseCloudVC.title = LocalizedString.getValue("addVault.openExistingVault.title")
 		chooseCloudVC.coordinator = self
@@ -30,8 +30,8 @@ class OpenExistingVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func showAccountList(for cloudProviderType: CloudProviderType) {
-		if cloudProviderType == .localFileSystem {
-			startLocalFileSystemAuthenticationFlow()
+		if case let CloudProviderType.localFileSystem(localFileSystemType) = cloudProviderType {
+			startLocalFileSystemAuthenticationFlow(for: localFileSystemType)
 		} else {
 			let viewModel = AccountListViewModel(with: cloudProviderType)
 			let accountListVC = AccountListViewController(with: viewModel)
@@ -69,8 +69,8 @@ class OpenExistingVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 
 	// MARK: - LocalFileSystemProvider Flow
 
-	private func startLocalFileSystemAuthenticationFlow() {
-		let child = OpenExistingLocalVaultCoordinator(navigationController: navigationController)
+	private func startLocalFileSystemAuthenticationFlow(for localFileSystemType: LocalFileSystemType) {
+		let child = OpenExistingLocalVaultCoordinator(navigationController: navigationController, selectedLocalFileSystem: localFileSystemType)
 		childCoordinators.append(child)
 		child.parentCoordinator = self
 		child.start()

--- a/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
@@ -22,7 +22,7 @@ class OpenExistingVaultCoordinator: AccountListing, CloudChoosing, Coordinator {
 	}
 
 	func start() {
-		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .iCloudDrive), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.openExistingVault.chooseCloud.header"))
+		let viewModel = ChooseCloudViewModel(clouds: [.localFileSystem(type: .iCloudDrive), .dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom), .localFileSystem(type: .custom)], headerTitle: LocalizedString.getValue("addVault.openExistingVault.chooseCloud.header"))
 		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
 		chooseCloudVC.title = LocalizedString.getValue("addVault.openExistingVault.title")
 		chooseCloudVC.coordinator = self

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -46,7 +46,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Clean up
 		_ = VaultDBManager.shared.removeAllUnusedFileProviderDomains()
 		do {
-			let webDAVAccountUIDs = try CloudProviderAccountDBManager.shared.getAllAccountUIDs(for: .webDAV)
+			let webDAVAccountUIDs = try CloudProviderAccountDBManager.shared.getAllAccountUIDs(for: .webDAV(type: .custom))
 			try WebDAVAuthenticator.removeUnusedWebDAVCredentials(existingAccountUIDs: webDAVAccountUIDs)
 		} catch {
 			DDLogError("Clean up unused WebDAV Credentials failed with error: \(error)")

--- a/Cryptomator/Common/CloudAuthenticator.swift
+++ b/Cryptomator/Common/CloudAuthenticator.swift
@@ -50,7 +50,7 @@ class CloudAuthenticator {
 
 	func authenticateWebDAV(from viewController: UIViewController) -> Promise<CloudProviderAccount> {
 		return WebDAVAuthenticator.authenticate(from: viewController).then { credential -> CloudProviderAccount in
-			let account = CloudProviderAccount(accountUID: credential.identifier, cloudProviderType: .webDAV)
+			let account = CloudProviderAccount(accountUID: credential.identifier, cloudProviderType: .webDAV(type: .custom))
 			try self.accountManager.saveNewAccount(account)
 			return account
 		}

--- a/Cryptomator/Common/CloudProviderType+Localization.swift
+++ b/Cryptomator/Common/CloudProviderType+Localization.swift
@@ -20,8 +20,19 @@ extension CloudProviderType {
 			return "OneDrive"
 		case .webDAV:
 			return "WebDAV"
-		case .localFileSystem:
+		case let .localFileSystem(localFileSystemType):
+			return localFileSystemType.localizedString()
+		}
+	}
+}
+
+extension LocalFileSystemType {
+	func localizedString() -> String {
+		switch self {
+		case .custom:
 			return LocalizedString.getValue("cloudProviderType.localFileSystem")
+		case .iCloudDrive:
+			return "iCloud Drive"
 		}
 	}
 }

--- a/Cryptomator/Common/UIImage+CloudProviderType.swift
+++ b/Cryptomator/Common/UIImage+CloudProviderType.swift
@@ -26,13 +26,22 @@ extension UIImage {
 			assetName = "onedrive-vault"
 		case .webDAV:
 			assetName = "webdav-vault"
-		case .localFileSystem:
-			assetName = "file-provider-vault"
+		case let .localFileSystem(localFileSystemType):
+			assetName = UIImage.getVaultIcon(for: localFileSystemType)
 		}
 		if state == .highlighted {
 			assetName += "-selected"
 		}
 		self.init(named: assetName)
+	}
+
+	private static func getVaultIcon(for type: LocalFileSystemType) -> String {
+		switch type {
+		case .custom:
+			return "file-provider-vault"
+		case .iCloudDrive:
+			return "icloud-drive-vault"
+		}
 	}
 
 	convenience init?(storageIconFor cloudProviderType: CloudProviderType) {
@@ -44,11 +53,20 @@ extension UIImage {
 			assetName = "google-drive"
 		case .oneDrive:
 			assetName = "onedrive"
-		case .localFileSystem:
-			assetName = "file-provider"
+		case let .localFileSystem(localFileSystemType):
+			assetName = UIImage.getStorageIcon(for: localFileSystemType)
 		case .webDAV:
 			assetName = "webdav"
 		}
 		self.init(named: assetName)
+	}
+
+	private static func getStorageIcon(for type: LocalFileSystemType) -> String {
+		switch type {
+		case .custom:
+			return "file-provider"
+		case .iCloudDrive:
+			return "icloud-drive"
+		}
 	}
 }

--- a/Cryptomator/Settings/SettingsCoordinator.swift
+++ b/Cryptomator/Settings/SettingsCoordinator.swift
@@ -48,7 +48,7 @@ class SettingsCoordinator: Coordinator {
 	}
 
 	func showCloudServices() {
-		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV], headerTitle: "")
+		let viewModel = ChooseCloudViewModel(clouds: [.dropbox, .googleDrive, .oneDrive, .webDAV(type: .custom)], headerTitle: "")
 		let chooseCloudVC = ChooseCloudViewController(viewModel: viewModel)
 		chooseCloudVC.title = LocalizedString.getValue("settings.cloudServices")
 		chooseCloudVC.coordinator = self

--- a/Cryptomator/VaultDetail/MoveVault/MoveVaultViewModel.swift
+++ b/Cryptomator/VaultDetail/MoveVault/MoveVaultViewModel.swift
@@ -83,7 +83,7 @@ class MoveVaultViewModel: ChooseFolderViewModel, MoveVaultViewModelProtocol {
 		if vaultInfo.vaultPath == CloudPath("/") {
 			return false
 		}
-		if vaultInfo.cloudProviderType == .localFileSystem {
+		if case CloudProviderType.localFileSystem = vaultInfo.cloudProviderType {
 			return false
 		}
 		return true

--- a/Cryptomator/VaultDetail/VaultDetailViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewModel.swift
@@ -264,6 +264,9 @@ class VaultDetailViewModel: VaultDetailViewModelProtocol {
 	}
 
 	private func vaultIsEligibleToMove() -> Bool {
-		return vaultInfo.cloudProviderType != .localFileSystem && vaultInfo.vaultPath != CloudPath("/")
+		if case CloudProviderType.localFileSystem = vaultInfo.cloudProviderType {
+			return false
+		}
+		return vaultInfo.vaultPath != CloudPath("/")
 	}
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderAccountDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderAccountDBManager.swift
@@ -29,8 +29,6 @@ extension CloudProviderAccount: PersistableRecord {
 	}
 }
 
-extension CloudProviderType: DatabaseValueConvertible {}
-
 public enum CloudProviderAccountError: Error {
 	case accountNotFoundError
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderType.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderType.swift
@@ -7,11 +7,39 @@
 //
 
 import Foundation
+import GRDB
 
-public enum CloudProviderType: String, Codable {
+public enum CloudProviderType: Codable, Equatable, Hashable {
 	case googleDrive
 	case dropbox
 	case oneDrive
-	case webDAV
-	case localFileSystem
+	case webDAV(type: WebDAVType)
+	case localFileSystem(type: LocalFileSystemType)
+}
+
+extension CloudProviderType: DatabaseValueConvertible {
+	public var databaseValue: DatabaseValue {
+		let jsonEncoder = JSONEncoder()
+		guard let data = try? jsonEncoder.encode(self) else {
+			return .null
+		}
+		let string = String(data: data, encoding: .utf8)
+		return string?.databaseValue ?? .null
+	}
+
+	public static func fromDatabaseValue(_ dbValue: DatabaseValue) -> Self? {
+		guard let string = String.fromDatabaseValue(dbValue) else { return nil }
+		guard let data = string.data(using: .utf8) else { return nil }
+		let jsonDecoder = JSONDecoder()
+		return try? jsonDecoder.decode(CloudProviderType.self, from: data)
+	}
+}
+
+public enum LocalFileSystemType: Codable {
+	case custom
+	case iCloudDrive
+}
+
+public enum WebDAVType: Codable {
+	case custom
 }

--- a/CryptomatorTests/AddLocalVault/CreateNewLocalVaultViewModelTests.swift
+++ b/CryptomatorTests/AddLocalVault/CreateNewLocalVaultViewModelTests.swift
@@ -14,12 +14,12 @@ import XCTest
 class CreateNewLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 	func testAddVault() throws {
 		let expectation = XCTestExpectation()
-		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", accountManager: accountManagerMock)
+		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", selectedLocalFileSystemType: .custom, accountManager: accountManagerMock)
 		let credential = LocalFileSystemCredential(rootURL: tmpDirURL, identifier: UUID().uuidString)
 		viewModel.addVault(for: credential).then { result in
 			XCTAssertEqual(credential, result.credential)
 			XCTAssertEqual(credential.identifier, result.account.accountUID)
-			XCTAssertEqual(CloudProviderType.localFileSystem, result.account.cloudProviderType)
+			XCTAssertEqual(CloudProviderType.localFileSystem(type: .custom), result.account.cloudProviderType)
 
 			guard let chosenFolder = result.item as? Folder else {
 				XCTFail("result item is not a Folder")
@@ -39,7 +39,7 @@ class CreateNewLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 
 	func testAddVaultWithNameCollision() throws {
 		let expectation = XCTestExpectation()
-		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", accountManager: accountManagerMock)
+		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", selectedLocalFileSystemType: .custom, accountManager: accountManagerMock)
 		try FileManager.default.createDirectory(at: tmpDirURL.appendingPathComponent("MyVault"), withIntermediateDirectories: false)
 		let credential = LocalFileSystemCredential(rootURL: tmpDirURL, identifier: UUID().uuidString)
 		viewModel.addVault(for: credential).then { _ in
@@ -58,7 +58,7 @@ class CreateNewLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 
 	func testAddVaultWithExistingVaultAtChosenURL() throws {
 		let expectation = XCTestExpectation()
-		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", accountManager: accountManagerMock)
+		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", selectedLocalFileSystemType: .custom, accountManager: accountManagerMock)
 		try createVault(at: tmpDirURL)
 		let credential = LocalFileSystemCredential(rootURL: tmpDirURL, identifier: UUID().uuidString)
 		viewModel.addVault(for: credential).then { _ in
@@ -77,7 +77,7 @@ class CreateNewLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 
 	func testAddVaultWithExistingLegacyVaultAtChosenURL() throws {
 		let expectation = XCTestExpectation()
-		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", accountManager: accountManagerMock)
+		let viewModel = CreateNewLocalVaultViewModel(vaultName: "MyVault", selectedLocalFileSystemType: .custom, accountManager: accountManagerMock)
 		try createLegacyVault(at: tmpDirURL)
 		let credential = LocalFileSystemCredential(rootURL: tmpDirURL, identifier: UUID().uuidString)
 		viewModel.addVault(for: credential).then { _ in

--- a/CryptomatorTests/AddLocalVault/OpenExistingLocalVaultViewModelTests.swift
+++ b/CryptomatorTests/AddLocalVault/OpenExistingLocalVaultViewModelTests.swift
@@ -16,7 +16,7 @@ class OpenExistingLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 
 	override func setUpWithError() throws {
 		try super.setUpWithError()
-		viewModel = OpenExistingLocalVaultViewModel(accountManager: accountManagerMock)
+		viewModel = OpenExistingLocalVaultViewModel(selectedLocalFileSystemType: .custom, accountManager: accountManagerMock)
 	}
 
 	func testAddVault() throws {
@@ -28,7 +28,7 @@ class OpenExistingLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 		viewModel.addVault(for: credential).then { result in
 			XCTAssertEqual(credential, result.credential)
 			XCTAssertEqual(credential.identifier, result.account.accountUID)
-			XCTAssertEqual(CloudProviderType.localFileSystem, result.account.cloudProviderType)
+			XCTAssertEqual(CloudProviderType.localFileSystem(type: .custom), result.account.cloudProviderType)
 
 			guard let vaultDetailItem = result.item as? VaultDetailItem else {
 				XCTFail("result item is not a VaultDetailItem")
@@ -57,7 +57,7 @@ class OpenExistingLocalVaultViewModelTests: AddLocalVaultViewModelTestCase {
 		viewModel.addVault(for: credential).then { result in
 			XCTAssertEqual(credential, result.credential)
 			XCTAssertEqual(credential.identifier, result.account.accountUID)
-			XCTAssertEqual(CloudProviderType.localFileSystem, result.account.cloudProviderType)
+			XCTAssertEqual(CloudProviderType.localFileSystem(type: .custom), result.account.cloudProviderType)
 
 			guard let vaultDetailItem = result.item as? VaultDetailItem else {
 				XCTFail("result item is not a VaultDetailItem")

--- a/CryptomatorTests/CreateNewVaultPasswordViewModelTests.swift
+++ b/CryptomatorTests/CreateNewVaultPasswordViewModelTests.swift
@@ -16,7 +16,7 @@ class CreateNewVaultPasswordViewModelTests: XCTestCase {
 	private var vaultManagerMock: PasswordVaultManagerMock!
 	private var viewModel: CreateNewVaultPasswordViewModel!
 	private let vaultPath = CloudPath("/Vault")
-	private let account = CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV)
+	private let account = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 	private let vaultUID = "12345"
 
 	override func setUpWithError() throws {

--- a/CryptomatorTests/DatabaseManagerTests.swift
+++ b/CryptomatorTests/DatabaseManagerTests.swift
@@ -39,7 +39,7 @@ class DatabaseManagerTests: XCTestCase {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 		let vaultAccountManager = VaultAccountDBManager(dbPool: dbPool)
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV)
+		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
 		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
 		try vaultAccountManager.saveNewAccount(vaultAccount)
@@ -65,7 +65,7 @@ class DatabaseManagerTests: XCTestCase {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 		let vaultAccountManager = VaultAccountDBManager(dbPool: dbPool)
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV)
+		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
 		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
 		try vaultAccountManager.saveNewAccount(vaultAccount)
@@ -100,7 +100,7 @@ class DatabaseManagerTests: XCTestCase {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 		let vaultAccountManager = VaultAccountDBManager(dbPool: dbPool)
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV)
+		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
 		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
 		try vaultAccountManager.saveNewAccount(vaultAccount)
@@ -132,31 +132,31 @@ class DatabaseManagerTests: XCTestCase {
 	func testCreateAccountListPositionTrigger() throws {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
 		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
 
 		let firstWebDAVAccountListPosition = try dbPool.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount" && Column("cloudProviderType") == "webDAV").fetchOne(db)
+			try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
 		}
 		XCTAssertNotNil(firstWebDAVAccountListPosition)
 		XCTAssertEqual(0, firstWebDAVAccountListPosition?.position)
 		XCTAssertEqual(1, firstWebDAVAccountListPosition?.id)
 
 		let secondWebDAVAccountListPosition = try dbPool.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount" && Column("cloudProviderType") == "webDAV").fetchOne(db)
+			try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
 		}
 		XCTAssertNotNil(secondWebDAVAccountListPosition)
 		XCTAssertEqual(1, secondWebDAVAccountListPosition?.position)
 		XCTAssertEqual(2, secondWebDAVAccountListPosition?.id)
 
 		let firstDropboxAccountListPosition = try dbPool.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount" && Column("cloudProviderType") == "dropbox").fetchOne(db)
+			try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.dropbox).fetchOne(db)
 		}
 		XCTAssertNotNil(firstDropboxAccountListPosition)
 		XCTAssertEqual(0, firstDropboxAccountListPosition?.position)
@@ -166,13 +166,13 @@ class DatabaseManagerTests: XCTestCase {
 	func testDeleteCloudProviderAccountUpdatesPositions() throws {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
 
 		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
@@ -209,16 +209,16 @@ class DatabaseManagerTests: XCTestCase {
 	func testUpdateAccountListPositions() throws {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
 
-		let accounts = try dbManager.getAllAccounts(for: .webDAV)
+		let accounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
 
 		XCTAssertEqual(3, accounts.count)
 
@@ -230,7 +230,7 @@ class DatabaseManagerTests: XCTestCase {
 		}
 		try dbManager.updateAccountListPositions(updatedAccountListPositions)
 
-		let updatedAccounts = try dbManager.getAllAccounts(for: .webDAV)
+		let updatedAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
 		let fetchedAccountListPositions = updatedAccounts.map { $0.accountListPosition }
 
 		let sortedUpdatedAccountListPositions = updatedAccountListPositions.sorted { $0.position! < $1.position! }
@@ -241,19 +241,19 @@ class DatabaseManagerTests: XCTestCase {
 	func testGetAllAccountsIsFiltered() throws {
 		let cloudAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV)
+		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
 
 		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
 
-		let webDAVAccounts = try dbManager.getAllAccounts(for: .webDAV)
+		let webDAVAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
 
 		let expectedWebDAVAccountListPositions = [AccountListPosition(id: 1, position: 0, accountUID: firstWebdavCloudProviderAccount.accountUID),
 		                                          AccountListPosition(id: 2, position: 1, accountUID: secondWebdavCloudProviderAccount.accountUID),

--- a/CryptomatorTests/MoveVaultViewModelTests.swift
+++ b/CryptomatorTests/MoveVaultViewModelTests.swift
@@ -28,7 +28,7 @@ class MoveVaultViewModelTests: XCTestCase {
 		fileProviderConnectorMock = FileProviderConnectorMock()
 		cloudProviderMock = CloudProviderMock()
 		vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 	}
 
 	func testMoveVault() throws {
@@ -58,7 +58,7 @@ class MoveVaultViewModelTests: XCTestCase {
 	func testRejectVaultsInTheLocalFileSystem() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .localFileSystem)
+		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
 		viewModel.moveVault(to: CloudPath("Baz")).then {
 			XCTFail("Promise fulfilled")
 		}.catch { error in
@@ -78,7 +78,7 @@ class MoveVaultViewModelTests: XCTestCase {
 	func testRejectMoveRootVault() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Foo")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		viewModel.moveVault(to: CloudPath("/Bar")).then {
 			XCTFail("Promise fulfilled")
 		}.catch { error in
@@ -139,7 +139,7 @@ class MoveVaultViewModelTests: XCTestCase {
 	func testDisableMaintenanceModeAfterVaultMoveFailure() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
 
@@ -167,15 +167,15 @@ class MoveVaultViewModelTests: XCTestCase {
 	}
 
 	func testIsAllowedToMove() throws {
-		let moveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Test"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let moveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Test"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		XCTAssert(moveVaultViewModel.isAllowedToMove())
 
 		// allowed to move for root path
-		let rootMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let rootMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		XCTAssert(rootMoveVaultViewModel.isAllowedToMove())
 
 		// not allowed to move for same location
-		let sameLocationMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Foo"), vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let sameLocationMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Foo"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		XCTAssertFalse(sameLocationMoveVaultViewModel.isAllowedToMove())
 	}
 

--- a/CryptomatorTests/RenameVaultViewModelTests.swift
+++ b/CryptomatorTests/RenameVaultViewModelTests.swift
@@ -24,13 +24,13 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 		vaultManagerMock = VaultManagerMock()
 		fileProviderConnectorMock = FileProviderConnectorMock()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 	}
 
 	func testRejectsVaultsInTheLocalFileSystem() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .localFileSystem)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
 
 		let newVaultName = "Baz"
 		setVaultName(newVaultName, viewModel: viewModel)
@@ -52,7 +52,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	func testRejectsRootVault() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
 		let newVaultName = "Baz"
 		setVaultName(newVaultName, viewModel: viewModel)
@@ -75,7 +75,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 		let expectation = XCTestExpectation()
 		let oldVaultName = "Bar"
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: oldVaultName)
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
 
@@ -104,7 +104,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	func testRenameVaultWithOldNameAsSubstring() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
 
@@ -131,7 +131,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	func testRenameVaultWithSameName() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
 
@@ -152,7 +152,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	func testEnableMaintenanceModeFailed() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
 		let newVaultName = "Baz"
 		setVaultName(newVaultName, viewModel: viewModel)
@@ -178,7 +178,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	func testDisableMaintenanceModeAfterVaultMoveFailure() throws {
 		let expectation = XCTestExpectation()
 		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .webDAV)
+		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
 

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -107,7 +107,7 @@ class VaultListViewModelTests: XCTestCase {
 		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		let vaultInfo = VaultInfo(vaultAccount: VaultAccount(vaultUID: "vault1", delegateAccountUID: "1", vaultPath: CloudPath("/vault1"), vaultName: "vault1"),
-		                          cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV),
+		                          cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox),
 		                          vaultListPosition: VaultListPosition(position: 1, vaultUID: "vault1"))
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
@@ -167,10 +167,10 @@ extension VaultListViewModel {
 private class DatabaseManagerMock: DatabaseManager {
 	var updatedPositions = [VaultListPosition]()
 	let vaults = [VaultInfo(vaultAccount: VaultAccount(vaultUID: "vault1", delegateAccountUID: "1", vaultPath: CloudPath("/vault1"), vaultName: "vault1"),
-	                        cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV),
+	                        cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox),
 	                        vaultListPosition: VaultListPosition(position: 1, vaultUID: "vault1")),
 	              VaultInfo(vaultAccount: VaultAccount(vaultUID: "vault2", delegateAccountUID: "1", vaultPath: CloudPath("/vault1"), vaultName: "vautlt1"),
-	                        cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .webDAV),
+	                        cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox),
 	                        vaultListPosition: VaultListPosition(position: 0, vaultUID: "vault2"))]
 
 	override func getAllVaults() throws -> [VaultInfo] {


### PR DESCRIPTION
This PR adds the option for iCloud Drive to the `ChooseCloud` screen and thus fixes #40.

The `CloudProviderType` now has underlying Types for WebDAV and LocalFileSystem, which refines the respective `CloudProviderType` (e.g. in `custom` and `iCloudDrive`) and thus enables further presets for the `ChooseCloud` screen.
This change to the `CloudProviderType` requires a migration of the existing database.
We did not nuke the database via GRDB this time, because this has the disadvantage that users of early TestFlight versions may have problems installing the release version.
For the TestFlight versions before the initial App Store release we did not migrate the database.
However, since we only nuke the database for TestFlight versions when making schema changes, this can lead to an incorrect DB schema.
Therefore, a new path for the `CryptomatorDatabase` is used and the old database, if existing, will be deleted.

In addition, nuking the database on database schema changes has now been removed completely, as this was only useful for versions before the initial App Store release.