### PR TITLE
Feature: Added support for fastlane snapshot

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		4A0C07E225AC80C100B83211 /* UIView+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C07E125AC80C100B83211 /* UIView+Preview.swift */; };
 		4A0C07EB25AC832900B83211 /* VaultListPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0C07EA25AC832900B83211 /* VaultListPosition.swift */; };
 		4A123EA824BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A123EA724BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift */; };
+		4A136124276767D60077EB7F /* Snapshots.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A136123276767D60077EB7F /* Snapshots.swift */; };
+		4A13612D276768000077EB7F /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A13612C276768000077EB7F /* SnapshotHelper.swift */; };
+		4A13612F27676F5C0077EB7F /* SnapshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A13612E27676F5C0077EB7F /* SnapshotCoordinator.swift */; };
+		4A136132276770BB0077EB7F /* SnapshotVaultListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A136131276770BB0077EB7F /* SnapshotVaultListViewModel.swift */; };
 		4A1673E1270C43AF0075C724 /* LoadingWithLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E0270C43AF0075C724 /* LoadingWithLabelCell.swift */; };
 		4A1673E3270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E2270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift */; };
 		4A1673E6270C652A0075C724 /* FileProviderCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E4270C5E6C0075C724 /* FileProviderCacheManager.swift */; };
@@ -177,6 +181,10 @@
 		4A7B97E525B6F86E0044B7FB /* AccountListPosition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7B97E425B6F86E0044B7FB /* AccountListPosition.swift */; };
 		4A7BC0E025ADF12D00F007B3 /* AddVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BC0DF25ADF12D00F007B3 /* AddVaultViewController.swift */; };
 		4A7BC0F125ADFAD600F007B3 /* AddVaultCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7BC0F025ADFAD600F007B3 /* AddVaultCoordinator.swift */; };
+		4A80407B2769201400D7D999 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 742679F926A56B33004C61BC /* Localizable.strings */; };
+		4A80407D27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A80407C27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift */; };
+		4A80408027694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A80407F27694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift */; };
+		4A804082276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A804081276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift */; };
 		4A88816427440CE300F7AA6E /* BaseUITableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A88816327440CE300F7AA6E /* BaseUITableViewController.swift */; };
 		4A8D05D625C5CBE10082C5F7 /* AddVaultSuccessViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8D05D525C5CBE10082C5F7 /* AddVaultSuccessViewController.swift */; };
 		4A8D060525C82F1F0082C5F7 /* AddVaultSuccesing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A8D060425C82F1F0082C5F7 /* AddVaultSuccesing.swift */; };
@@ -326,6 +334,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		4A136127276767D60077EB7F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 4A5E5B212453119100BD6298 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4AE97DA724572E4900452814;
+			remoteInfo = Cryptomator;
+		};
 		4A1673EE270DE4600075C724 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 4A5E5B212453119100BD6298 /* Project object */;
@@ -431,6 +446,11 @@
 		4A0C07E125AC80C100B83211 /* UIView+Preview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Preview.swift"; sourceTree = "<group>"; };
 		4A0C07EA25AC832900B83211 /* VaultListPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultListPosition.swift; sourceTree = "<group>"; };
 		4A123EA724BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudProviderPaginationMock.swift; sourceTree = "<group>"; };
+		4A136121276767D60077EB7F /* Snapshots.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Snapshots.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4A136123276767D60077EB7F /* Snapshots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Snapshots.swift; sourceTree = "<group>"; };
+		4A13612C276768000077EB7F /* SnapshotHelper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SnapshotHelper.swift; sourceTree = "<group>"; };
+		4A13612E27676F5C0077EB7F /* SnapshotCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotCoordinator.swift; sourceTree = "<group>"; };
+		4A136131276770BB0077EB7F /* SnapshotVaultListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SnapshotVaultListViewModel.swift; sourceTree = "<group>"; };
 		4A1673E0270C43AF0075C724 /* LoadingWithLabelCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingWithLabelCell.swift; sourceTree = "<group>"; };
 		4A1673E2270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingWithLabelCellViewModel.swift; sourceTree = "<group>"; };
 		4A1673E4270C5E6C0075C724 /* FileProviderCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderCacheManager.swift; sourceTree = "<group>"; };
@@ -590,6 +610,9 @@
 		4A7B97E425B6F86E0044B7FB /* AccountListPosition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListPosition.swift; sourceTree = "<group>"; };
 		4A7BC0DF25ADF12D00F007B3 /* AddVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddVaultViewController.swift; sourceTree = "<group>"; };
 		4A7BC0F025ADFAD600F007B3 /* AddVaultCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddVaultCoordinator.swift; sourceTree = "<group>"; };
+		4A80407C27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumeratorSnapshotMock.swift; sourceTree = "<group>"; };
+		4A80407F27694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockingServiceSourceSnapshotMock.swift; sourceTree = "<group>"; };
+		4A804081276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderCoordinatorSnapshotMock.swift; sourceTree = "<group>"; };
 		4A88816327440CE300F7AA6E /* BaseUITableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseUITableViewController.swift; sourceTree = "<group>"; };
 		4A8D05D525C5CBE10082C5F7 /* AddVaultSuccessViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddVaultSuccessViewController.swift; sourceTree = "<group>"; };
 		4A8D060425C82F1F0082C5F7 /* AddVaultSuccesing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddVaultSuccesing.swift; sourceTree = "<group>"; };
@@ -767,6 +790,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		4A13611E276767D60077EB7F /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A2245CD24A5E16300DBA437 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -833,6 +863,24 @@
 				4ADBD35727284BAB00B19B5C /* MoveVaultViewController.swift */,
 			);
 			path = MoveVault;
+			sourceTree = "<group>";
+		};
+		4A136122276767D60077EB7F /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				4A13612C276768000077EB7F /* SnapshotHelper.swift */,
+				4A136123276767D60077EB7F /* Snapshots.swift */,
+			);
+			path = Snapshots;
+			sourceTree = "<group>";
+		};
+		4A13613027676F610077EB7F /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				4A13612E27676F5C0077EB7F /* SnapshotCoordinator.swift */,
+				4A136131276770BB0077EB7F /* SnapshotVaultListViewModel.swift */,
+			);
+			path = Snapshots;
 			sourceTree = "<group>";
 		};
 		4A1C6D5B274D225A00B41FFF /* Purchase */ = {
@@ -1012,6 +1060,7 @@
 				4AE97DC024572E4A00452814 /* CryptomatorTests */,
 				4AA621D7249A6A8400A0BCBD /* FileProviderExtension */,
 				4AA621E5249A6A8400A0BCBD /* FileProviderExtensionUI */,
+				4A136122276767D60077EB7F /* Snapshots */,
 				4A828287252617D600A4EAD4 /* Frameworks */,
 				4A5E5B2A2453119100BD6298 /* Products */,
 				74D365BC268B965B005ECD69 /* SharedResources */,
@@ -1029,6 +1078,7 @@
 				4A2245D024A5E16300DBA437 /* CryptomatorFileProviderTests.xctest */,
 				740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */,
 				4A51E5FC261C9A7000CC8C9B /* CryptomatorCommonHostedTests.xctest */,
+				4A136121276767D60077EB7F /* Snapshots.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1104,6 +1154,23 @@
 				4AA8613F25C1AC4D002A59F5 /* OpenExistingVault */,
 			);
 			path = AddVault;
+			sourceTree = "<group>";
+		};
+		4A80407E27692A0900D7D999 /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				4A80407C27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift */,
+				4A80407F27694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift */,
+			);
+			path = Snapshots;
+			sourceTree = "<group>";
+		};
+		4A804083276952C600D7D999 /* Snapshots */ = {
+			isa = PBXGroup;
+			children = (
+				4A804081276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift */,
+			);
+			path = Snapshots;
 			sourceTree = "<group>";
 		};
 		4A8195DB25ADB8AD00F7DDA1 /* VaultList */ = {
@@ -1251,6 +1318,7 @@
 				4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */,
 				4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */,
 				4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */,
+				4A80407E27692A0900D7D999 /* Snapshots */,
 			);
 			path = FileProviderExtension;
 			sourceTree = "<group>";
@@ -1265,6 +1333,7 @@
 				4A6A520C268B5EF7006F7368 /* RootViewController.swift */,
 				4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */,
 				4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */,
+				4A804083276952C600D7D999 /* Snapshots */,
 			);
 			path = FileProviderExtensionUI;
 			sourceTree = "<group>";
@@ -1339,6 +1408,7 @@
 				4A4B7E4026B2ABC4009BFDB1 /* VaultDetail */,
 				4A8195DB25ADB8AD00F7DDA1 /* VaultList */,
 				4AA22C08261CA71300A17486 /* WebDAV */,
+				4A13613027676F610077EB7F /* Snapshots */,
 			);
 			path = Cryptomator;
 			sourceTree = "<group>";
@@ -1560,6 +1630,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		4A136120276767D60077EB7F /* Snapshots */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4A13612B276767D60077EB7F /* Build configuration list for PBXNativeTarget "Snapshots" */;
+			buildPhases = (
+				4A13611D276767D60077EB7F /* Sources */,
+				4A13611E276767D60077EB7F /* Frameworks */,
+				4A13611F276767D60077EB7F /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				4A136128276767D60077EB7F /* PBXTargetDependency */,
+			);
+			name = Snapshots;
+			packageProductDependencies = (
+			);
+			productName = Snapshots;
+			productReference = 4A136121276767D60077EB7F /* Snapshots.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
 		4A2245CF24A5E16300DBA437 /* CryptomatorFileProviderTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 4A2245D824A5E16300DBA437 /* Build configuration list for PBXNativeTarget "CryptomatorFileProviderTests" */;
@@ -1706,10 +1796,14 @@
 		4A5E5B212453119100BD6298 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1240;
+				LastSwiftUpdateCheck = 1310;
 				LastUpgradeCheck = 1250;
 				ORGANIZATIONNAME = "Skymatic GmbH";
 				TargetAttributes = {
+					4A136120276767D60077EB7F = {
+						CreatedOnToolsVersion = 13.1;
+						TestTargetID = 4AE97DA724572E4900452814;
+					};
 					4A2245CF24A5E16300DBA437 = {
 						CreatedOnToolsVersion = 11.5;
 					};
@@ -1777,11 +1871,19 @@
 				4AA621E3249A6A8400A0BCBD /* FileProviderExtensionUI */,
 				740375D62587AE7A0023FF53 /* CryptomatorFileProvider */,
 				4A2245CF24A5E16300DBA437 /* CryptomatorFileProviderTests */,
+				4A136120276767D60077EB7F /* Snapshots */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		4A13611F276767D60077EB7F /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A2245CE24A5E16300DBA437 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1800,6 +1902,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A80407B2769201400D7D999 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1917,6 +2020,15 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4A13611D276767D60077EB7F /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4A136124276767D60077EB7F /* Snapshots.swift in Sources */,
+				4A13612D276768000077EB7F /* SnapshotHelper.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4A2245CC24A5E16300DBA437 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1974,8 +2086,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A80408027694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift in Sources */,
 				4AFD8C112693204900F77BA6 /* ErrorWrapper.swift in Sources */,
 				4AE7D79525826A0900C5E1D8 /* FileProviderValidationServiceSource.m in Sources */,
+				4A80407D27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift in Sources */,
 				4AA621D9249A6A8400A0BCBD /* FileProviderExtension.swift in Sources */,
 				4A24001A26AE9F3A009DBC2E /* VaultLockingServiceSource.swift in Sources */,
 				4A9BED64268F1DB000721BAA /* VaultUnlockingServiceSource.swift in Sources */,
@@ -1989,6 +2103,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A6A520D268B5EF7006F7368 /* RootViewController.swift in Sources */,
+				4A804082276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift in Sources */,
 				4A9BED66268F2D9D00721BAA /* UnlockVaultViewController.swift in Sources */,
 				4A6A521B268B7147006F7368 /* FileProviderCoordinator.swift in Sources */,
 				4A6A5219268B6D32006F7368 /* OnboardingViewController.swift in Sources */,
@@ -2030,6 +2145,7 @@
 				4A644B57267C958F008CBB9A /* ChildCoordinator.swift in Sources */,
 				4A53CC15267CC33100853BB3 /* CreateNewVaultPasswordViewModel.swift in Sources */,
 				4AA22C1E261CA94700A17486 /* UsernameFieldCell.swift in Sources */,
+				4A136132276770BB0077EB7F /* SnapshotVaultListViewModel.swift in Sources */,
 				747C35172762A3F500E4CA28 /* AttributedTextHeaderFooterViewModel.swift in Sources */,
 				7408E6BF267783F100D7FAEA /* LocalWebViewController.swift in Sources */,
 				4A447E4D25BF1E8B00D9520D /* FileCell.swift in Sources */,
@@ -2076,6 +2192,7 @@
 				4A1EB0CA2689C373006D072B /* LocalVaultAdding.swift in Sources */,
 				4A4B7E6D26B9462F009BFDB1 /* Bindable.swift in Sources */,
 				4A512D6A274277FF00DC26F8 /* EditableDataSource.swift in Sources */,
+				4A13612F27676F5C0077EB7F /* SnapshotCoordinator.swift in Sources */,
 				4AF91D0D25A8D5EF00ACF01E /* ListViewModel.swift in Sources */,
 				4A8D060525C82F1F0082C5F7 /* AddVaultSuccesing.swift in Sources */,
 				4A61F6B9274582E3007AA422 /* StaticUITableViewController.swift in Sources */,
@@ -2266,6 +2383,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		4A136128276767D60077EB7F /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 4AE97DA724572E4900452814 /* Cryptomator */;
+			targetProxy = 4A136127276767D60077EB7F /* PBXContainerItemProxy */;
+		};
 		4A1673EF270DE4600075C724 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 740375D62587AE7A0023FF53 /* CryptomatorFileProvider */;
@@ -2351,6 +2473,58 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		4A136129276767D60077EB7F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FZ53285T8H;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.Snapshots;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Cryptomator;
+			};
+			name = Debug;
+		};
+		4A13612A276767D60077EB7F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = FZ53285T8H;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.Snapshots;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Cryptomator;
+			};
+			name = Release;
+		};
 		4A2245D924A5E16300DBA437 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2766,6 +2940,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		4A13612B276767D60077EB7F /* Build configuration list for PBXNativeTarget "Snapshots" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4A136129276767D60077EB7F /* Debug */,
+				4A13612A276767D60077EB7F /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		4A2245D824A5E16300DBA437 /* Build configuration list for PBXNativeTarget "CryptomatorFileProviderTests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -1060,10 +1060,10 @@
 				4AE97DC024572E4A00452814 /* CryptomatorTests */,
 				4AA621D7249A6A8400A0BCBD /* FileProviderExtension */,
 				4AA621E5249A6A8400A0BCBD /* FileProviderExtensionUI */,
-				4A136122276767D60077EB7F /* Snapshots */,
 				4A828287252617D600A4EAD4 /* Frameworks */,
 				4A5E5B2A2453119100BD6298 /* Products */,
 				74D365BC268B965B005ECD69 /* SharedResources */,
+				4A136122276767D60077EB7F /* Snapshots */,
 				74F5DC1826D929FC00AFE989 /* StoreKitTestConfiguration */,
 			);
 			sourceTree = "<group>";
@@ -1405,10 +1405,10 @@
 				74F5DC1A26DCD2E300AFE989 /* Purchase */,
 				7408E6C8267797DC00D7FAEA /* Resources */,
 				740D367C266A18C80058744D /* Settings */,
+				4A13613027676F610077EB7F /* Snapshots */,
 				4A4B7E4026B2ABC4009BFDB1 /* VaultDetail */,
 				4A8195DB25ADB8AD00F7DDA1 /* VaultList */,
 				4AA22C08261CA71300A17486 /* WebDAV */,
-				4A13613027676F610077EB7F /* Snapshots */,
 			);
 			path = Cryptomator;
 			sourceTree = "<group>";
@@ -2476,27 +2476,16 @@
 		4A136129276767D60077EB7F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = FZ53285T8H;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
+				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.Snapshots;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Debug;
@@ -2504,23 +2493,16 @@
 		4A13612A276767D60077EB7F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = FZ53285T8H;
+				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.Snapshots;
+				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_EMIT_LOC_STRINGS = NO;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Release;
@@ -2538,8 +2520,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cryptomator.ios.fileprovider-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2556,8 +2536,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cryptomator.ios.fileprovider-tests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2575,8 +2553,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cryptomator.ios.common-hostedtests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cryptomator.app/Cryptomator";
 			};
 			name = Debug;
@@ -2595,8 +2571,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = "org.cryptomator.ios.common-hostedtests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cryptomator.app/Cryptomator";
 			};
 			name = Release;
@@ -2661,6 +2635,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2718,6 +2694,8 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -2741,8 +2719,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development org.cryptomator.ios.fileprovider-ui";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2765,8 +2741,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.cryptomator.ios.fileprovider-ui";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2792,8 +2766,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FileProviderExtension/FileProviderExtension-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2818,8 +2790,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.cryptomator.ios.fileprovider";
 				SKIP_INSTALL = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "FileProviderExtension/FileProviderExtension-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2841,8 +2811,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development org.cryptomator.ios";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2864,8 +2832,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.cryptomator.ios";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};
@@ -2883,8 +2849,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cryptomator.app/Cryptomator";
 			};
 			name = Debug;
@@ -2903,8 +2867,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Cryptomator.app/Cryptomator";
 			};
 			name = Release;
@@ -2918,8 +2880,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -2932,8 +2892,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Cryptomator.xcodeproj/xcshareddata/xcschemes/Snapshots.xcscheme
+++ b/Cryptomator.xcodeproj/xcshareddata/xcschemes/Snapshots.xcscheme
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1310"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4AE97DA724572E4900452814"
+               BuildableName = "Cryptomator.app"
+               BlueprintName = "Cryptomator"
+               ReferencedContainer = "container:Cryptomator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A136120276767D60077EB7F"
+               BuildableName = "Snapshots.xctest"
+               BlueprintName = "Snapshots"
+               ReferencedContainer = "container:Cryptomator.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "4A136120276767D60077EB7F"
+               BuildableName = "Snapshots.xctest"
+               BlueprintName = "Snapshots"
+               ReferencedContainer = "container:Cryptomator.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE97DA724572E4900452814"
+            BuildableName = "Cryptomator.app"
+            BlueprintName = "Cryptomator"
+            ReferencedContainer = "container:Cryptomator.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-FASTLANE_SNAPSHOT"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "4AE97DA724572E4900452814"
+            BuildableName = "Cryptomator.app"
+            BlueprintName = "Cryptomator"
+            ReferencedContainer = "container:Cryptomator.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -70,6 +70,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Create window
 		let navigationController = BaseNavigationController()
 		coordinator = MainCoordinator(navigationController: navigationController)
+		#if SNAPSHOTS
+		coordinator = SnapshotCoordinator(navigationController: navigationController)
+		UIView.setAnimationsEnabled(false)
+		#endif
 		coordinator?.start()
 		StoreObserver.shared.fallbackDelegate = coordinator
 		window = UIWindow(frame: UIScreen.main.bounds)

--- a/Cryptomator/Snapshots/SnapshotCoordinator.swift
+++ b/Cryptomator/Snapshots/SnapshotCoordinator.swift
@@ -1,0 +1,114 @@
+//
+//  SnapshotCoordinator.swift
+//  Cryptomator
+//
+//  Created by Philipp Schmid on 13.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import FileProvider
+import Foundation
+import Promises
+
+class SnapshotCoordinator: MainCoordinator {
+	private static let vaultListViewModel = SnapshotVaultListViewModel()
+
+	override func start() {
+		swizzleViewController()
+		resetOnboarding()
+		unlockFullVersion()
+		let vaultListViewController = VaultListViewController(with: SnapshotCoordinator.vaultListViewModel)
+		vaultListViewController.coordinator = self
+		navigationController.pushViewController(vaultListViewController, animated: false)
+	}
+
+	override func showVaultDetail(for vaultInfo: VaultInfo) {
+		let snapshotFileProviderConnectorMock = SnapshotFileProviderConntectorMock()
+		snapshotFileProviderConnectorMock.proxy = SnapshotVaultLockingMock()
+		let viewModel = VaultDetailViewModel(vaultInfo: vaultInfo, vaultManager: VaultDBManager.shared, fileProviderConnector: SnapshotFileProviderConntectorMock(), passwordManager: VaultPasswordKeychainManager(), dbManager: DatabaseManager.shared)
+		let vaultDetailViewController = VaultDetailViewController(viewModel: viewModel)
+		navigationController.pushViewController(vaultDetailViewController, animated: true)
+	}
+
+	static func startShowingMockVaults() {
+		vaultListViewModel.showMockVaults = true
+	}
+
+	private func resetOnboarding() {
+		CryptomatorUserDefaults.shared.showOnboardingAtStartup = true
+	}
+
+	private func unlockFullVersion() {
+		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
+	}
+
+	private func swizzleViewController() {
+		BaseUITableViewController.setSnapshotAccessibilityIdentifier
+		OnboardingNavigationController.informAboutDisappear
+	}
+}
+
+private class SnapshotFileProviderConntectorMock: FileProviderConnector {
+	var proxy: Any?
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domainIdentifier: NSFileProviderDomainIdentifier) -> Promise<T> {
+		return getCastedProxy()
+	}
+
+	func getProxy<T>(serviceName: NSFileProviderServiceName, domain: NSFileProviderDomain?) -> Promise<T> {
+		return getCastedProxy()
+	}
+
+	private func getCastedProxy<T>() -> Promise<T> {
+		guard let castedProxy = proxy as? T else {
+			return Promise(FileProviderXPCConnectorError.typeMismatch)
+		}
+		return Promise(castedProxy)
+	}
+}
+
+private class SnapshotVaultLockingMock: VaultLocking {
+	func lockVault(domainIdentifier: NSFileProviderDomainIdentifier) {}
+
+	func getIsUnlockedVault(domainIdentifier: NSFileProviderDomainIdentifier, reply: @escaping (Bool) -> Void) {
+		reply(true)
+	}
+
+	func getUnlockedVaultDomainIdentifiers(reply: @escaping ([NSFileProviderDomainIdentifier]) -> Void) {
+		fatalError()
+	}
+
+	var serviceName: NSFileProviderServiceName = .init("org.cryptomator.ios.vault-locking")
+
+	func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
+		fatalError()
+	}
+}
+
+extension BaseUITableViewController {
+	static let setSnapshotAccessibilityIdentifier: Void = {
+		guard let originalMethod = class_getInstanceMethod(BaseUITableViewController.self, #selector(viewDidLoad)),
+		      let swizzledMethod = class_getInstanceMethod(BaseUITableViewController.self, #selector(swizzled_viewDidLoad))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_viewDidLoad() {
+		swizzled_viewDidLoad()
+		tableView.accessibilityIdentifier = "Snapshot_\(String(describing: type(of: self)))"
+	}
+}
+
+extension OnboardingNavigationController {
+	static let informAboutDisappear: Void = {
+		guard let originalMethod = class_getInstanceMethod(OnboardingNavigationController.self, #selector(viewWillDisappear(_:))),
+		      let swizzledMethod = class_getInstanceMethod(OnboardingNavigationController.self, #selector(swizzled_viewWillDisappear(_:)))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_viewWillDisappear(_ animated: Bool) {
+		swizzled_viewWillDisappear(animated)
+		SnapshotCoordinator.startShowingMockVaults()
+	}
+}

--- a/Cryptomator/Snapshots/SnapshotCoordinator.swift
+++ b/Cryptomator/Snapshots/SnapshotCoordinator.swift
@@ -6,10 +6,12 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+#if SNAPSHOTS
 import CryptomatorCommonCore
 import FileProvider
 import Foundation
 import Promises
+import UIKit
 
 class SnapshotCoordinator: MainCoordinator {
 	private static let vaultListViewModel = SnapshotVaultListViewModel()
@@ -45,6 +47,7 @@ class SnapshotCoordinator: MainCoordinator {
 
 	private func swizzleViewController() {
 		BaseUITableViewController.setSnapshotAccessibilityIdentifier
+		OnboardingViewController.skipPurchaseViewController
 		OnboardingNavigationController.informAboutDisappear
 	}
 }
@@ -99,6 +102,19 @@ extension BaseUITableViewController {
 	}
 }
 
+extension OnboardingViewController {
+	static let skipPurchaseViewController: Void = {
+		guard let originalMethod = class_getInstanceMethod(OnboardingViewController.self, #selector(tableView(_:didSelectRowAt:))),
+		      let swizzledMethod = class_getInstanceMethod(OnboardingViewController.self, #selector(swizzled_tableView(_:didSelectRowAt:)))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		dismiss(animated: false)
+	}
+}
+
 extension OnboardingNavigationController {
 	static let informAboutDisappear: Void = {
 		guard let originalMethod = class_getInstanceMethod(OnboardingNavigationController.self, #selector(viewWillDisappear(_:))),
@@ -112,3 +128,4 @@ extension OnboardingNavigationController {
 		SnapshotCoordinator.startShowingMockVaults()
 	}
 }
+#endif

--- a/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
+++ b/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
@@ -1,0 +1,66 @@
+//
+//  SnapshotVaultListViewModel.swift
+//  Cryptomator
+//
+//  Created by Philipp Schmid on 13.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Combine
+import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
+import Foundation
+import Promises
+
+class SnapshotVaultListViewModel: VaultListViewModelProtocol {
+	@Published var showMockVaults = false
+	func refreshVaultLockStates() -> Promise<Void> {
+		return Promise(())
+	}
+
+	let headerTitle = LocalizedString.getValue("vaultList.header.title")
+	let emptyListMessage = LocalizedString.getValue("vaultList.emptyList.message")
+
+	var removeAlert: ListViewModelAlertContent {
+		.init(title: "", message: "", confirmButtonText: "")
+	}
+
+	private lazy var vaultCellViewModels: [VaultCellViewModel] = createVaulCells()
+
+	func moveRow(at sourceIndex: Int, to destinationIndex: Int) throws {}
+
+	func removeRow(at index: Int) throws {}
+
+	func startListenForChanges() -> AnyPublisher<Result<[TableViewCellViewModel], Error>, Never> {
+		return $showMockVaults.map { showMockVaults in
+			let result: Result<[TableViewCellViewModel], Error>
+			if showMockVaults {
+				result = .success(self.vaultCellViewModels)
+			} else {
+				result = .success([])
+			}
+			return result
+		}.eraseToAnyPublisher()
+	}
+
+	private func createVaulCells() -> [VaultCellViewModel] {
+		let cloudProviderAccounts = [
+			CloudProviderAccount(accountUID: UUID().uuidString, cloudProviderType: .oneDrive),
+			CloudProviderAccount(accountUID: UUID().uuidString, cloudProviderType: .googleDrive),
+			CloudProviderAccount(accountUID: UUID().uuidString, cloudProviderType: .dropbox),
+			CloudProviderAccount(accountUID: UUID().uuidString, cloudProviderType: .localFileSystem(type: .iCloudDrive))
+		]
+		let vaultPaths = [
+			CloudPath("/Work"),
+			CloudPath("/Family"),
+			CloudPath("/Documents"),
+			CloudPath("/Trip to California")
+		]
+		let vaults = cloudProviderAccounts.enumerated().map { index, cloudProviderAccount -> VaultInfo in
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: vaultPaths[index], vaultName: vaultPaths[index].lastPathComponent)
+			let vaultListPosition = VaultListPosition(id: nil, position: index, vaultUID: vaultAccount.vaultUID)
+			return VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
+		}
+		return vaults.map { VaultCellViewModel(vault: $0) }
+	}
+}

--- a/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
+++ b/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+#if SNAPSHOTS
 import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
@@ -64,3 +65,4 @@ class SnapshotVaultListViewModel: VaultListViewModelProtocol {
 		return vaults.map { VaultCellViewModel(vault: $0) }
 	}
 }
+#endif

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultPasswordManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultPasswordManager.swift
@@ -11,7 +11,7 @@ import LocalAuthentication
 
 public protocol VaultPasswordManager {
 	func setPassword(_ password: String, forVaultUID vaultUID: String) throws
-	func getPassword(forVaultUID vaultUID: String) throws -> String
+	func getPassword(forVaultUID vaultUID: String, context: LAContext) throws -> String
 	func removePassword(forVaultUID vaultUID: String) throws
 	func hasPassword(forVaultUID vaultUID: String) throws -> Bool
 }
@@ -28,16 +28,6 @@ public class VaultPasswordKeychainManager: VaultPasswordManager {
 			throw VaultPasswordManagerError.encodingError
 		}
 		try CryptomatorUserPresenceKeychain.vaultPassword.set(vaultUID, value: data)
-	}
-
-	public func getPassword(forVaultUID vaultUID: String) throws -> String {
-		guard let data = CryptomatorUserPresenceKeychain.vaultPassword.getAsData(vaultUID) else {
-			throw VaultPasswordManagerError.passwordNotFound
-		}
-		guard let password = String(data: data, encoding: .utf8) else {
-			throw VaultPasswordManagerError.encodingError
-		}
-		return password
 	}
 
 	public func removePassword(forVaultUID vaultUID: String) throws {

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/VaultManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/VaultManagerTests.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import GRDB
+import LocalAuthentication
 import Promises
 import XCTest
 @testable import CryptomatorCloudAccessCore
@@ -718,7 +719,7 @@ class VaultPasswordManagerMock: VaultPasswordManager {
 		savedPasswords[vaultUID] = password
 	}
 
-	func getPassword(forVaultUID vaultUID: String) throws -> String {
+	func getPassword(forVaultUID vaultUID: String, context: LAContext) throws -> String {
 		guard let password = savedPasswords[vaultUID] else {
 			throw VaultPasswordManagerError.passwordNotFound
 		}

--- a/CryptomatorCommonHostedTests/Keychain/VaultPasswordKeychainManagerTests.swift
+++ b/CryptomatorCommonHostedTests/Keychain/VaultPasswordKeychainManagerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import LocalAuthentication
 import XCTest
 @testable import CryptomatorCommonCore
 
@@ -18,7 +19,7 @@ class VaultPasswordKeychainManagerTests: XCTestCase {
 		let password = "pw"
 		let vaultUID = UUID().uuidString
 		try passwordManager.setPassword(password, forVaultUID: vaultUID)
-		let fetchedPassword = try passwordManager.getPassword(forVaultUID: vaultUID)
+		let fetchedPassword = try passwordManager.getPassword(forVaultUID: vaultUID, context: LAContext())
 		XCTAssertEqual(password, fetchedPassword)
 		try passwordManager.removePassword(forVaultUID: vaultUID)
 	}
@@ -33,7 +34,7 @@ class VaultPasswordKeychainManagerTests: XCTestCase {
 		try passwordManager.setPassword(oldPassword, forVaultUID: vaultUID)
 		let newPassword = "newPW"
 		try passwordManager.setPassword(newPassword, forVaultUID: vaultUID)
-		let fetchedPassword = try passwordManager.getPassword(forVaultUID: vaultUID)
+		let fetchedPassword = try passwordManager.getPassword(forVaultUID: vaultUID, context: LAContext())
 		XCTAssertEqual(newPassword, fetchedPassword)
 		try passwordManager.removePassword(forVaultUID: vaultUID)
 	}
@@ -47,7 +48,7 @@ class VaultPasswordKeychainManagerTests: XCTestCase {
 		let vaultUID = UUID().uuidString
 		try passwordManager.setPassword(password, forVaultUID: vaultUID)
 		try passwordManager.removePassword(forVaultUID: vaultUID)
-		XCTAssertThrowsError(try passwordManager.getPassword(forVaultUID: vaultUID)) { error in
+		XCTAssertThrowsError(try passwordManager.getPassword(forVaultUID: vaultUID, context: LAContext())) { error in
 			guard case VaultPasswordManagerError.passwordNotFound = error else {
 				XCTFail("Throws the wrong error: \(error)")
 				return

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -8,6 +8,7 @@
 
 import CryptomatorCloudAccessCore
 import GRDB
+import LocalAuthentication
 import Promises
 import XCTest
 @testable import Cryptomator
@@ -264,7 +265,7 @@ private class VaultPasswordManagerMock: VaultPasswordManager {
 		throw MockError.notMocked
 	}
 
-	func getPassword(forVaultUID vaultUID: String) throws -> String {
+	func getPassword(forVaultUID vaultUID: String, context: LAContext) throws -> String {
 		throw MockError.notMocked
 	}
 

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -227,6 +227,9 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		 }
 		 return enumerator
 		 */
+		#if SNAPSHOTS
+		return FileProviderEnumeratorSnapshotMock()
+		#endif
 		// TODO: Change error handling here
 		DDLogDebug("FPExt: enumerator(for: \(containerItemIdentifier)) called")
 		guard let manager = manager, let domain = domain, let dbPath = dbPath, let notificator = notificator else {
@@ -260,7 +263,11 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		#if DEBUG
 		serviceSources.append(FileProviderValidationServiceSource(fileProviderExtension: self, itemIdentifier: itemIdentifier))
 		#endif
+		#if SNAPSHOTS
+		serviceSources.append(VaultUnlockingServiceSourceSnapshotMock(fileprovider: self))
+		#else
 		serviceSources.append(VaultUnlockingServiceSource(fileprovider: self))
+		#endif
 		serviceSources.append(VaultLockingServiceSource())
 		serviceSources.append(LogLevelUpdatingServiceSource())
 		return serviceSources

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -229,7 +229,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		 */
 		#if SNAPSHOTS
 		return FileProviderEnumeratorSnapshotMock()
-		#endif
+		#else
 		// TODO: Change error handling here
 		DDLogDebug("FPExt: enumerator(for: \(containerItemIdentifier)) called")
 		guard let manager = manager, let domain = domain, let dbPath = dbPath, let notificator = notificator else {
@@ -238,6 +238,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 			throw NSFileProviderError(.notAuthenticated)
 		}
 		return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier, notificator: notificator, domain: domain, manager: manager, dbPath: dbPath, localURLProvider: self)
+		#endif
 	}
 
 	func setUp() throws {

--- a/FileProviderExtension/Snapshots/FileProviderEnumeratorSnapshotMock.swift
+++ b/FileProviderExtension/Snapshots/FileProviderEnumeratorSnapshotMock.swift
@@ -1,0 +1,82 @@
+//
+//  FileProviderEnumeratorSnapshotMock.swift
+//  FileProviderExtension
+//
+//  Created by Philipp Schmid on 14.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if SNAPSHOTS
+import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
+import CryptomatorFileProvider
+import FileProvider
+import Foundation
+import MobileCoreServices
+
+public class FileProviderEnumeratorSnapshotMock: NSObject, NSFileProviderEnumerator {
+	static var isUnlocked = false
+	private lazy var items: [FileProviderItemSnapshotMock] = [
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.file1")), itemType: .file, contentModificationDate: currentDate - 604_800, documentSize: 254_076),
+		.init(path: CloudPath("/CeBIT Award 2016.jpg"), itemType: .file, contentModificationDate: currentDate - 31_536_000, documentSize: 240_660),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.folder1")), itemType: .folder, contentModificationDate: nil, documentSize: nil),
+		.init(path: CloudPath("/Cryptomator.jpg"), itemType: .file, contentModificationDate: currentDate - 120, documentSize: 200_195),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.file2")), itemType: .file, contentModificationDate: currentDate - 345_600, documentSize: 3_026_152),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.folder2")), itemType: .folder, contentModificationDate: nil, documentSize: nil),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.file3")), itemType: .file, contentModificationDate: currentDate - 604_800, documentSize: 135_137_445),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.file4")), itemType: .file, contentModificationDate: currentDate - 518_400, documentSize: 471_027),
+		.init(path: CloudPath(LocalizedString.getValue("snapshots.fileprovider.file5")), itemType: .file, contentModificationDate: currentDate - 172_800, documentSize: 1_540_417)
+	]
+	private lazy var currentDate = Date()
+	public func invalidate() {}
+
+	public func enumerateItems(for observer: NSFileProviderEnumerationObserver, startingAt page: NSFileProviderPage) {
+		if FileProviderEnumeratorSnapshotMock.isUnlocked {
+			observer.didEnumerate(items)
+			observer.finishEnumerating(upTo: nil)
+		} else {
+			let vaultPath = CloudPath(LocalizedString.getValue("snapshots.main.vault1"))
+			observer.finishEnumeratingWithError(NSFileProviderError(.notAuthenticated, userInfo: ["internalError": FileProviderAdapterManagerError.cachedAdapterNotFound,
+			                                                                                      "vaultName": vaultPath.lastPathComponent,
+			                                                                                      "pathRelativeToDocumentStorage": "",
+			                                                                                      "domainIdentifier": ""]))
+		}
+	}
+}
+
+class FileProviderItemSnapshotMock: NSObject, NSFileProviderItem {
+	var itemIdentifier: NSFileProviderItemIdentifier {
+		return NSFileProviderItemIdentifier(rawValue: filename)
+	}
+
+	var parentItemIdentifier: NSFileProviderItemIdentifier = .rootContainer
+	var filename: String {
+		path.lastPathComponent
+	}
+
+	var contentModificationDate: Date?
+	var documentSize: NSNumber?
+	var typeIdentifier: String {
+		switch itemType {
+		case .folder:
+			return kUTTypeFolder as String
+		default:
+			if let typeIdentifier = UTTypeCreatePreferredIdentifierForTag(kUTTagClassFilenameExtension, path.pathExtension as CFString, nil) {
+				return typeIdentifier.takeRetainedValue() as String
+			} else {
+				return kUTTypeData as String
+			}
+		}
+	}
+
+	private let path: CloudPath
+	private let itemType: CloudItemType
+
+	init(path: CloudPath, itemType: CloudItemType, contentModificationDate: Date?, documentSize: NSNumber?) {
+		self.path = path
+		self.itemType = itemType
+		self.contentModificationDate = contentModificationDate
+		self.documentSize = documentSize
+	}
+}
+#endif

--- a/FileProviderExtension/Snapshots/VaultUnlockingServiceSourceSnapshotMock.swift
+++ b/FileProviderExtension/Snapshots/VaultUnlockingServiceSourceSnapshotMock.swift
@@ -1,0 +1,18 @@
+//
+//  VaultUnlockingServiceSourceSnapshotMock.swift
+//  FileProviderExtension
+//
+//  Created by Philipp Schmid on 14.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if SNAPSHOTS
+import Foundation
+
+class VaultUnlockingServiceSourceSnapshotMock: VaultUnlockingServiceSource {
+	override func unlockVault(kek: [UInt8], reply: @escaping (Error?) -> Void) {
+		FileProviderEnumeratorSnapshotMock.isUnlocked = true
+		reply(nil)
+	}
+}
+#endif

--- a/FileProviderExtensionUI/FileProviderCoordinator.swift
+++ b/FileProviderExtensionUI/FileProviderCoordinator.swift
@@ -13,9 +13,7 @@ import FileProviderUI
 import UIKit
 
 class FileProviderCoordinator {
-	private let extensionContext: FPUIActionExtensionContext
-	private weak var hostViewController: UIViewController?
-	private lazy var navigationController: UINavigationController = {
+	lazy var navigationController: UINavigationController = {
 		let appearance = UINavigationBarAppearance()
 		appearance.configureWithOpaqueBackground()
 		appearance.backgroundColor = UIColor(named: "primary")
@@ -27,6 +25,9 @@ class FileProviderCoordinator {
 		addViewControllerAsChildToHost(navigationController)
 		return navigationController
 	}()
+
+	private let extensionContext: FPUIActionExtensionContext
+	private weak var hostViewController: UIViewController?
 
 	init(extensionContext: FPUIActionExtensionContext, hostViewController: UIViewController) {
 		self.extensionContext = extensionContext

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -15,8 +15,9 @@ class RootViewController: FPUIActionExtensionViewController {
 	private lazy var coordinator: FileProviderCoordinator = {
 		#if SNAPSHOTS
 		return FileProviderCoordinatorSnapshotMock(extensionContext: extensionContext, hostViewController: self)
-		#endif
+		#else
 		return .init(extensionContext: extensionContext, hostViewController: self)
+		#endif
 	}()
 
 	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -12,7 +12,12 @@ import FileProviderUI
 import UIKit
 
 class RootViewController: FPUIActionExtensionViewController {
-	private lazy var coordinator: FileProviderCoordinator = .init(extensionContext: extensionContext, hostViewController: self)
+	private lazy var coordinator: FileProviderCoordinator = {
+		#if SNAPSHOTS
+		return FileProviderCoordinatorSnapshotMock(extensionContext: extensionContext, hostViewController: self)
+		#endif
+		return .init(extensionContext: extensionContext, hostViewController: self)
+	}()
 
 	override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
 		super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)

--- a/FileProviderExtensionUI/Snapshots/FileProviderCoordinatorSnapshotMock.swift
+++ b/FileProviderExtensionUI/Snapshots/FileProviderCoordinatorSnapshotMock.swift
@@ -1,0 +1,119 @@
+//
+//  FileProviderCoordinatorSnapshotMock.swift
+//  FileProviderExtensionUI
+//
+//  Created by Philipp Schmid on 14.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#if SNAPSHOTS
+import CryptomatorCommonCore
+import FileProviderUI
+import LocalAuthentication
+import Promises
+import UIKit
+
+class FileProviderCoordinatorSnapshotMock: FileProviderCoordinator {
+	override init(extensionContext: FPUIActionExtensionContext, hostViewController: UIViewController) {
+		UnlockVaultViewController.changeUnlock
+		UnlockVaultViewController.setSnapshotAccessibilityIdentifier
+		UITextField.changePasswordFielCell
+		LAContext.activateFaceID
+		super.init(extensionContext: extensionContext, hostViewController: hostViewController)
+	}
+
+	override func showPasswordScreen(for domain: NSFileProviderDomain) {
+		let viewModel = UnlockVaultViewModelSnapshotMock(domain: domain)
+		let unlockVaultVC = UnlockVaultViewController(viewModel: viewModel)
+		unlockVaultVC.coordinator = self
+		navigationController.pushViewController(unlockVaultVC, animated: false)
+	}
+}
+
+class UnlockVaultViewModelSnapshotMock: UnlockVaultViewModel {
+	init(domain: NSFileProviderDomain) {
+		super.init(domain: domain, passwordManager: VaultPasswordManagerSnapshotMock())
+	}
+}
+
+class VaultPasswordManagerSnapshotMock: VaultPasswordManager {
+	func setPassword(_ password: String, forVaultUID vaultUID: String) throws {}
+
+	func getPassword(forVaultUID vaultUID: String, context: LAContext) throws -> String {
+		return ""
+	}
+
+	func removePassword(forVaultUID vaultUID: String) throws {}
+
+	func hasPassword(forVaultUID vaultUID: String) throws -> Bool {
+		return true
+	}
+}
+
+extension UnlockVaultViewController {
+	static let changeUnlock: Void = {
+		guard let originalMethod = class_getInstanceMethod(UnlockVaultViewController.self, #selector(unlock)),
+		      let swizzledMethod = class_getInstanceMethod(UnlockVaultViewController.self, #selector(swizzled_unlock))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_unlock() {
+		let getProxyPromise: Promise<VaultUnlocking> = FileProviderXPCConnector.shared.getProxy(serviceName: VaultUnlockingService.name, domain: nil)
+		getProxyPromise.then { proxy in
+			proxy.unlockVault(kek: [UInt8](), reply: { [weak self] _ in
+				self?.coordinator?.done()
+			})
+		}
+	}
+
+	static let setSnapshotAccessibilityIdentifier: Void = {
+		guard let originalMethod = class_getInstanceMethod(UnlockVaultViewController.self, #selector(viewDidLoad)),
+		      let swizzledMethod = class_getInstanceMethod(UnlockVaultViewController.self, #selector(swizzled_viewDidLoad))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_viewDidLoad() {
+		swizzled_viewDidLoad()
+		tableView.accessibilityIdentifier = "Snapshot_\(String(describing: type(of: self)))"
+		navigationItem.rightBarButtonItem?.accessibilityIdentifier = "Snapshot_UnlockButton"
+	}
+}
+
+extension UITextField {
+	static let changePasswordFielCell: Void = {
+		guard let originalMethod = class_getInstanceMethod(UITextField.self, #selector(layoutSubviews)),
+		      let swizzledMethod = class_getInstanceMethod(UITextField.self, #selector(swizzled_layoutSubviews))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+	}()
+
+	@objc func swizzled_layoutSubviews() {
+		swizzled_layoutSubviews()
+		isSecureTextEntry = false
+	}
+}
+
+extension LAContext {
+	static let activateFaceID: Void = {
+		guard let originalMethod = class_getInstanceMethod(LAContext.self, #selector(canEvaluatePolicy(_:error:))),
+		      let swizzledMethod = class_getInstanceMethod(LAContext.self, #selector(swizzled_canEvaluatePolicy(_:error:)))
+		else { return }
+		method_exchangeImplementations(originalMethod, swizzledMethod)
+
+		guard let originalMethod2 = class_getInstanceMethod(LAContext.self, #selector(getter: biometryType)),
+		      let swizzledMethod2 = class_getInstanceMethod(LAContext.self, #selector(swizzled_getBiometryType))
+		else { return }
+		method_exchangeImplementations(originalMethod2, swizzledMethod2)
+	}()
+
+	@objc func swizzled_canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
+		return true
+	}
+
+	@objc func swizzled_getBiometryType() -> LABiometryType {
+		return .faceID
+	}
+}
+#endif

--- a/FileProviderExtensionUI/UnlockVaultViewModel.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewModel.swift
@@ -86,7 +86,7 @@ class UnlockVaultViewModel {
 	]
 
 	private let context: LAContext
-	private let passwordManager: VaultPasswordKeychainManager
+	private let passwordManager: VaultPasswordManager
 	private lazy var canEvaluatePolicy: Bool = {
 		var error: NSError?
 		if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: &error) {
@@ -99,14 +99,14 @@ class UnlockVaultViewModel {
 
 	private let fileProviderConnector: FileProviderConnector
 
-	init(domain: NSFileProviderDomain, fileProviderConnector: FileProviderConnector = FileProviderXPCConnector.shared) {
+	init(domain: NSFileProviderDomain, fileProviderConnector: FileProviderConnector = FileProviderXPCConnector.shared, passwordManager: VaultPasswordManager = VaultPasswordKeychainManager()) {
 		self.domain = domain
 		self.fileProviderConnector = fileProviderConnector
 		let context = LAContext()
 		// Remove fallback title because "Enter password" also closes the FileProviderExtensionUI and does not display the password input
 		context.localizedFallbackTitle = ""
 		self.context = context
-		self.passwordManager = VaultPasswordKeychainManager()
+		self.passwordManager = passwordManager
 	}
 
 	func numberOfRows(in section: Int) -> Int {

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -141,6 +141,19 @@
 "settings.sendLogFile" = "Send Log File";
 "settings.unlockFullVersion" = "Unlock Full Version";
 
+"snapshots.fileprovider.file1" = "/Accounting.numbers";
+"snapshots.fileprovider.file2" = "/Final Presentation.key";
+"snapshots.fileprovider.file3" = "/Product Trailer.mov";
+"snapshots.fileprovider.file4" = "/Proposal.docx";
+"snapshots.fileprovider.file5" = "/Report.pdf";
+"snapshots.fileprovider.folder3" = "/Secret Project";
+"snapshots.fileprovider.folder2" = "/Invoices";
+"snapshots.fileprovider.folder1" = "/Certificates";
+"snapshots.main.vault1" = "/Work";
+"snapshots.main.vault2" = "/Family";
+"snapshots.main.vault3" = "/Documents";
+"snapshots.main.vault4" = "/Trip to California";
+
 "unlockVault.button.unlock" = "Unlock";
 "unlockVault.button.unlockVia" = "Unlock via %@";
 "unlockVault.password.footer" = "Enter password for \"%@\".";

--- a/Snapshots/SnapshotHelper.swift
+++ b/Snapshots/SnapshotHelper.swift
@@ -1,0 +1,308 @@
+//
+//  SnapshotHelper.swift
+//  Example
+//
+//  Created by Felix Krause on 10/8/15.
+//
+
+// -----------------------------------------------------
+// IMPORTANT: When modifying this file, make sure to
+//            increment the version number at the very
+//            bottom of the file to notify users about
+//            the new SnapshotHelper.swift
+// -----------------------------------------------------
+
+import Foundation
+import XCTest
+
+var deviceLanguage = ""
+var locale = ""
+
+func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+	Snapshot.setupSnapshot(app, waitForAnimations: waitForAnimations)
+}
+
+func snapshot(_ name: String, waitForLoadingIndicator: Bool) {
+	if waitForLoadingIndicator {
+		Snapshot.snapshot(name)
+	} else {
+		Snapshot.snapshot(name, timeWaitingForIdle: 0)
+	}
+}
+
+/// - Parameters:
+///   - name: The name of the snapshot
+///   - timeout: Amount of seconds to wait until the network loading indicator disappears. Pass `0` if you don't want to wait.
+func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+	Snapshot.snapshot(name, timeWaitingForIdle: timeout)
+}
+
+enum SnapshotError: Error, CustomDebugStringConvertible {
+	case cannotFindSimulatorHomeDirectory
+	case cannotRunOnPhysicalDevice
+
+	var debugDescription: String {
+		switch self {
+		case .cannotFindSimulatorHomeDirectory:
+			return "Couldn't find simulator home location. Please, check SIMULATOR_HOST_HOME env variable."
+		case .cannotRunOnPhysicalDevice:
+			return "Can't use Snapshot on a physical device."
+		}
+	}
+}
+
+@objcMembers
+open class Snapshot: NSObject {
+	static var app: XCUIApplication?
+	static var waitForAnimations = true
+	static var cacheDirectory: URL?
+	static var screenshotsDirectory: URL? {
+		return cacheDirectory?.appendingPathComponent("screenshots", isDirectory: true)
+	}
+
+	open class func setupSnapshot(_ app: XCUIApplication, waitForAnimations: Bool = true) {
+		Snapshot.app = app
+		Snapshot.waitForAnimations = waitForAnimations
+
+		do {
+			let cacheDir = try getCacheDirectory()
+			Snapshot.cacheDirectory = cacheDir
+			setLanguage(app)
+			setLocale(app)
+			setLaunchArguments(app)
+		} catch {
+			NSLog(error.localizedDescription)
+		}
+	}
+
+	class func setLanguage(_ app: XCUIApplication) {
+		guard let cacheDirectory = cacheDirectory else {
+			NSLog("CacheDirectory is not set - probably running on a physical device?")
+			return
+		}
+
+		let path = cacheDirectory.appendingPathComponent("language.txt")
+
+		do {
+			let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+			deviceLanguage = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+			app.launchArguments += ["-AppleLanguages", "(\(deviceLanguage))"]
+		} catch {
+			NSLog("Couldn't detect/set language...")
+		}
+	}
+
+	class func setLocale(_ app: XCUIApplication) {
+		guard let cacheDirectory = cacheDirectory else {
+			NSLog("CacheDirectory is not set - probably running on a physical device?")
+			return
+		}
+
+		let path = cacheDirectory.appendingPathComponent("locale.txt")
+
+		do {
+			let trimCharacterSet = CharacterSet.whitespacesAndNewlines
+			locale = try String(contentsOf: path, encoding: .utf8).trimmingCharacters(in: trimCharacterSet)
+		} catch {
+			NSLog("Couldn't detect/set locale...")
+		}
+
+		if locale.isEmpty, !deviceLanguage.isEmpty {
+			locale = Locale(identifier: deviceLanguage).identifier
+		}
+
+		if !locale.isEmpty {
+			app.launchArguments += ["-AppleLocale", "\"\(locale)\""]
+		}
+	}
+
+	class func setLaunchArguments(_ app: XCUIApplication) {
+		guard let cacheDirectory = cacheDirectory else {
+			NSLog("CacheDirectory is not set - probably running on a physical device?")
+			return
+		}
+
+		let path = cacheDirectory.appendingPathComponent("snapshot-launch_arguments.txt")
+		app.launchArguments += ["-FASTLANE_SNAPSHOT", "YES", "-ui_testing"]
+
+		do {
+			let launchArguments = try String(contentsOf: path, encoding: String.Encoding.utf8)
+			let regex = try NSRegularExpression(pattern: "(\\\".+?\\\"|\\S+)", options: [])
+			let matches = regex.matches(in: launchArguments, options: [], range: NSRange(location: 0, length: launchArguments.count))
+			let results = matches.map { result -> String in
+				(launchArguments as NSString).substring(with: result.range)
+			}
+			app.launchArguments += results
+		} catch {
+			NSLog("Couldn't detect/set launch_arguments...")
+		}
+	}
+
+	open class func snapshot(_ name: String, timeWaitingForIdle timeout: TimeInterval = 20) {
+		if timeout > 0 {
+			waitForLoadingIndicatorToDisappear(within: timeout)
+		}
+
+		NSLog("snapshot: \(name)") // more information about this, check out https://docs.fastlane.tools/actions/snapshot/#how-does-it-work
+
+		if Snapshot.waitForAnimations {
+			sleep(1) // Waiting for the animation to be finished (kind of)
+		}
+
+		#if os(OSX)
+		guard let app = app else {
+			NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+			return
+		}
+
+		app.typeKey(XCUIKeyboardKeySecondaryFn, modifierFlags: [])
+		#else
+
+		guard self.app != nil else {
+			NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+			return
+		}
+
+		let screenshot = XCUIScreen.main.screenshot()
+		#if os(iOS)
+		let image = XCUIDevice.shared.orientation.isLandscape ? fixLandscapeOrientation(image: screenshot.image) : screenshot.image
+		#else
+		let image = screenshot.image
+		#endif
+
+		guard var simulator = ProcessInfo().environment["SIMULATOR_DEVICE_NAME"], let screenshotsDir = screenshotsDirectory else { return }
+
+		do {
+			// The simulator name contains "Clone X of " inside the screenshot file when running parallelized UI Tests on concurrent devices
+			let regex = try NSRegularExpression(pattern: "Clone [0-9]+ of ")
+			let range = NSRange(location: 0, length: simulator.count)
+			simulator = regex.stringByReplacingMatches(in: simulator, range: range, withTemplate: "")
+
+			let path = screenshotsDir.appendingPathComponent("\(simulator)-\(name).png")
+			#if swift(<5.0)
+			UIImagePNGRepresentation(image)?.write(to: path, options: .atomic)
+			#else
+			try image.pngData()?.write(to: path, options: .atomic)
+			#endif
+		} catch {
+			NSLog("Problem writing screenshot: \(name) to \(screenshotsDir)/\(simulator)-\(name).png")
+			NSLog(error.localizedDescription)
+		}
+		#endif
+	}
+
+	class func fixLandscapeOrientation(image: UIImage) -> UIImage {
+		#if os(watchOS)
+		return image
+		#else
+		if #available(iOS 10.0, *) {
+			let format = UIGraphicsImageRendererFormat()
+			format.scale = image.scale
+			let renderer = UIGraphicsImageRenderer(size: image.size, format: format)
+			return renderer.image { _ in
+				image.draw(in: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
+			}
+		} else {
+			return image
+		}
+		#endif
+	}
+
+	class func waitForLoadingIndicatorToDisappear(within timeout: TimeInterval) {
+		#if os(tvOS)
+		return
+		#endif
+
+		guard let app = app else {
+			NSLog("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+			return
+		}
+
+		let networkLoadingIndicator = app.otherElements.deviceStatusBars.networkLoadingIndicators.element
+		let networkLoadingIndicatorDisappeared = XCTNSPredicateExpectation(predicate: NSPredicate(format: "exists == false"), object: networkLoadingIndicator)
+		_ = XCTWaiter.wait(for: [networkLoadingIndicatorDisappeared], timeout: timeout)
+	}
+
+	class func getCacheDirectory() throws -> URL {
+		let cachePath = "Library/Caches/tools.fastlane"
+		// on OSX config is stored in /Users/<username>/Library
+		// and on iOS/tvOS/WatchOS it's in simulator's home dir
+		#if os(OSX)
+		let homeDir = URL(fileURLWithPath: NSHomeDirectory())
+		return homeDir.appendingPathComponent(cachePath)
+		#elseif arch(i386) || arch(x86_64) || arch(arm64)
+		guard let simulatorHostHome = ProcessInfo().environment["SIMULATOR_HOST_HOME"] else {
+			throw SnapshotError.cannotFindSimulatorHomeDirectory
+		}
+		let homeDir = URL(fileURLWithPath: simulatorHostHome)
+		return homeDir.appendingPathComponent(cachePath)
+		#else
+		throw SnapshotError.cannotRunOnPhysicalDevice
+		#endif
+	}
+}
+
+private extension XCUIElementAttributes {
+	var isNetworkLoadingIndicator: Bool {
+		if hasAllowListedIdentifier { return false }
+
+		let hasOldLoadingIndicatorSize = frame.size == CGSize(width: 10, height: 20)
+		let hasNewLoadingIndicatorSize = frame.size.width.isBetween(46, and: 47) && frame.size.height.isBetween(2, and: 3)
+
+		return hasOldLoadingIndicatorSize || hasNewLoadingIndicatorSize
+	}
+
+	var hasAllowListedIdentifier: Bool {
+		let allowListedIdentifiers = ["GeofenceLocationTrackingOn", "StandardLocationTrackingOn"]
+
+		return allowListedIdentifiers.contains(identifier)
+	}
+
+	func isStatusBar(_ deviceWidth: CGFloat) -> Bool {
+		if elementType == .statusBar { return true }
+		guard frame.origin == .zero else { return false }
+
+		let oldStatusBarSize = CGSize(width: deviceWidth, height: 20)
+		let newStatusBarSize = CGSize(width: deviceWidth, height: 44)
+
+		return [oldStatusBarSize, newStatusBarSize].contains(frame.size)
+	}
+}
+
+private extension XCUIElementQuery {
+	var networkLoadingIndicators: XCUIElementQuery {
+		let isNetworkLoadingIndicator = NSPredicate { evaluatedObject, _ in
+			guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+			return element.isNetworkLoadingIndicator
+		}
+
+		return containing(isNetworkLoadingIndicator)
+	}
+
+	var deviceStatusBars: XCUIElementQuery {
+		guard let app = Snapshot.app else {
+			fatalError("XCUIApplication is not set. Please call setupSnapshot(app) before snapshot().")
+		}
+
+		let deviceWidth = app.windows.firstMatch.frame.width
+
+		let isStatusBar = NSPredicate { evaluatedObject, _ in
+			guard let element = evaluatedObject as? XCUIElementAttributes else { return false }
+
+			return element.isStatusBar(deviceWidth)
+		}
+
+		return containing(isStatusBar)
+	}
+}
+
+private extension CGFloat {
+	func isBetween(_ numberA: CGFloat, and numberB: CGFloat) -> Bool {
+		return numberA ... numberB ~= self
+	}
+}
+
+// Please don't remove the lines below
+// They are used to detect outdated configuration files
+// SnapshotHelperVersion [1.27]

--- a/Snapshots/Snapshots.swift
+++ b/Snapshots/Snapshots.swift
@@ -1,0 +1,275 @@
+//
+//  Snapshots.swift
+//  Snapshots
+//
+//  Created by Philipp Schmid on 13.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import XCTest
+
+class Snapshots: XCTestCase {
+	var app: XCUIApplication!
+	var filesApp: XCUIApplication!
+	override func setUpWithError() throws {
+		app = XCUIApplication()
+		filesApp = XCUIApplication(bundleIdentifier: "com.apple.DocumentsApp")
+
+		// In UI tests it is usually best to stop immediately when a failure occurs.
+		continueAfterFailure = false
+
+		switch UIDevice.current.userInterfaceIdiom {
+		case .pad:
+			XCUIDevice.shared.orientation = .landscapeLeft
+		default:
+			XCUIDevice.shared.orientation = .portrait
+		}
+	}
+
+	func testSnapshots() throws {
+		filesAppSnapshots()
+		mainAppSnapshots()
+	}
+
+	private func mainAppSnapshots() {
+		setupSnapshot(app)
+		app.launch()
+		switch UIDevice.current.userInterfaceIdiom {
+		case .phone:
+			iPhoneMainAppSnapshots()
+		case .pad:
+			iPadMainAppSnapshots()
+		default:
+			XCTFail("Device \(UIDevice.current.userInterfaceIdiom) not supported")
+		}
+		app.terminate()
+	}
+
+	private func iPhoneMainAppSnapshots() {
+		onboardingSnapshot()
+
+		navigateFromOnboardingToVaultList()
+		vaultListSnapshot()
+
+		navigateFromVaultListToVaultDetail()
+		vaultDetailSnapshot()
+
+		navigateFromVaultDetailToOpenExistingVault()
+		cloudServicesSnapshot()
+	}
+
+	private func iPadMainAppSnapshots() {
+		onboardingSnapshot()
+
+		navigateFromOnboardingToVaultList()
+		navigateFromVaultListToVaultDetail()
+		vaultDetailSnapshot()
+
+		navigateFromVaultDetailToOpenExistingVault()
+		cloudServicesSnapshot()
+	}
+
+	private func onboardingSnapshot() {
+		let onboardingTable = app.tables["Snapshot_OnboardingViewController"]
+		XCTAssert(onboardingTable.waitForExistence(timeout: 3.0))
+		snapshot("01-Onboarding")
+	}
+
+	private func navigateFromOnboardingToVaultList() {
+		let onboardingTable = app.tables["Snapshot_OnboardingViewController"]
+		let continueButton = onboardingTable.cells.firstMatch
+		XCTAssert(continueButton.waitForIsHittable(timeout: 3.0))
+		continueButton.tap()
+
+		let purchaseTable = app.tables["Snapshot_PurchaseViewController"]
+		let decideLaterButton = purchaseTable.cells.element(boundBy: 3)
+		XCTAssert(decideLaterButton.waitForIsHittable(timeout: 10.0))
+		decideLaterButton.tap()
+	}
+
+	private func vaultListSnapshot() {
+		let vaultListTable = app.tables["Snapshot_VaultListViewController"]
+		let workVault = vaultListTable.cells.element(boundBy: 0)
+		XCTAssert(workVault.waitForIsHittable(timeout: 3.0))
+		snapshot("02-VaultList")
+	}
+
+	private func navigateFromVaultListToVaultDetail() {
+		let vaultListTable = app.tables["Snapshot_VaultListViewController"]
+		let workVault = vaultListTable.cells.element(boundBy: 0)
+		workVault.tap()
+	}
+
+	private func vaultDetailSnapshot() {
+		let vaultDetailTableView = app.tables["Snapshot_VaultDetailViewController"]
+		XCTAssert(vaultDetailTableView.waitForExistence(timeout: 3.0))
+		snapshot("04-VaultDetail")
+	}
+
+	private func navigateFromVaultDetailToOpenExistingVault() {
+		let tablesQuery = app.tables
+		// Tap on Back
+		app.navigationBars.buttons.element(boundBy: 0).tap()
+
+		// Tap on the + symbol
+		app.navigationBars.buttons.element(boundBy: 1).tap()
+
+		// Open Existing Vault
+		let openExistingVaultButton = tablesQuery["Snapshot_AddVaultViewController"].buttons.element(boundBy: 1)
+		XCTAssert(openExistingVaultButton.waitForIsHittable(timeout: 3.0))
+		openExistingVaultButton.tap()
+	}
+
+	private func cloudServicesSnapshot() {
+		let tablesQuery = app.tables
+		XCTAssert(tablesQuery.staticTexts["Dropbox"].waitForIsHittable(timeout: 3.0))
+		snapshot("03-CloudServices")
+	}
+
+	// MARK: Files App
+
+	private func filesAppSnapshots() {
+		app.launch()
+		XCTAssert(app.wait(for: .runningForeground, timeout: 10.0))
+		app.terminate()
+		setupSnapshot(filesApp)
+		filesApp.activate()
+		switch UIDevice.current.userInterfaceIdiom {
+		case .phone:
+			iPhoneFilesAppSnapshots()
+		case .pad:
+			iPadFilesAppSnapshots()
+		default:
+			XCTFail("Device \(UIDevice.current.userInterfaceIdiom) not supported for Files app snapshots")
+		}
+		filesApp.terminate()
+	}
+
+	private func iPhoneFilesAppSnapshots() {
+		enableCryptomatorInFilesApp()
+		snapshotFilesOverview()
+
+		showFilesAppUnlock()
+		snapshotFilesAppUnlock()
+
+		closeFilesAppUnlock()
+		snapshotFilesAppDirectoryList()
+	}
+
+	private func iPadFilesAppSnapshots() {
+		enableCryptomatorInFilesApp()
+		showFilesAppUnlock()
+		snapshotFilesAppUnlock()
+
+		closeFilesAppUnlock()
+		snapshotFilesAppDirectoryList()
+	}
+
+	private func enableCryptomatorInFilesApp() {
+		XCTAssert(filesApp.wait(for: .runningForeground, timeout: 5.0))
+
+		navigateFromRecentsToFilesAppOverview()
+
+		// Tap on More Locations
+		tapMoreLocationsInFilesAppOverview()
+
+		// Enable Cryptomator as FileProvider
+		let browseCollectionView = filesApp.collectionViews["Browse View"]
+		let cryptomatorCell = browseCollectionView.cells["DOC.sidebar.item.Cryptomator"]
+		let cryptomatorCellSwitch = cryptomatorCell.switches.firstMatch
+		XCTAssert(cryptomatorCellSwitch.waitForIsHittable(timeout: 3.0))
+		cryptomatorCellSwitch.tap()
+
+		// Press Done
+		tapDoneButtonInFilesAppOverview()
+	}
+
+	private func navigateFromRecentsToFilesAppOverview() {
+		guard XCUIDevice.shared.orientation == .portrait else {
+			return
+		}
+		// Tap on Browse
+		filesApp.tabBars["DOC.browsingModeTabBar"].buttons.element(boundBy: 1).tap(withNumberOfTaps: 2, numberOfTouches: 1)
+	}
+
+	private func tapDoneButtonInFilesAppOverview() {
+		let doneButton: XCUIElement
+		switch UIDevice.current.userInterfaceIdiom {
+		case .phone:
+			doneButton = filesApp.navigationBars["FullDocumentManagerViewControllerNavigationBar"].buttons.firstMatch
+		case .pad:
+			doneButton = filesApp.navigationBars.firstMatch.buttons.element(boundBy: 1)
+		default:
+			XCTFail("Tap Done button in Files app overview is not supported for device: \(UIDevice.current.userInterfaceIdiom)")
+			return
+		}
+		XCTAssert(doneButton.waitForIsHittable(timeout: 3.0))
+		doneButton.tap()
+	}
+
+	private func tapMoreLocationsInFilesAppOverview() {
+		let index: Int
+		switch UIDevice.current.userInterfaceIdiom {
+		case .phone:
+			index = 2
+		case .pad:
+			index = 3
+		default:
+			XCTFail("Tap Done button in Files app overview is not supported for device: \(UIDevice.current.userInterfaceIdiom)")
+			return
+		}
+		let moreLocationsCell = filesApp.cells.element(boundBy: index)
+		XCTAssert(moreLocationsCell.waitForIsHittable(timeout: 3.0))
+		moreLocationsCell.tap()
+	}
+
+	private func snapshotFilesOverview() {
+		let browseCollectionView = filesApp.collectionViews["Browse View"]
+		let cryptomatorCell = browseCollectionView.cells["DOC.sidebar.item.Cryptomator"]
+		XCTAssert(cryptomatorCell.waitForIsHittable(timeout: 3.0))
+		snapshot("05-Files-Overview")
+	}
+
+	private func showFilesAppUnlock() {
+		let browseCollectionView = filesApp.collectionViews["Browse View"]
+		let cryptomatorCell = browseCollectionView.cells["DOC.sidebar.item.Cryptomator"]
+		// Start Cryptomator FileProvider
+		cryptomatorCell.tap()
+
+		// Unlock Screen
+		let vaultUnlockTableView = filesApp.tables["Snapshot_UnlockVaultViewController"]
+		XCTAssert(vaultUnlockTableView.waitForExistence(timeout: 20.0))
+
+		let passwordField = vaultUnlockTableView.textFields.firstMatch
+		passwordField.typeText("••••••••")
+	}
+
+	private func closeFilesAppUnlock() {
+		filesApp.buttons["Snapshot_UnlockButton"].tap()
+	}
+
+	private func snapshotFilesAppUnlock() {
+		sleep(1)
+		snapshot("06-Files-UnlockWithPassword")
+	}
+
+	private func snapshotFilesAppDirectoryList() {
+		let vaultRootFolderView = filesApp.collectionViews["File View"]
+		XCTAssert(vaultRootFolderView.value as? String == "Icon Mode")
+		let cryptomatorJPGFile = vaultRootFolderView.cells["Cryptomator, jpg"]
+		XCTAssert(cryptomatorJPGFile.waitForIsHittable(timeout: 10.0))
+		snapshot("07-Files-DirectoryList")
+	}
+}
+
+extension XCUIElement {
+	func waitForIsHittable(timeout: TimeInterval) -> Bool {
+		return waitForPredicate(NSPredicate(format: "isHittable == true"), timeout: timeout)
+	}
+
+	private func waitForPredicate(_ predicate: NSPredicate, timeout: TimeInterval) -> Bool {
+		let expectation = XCTNSPredicateExpectation(predicate: predicate, object: self)
+		let result = XCTWaiter.wait(for: [expectation], timeout: timeout)
+		return result == .completed
+	}
+}

--- a/Snapshots/Snapshots.swift
+++ b/Snapshots/Snapshots.swift
@@ -32,7 +32,7 @@ class Snapshots: XCTestCase {
 	}
 
 	private func mainAppSnapshots() {
-		setupSnapshot(app)
+		setupSnapshot(app, waitForAnimations: false)
 		app.launch()
 		switch UIDevice.current.userInterfaceIdiom {
 		case .phone:
@@ -80,11 +80,6 @@ class Snapshots: XCTestCase {
 		let continueButton = onboardingTable.cells.firstMatch
 		XCTAssert(continueButton.waitForIsHittable(timeout: 3.0))
 		continueButton.tap()
-
-		let purchaseTable = app.tables["Snapshot_PurchaseViewController"]
-		let decideLaterButton = purchaseTable.cells.element(boundBy: 3)
-		XCTAssert(decideLaterButton.waitForIsHittable(timeout: 10.0))
-		decideLaterButton.tap()
 	}
 
 	private func vaultListSnapshot() {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -9,6 +9,16 @@ platform :ios do
     match(type: "development", force_for_new_devices: true)
   end
 
+  desc "Create screenshots in every language with every device"
+  lane :create_screenshots do
+    snapshot()
+  end
+
+  desc "Upload screenshots to App Store Connect"
+  lane :upload_screenshots do
+    deliver(skip_binary_upload: true, skip_metadata: true, overwrite_screenshots: true, run_precheck_before_submit: false, submit_for_review: false)
+  end
+
   desc "Update metadata in App Store Connect"
   lane :update_metadata do
     deliver(skip_binary_upload: true, skip_screenshots: true, run_precheck_before_submit: false)

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -1,39 +1,64 @@
 fastlane documentation
-================
+----
+
 # Installation
 
 Make sure you have the latest version of the Xcode command line tools installed:
 
-```
+```sh
 xcode-select --install
 ```
 
-Install _fastlane_ using
-```
-[sudo] gem install fastlane -NV
-```
-or alternatively using `brew install fastlane`
+For _fastlane_ installation instructions, see [Installing _fastlane_](https://docs.fastlane.tools/#installing-fastlane)
 
 # Available Actions
+
 ## iOS
+
 ### ios certificates
+
+```sh
+[bundle exec] fastlane ios certificates
 ```
-fastlane ios certificates
-```
+
 Sync certificates and provisioning profiles for all targets
+
+### ios create_screenshots
+
+```sh
+[bundle exec] fastlane ios create_screenshots
+```
+
+Create screenshots in every language with every device
+
+### ios upload_screenshots
+
+```sh
+[bundle exec] fastlane ios upload_screenshots
+```
+
+Upload screenshots to App Store Connect
+
 ### ios update_metadata
+
+```sh
+[bundle exec] fastlane ios update_metadata
 ```
-fastlane ios update_metadata
-```
+
 Update metadata in App Store Connect
+
 ### ios beta
+
+```sh
+[bundle exec] fastlane ios beta
 ```
-fastlane ios beta
-```
+
 Submit a new internal beta build to TestFlight
 
 ----
 
 This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
-More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
-The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).
+
+More information about _fastlane_ can be found on [fastlane.tools](https://fastlane.tools).
+
+The documentation of _fastlane_ can be found on [docs.fastlane.tools](https://docs.fastlane.tools).

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,15 +1,15 @@
 # A list of devices you want to take the screenshots from
- devices([
-"iPhone 13 Pro Max",
-"iPhone 8 Plus"
-"iPad Pro (12.9-inch) (4th generation)",
-"iPad Pro (12.9-inch) (2nd generation)"
- ])
+devices([
+  "iPhone 13 Pro Max",
+  "iPhone 8 Plus",
+  "iPad Pro (12.9-inch) (4th generation)",
+  "iPad Pro (12.9-inch) (2nd generation)",
+])
 
- languages([
-   "en-US",
-   "de-DE",
- ])
+languages([
+  "en-US",
+  "de-DE",
+])
 
 # The name of the scheme which contains the UI Tests
 scheme("Snapshots")
@@ -25,7 +25,6 @@ xcargs "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) SNAPSHOTS'"
 
 # Erasing the simulator is necessary to bring the Files App to its original state
 erase_simulator(true)
-
 
 # Uncomment below for debugging
 # clear_previous_screenshots(true)

--- a/fastlane/Snapfile
+++ b/fastlane/Snapfile
@@ -1,0 +1,35 @@
+# A list of devices you want to take the screenshots from
+ devices([
+"iPhone 13 Pro Max",
+"iPhone 8 Plus"
+"iPad Pro (12.9-inch) (4th generation)",
+"iPad Pro (12.9-inch) (2nd generation)"
+ ])
+
+ languages([
+   "en-US",
+   "de-DE",
+ ])
+
+# The name of the scheme which contains the UI Tests
+scheme("Snapshots")
+
+# Set the status bar to 9:41 AM, and show full battery and reception. See also override_status_bar_arguments for custom options.
+override_status_bar(true)
+
+localize_simulator(true)
+
+disable_slide_to_type(true)
+
+xcargs "SWIFT_ACTIVE_COMPILATION_CONDITIONS='$(inherited) SNAPSHOTS'"
+
+# Erasing the simulator is necessary to bring the Files App to its original state
+erase_simulator(true)
+
+
+# Uncomment below for debugging
+# clear_previous_screenshots(true)
+# Set derived data path for faster debug builds
+# derived_data_path("")
+# Show Simualtor
+# headless(false)


### PR DESCRIPTION
This PR enables the automatic creation of snapshots via fastlane.
As we mock some data for the snapshots, we use the active compilation conditions `SNAPSHOTS` in order to not pollute the normal code base.
The active compilation condition will be set automatically when running `fastlane snapshot`.
However, if one wants to run the snapshot UI tests via Xcode, one has to manually add `SNAPSHOTS` to the active compilation conditions of each involved target (currently: `Cryptomator`, `FileProviderExtension` and `FileProviderExtensionUI`).