### PR TITLE
Added a more detailed description about upgrading from the legacy app

### DIFF
--- a/Cryptomator/Purchase/PurchaseCoordinator.swift
+++ b/Cryptomator/Purchase/PurchaseCoordinator.swift
@@ -35,7 +35,7 @@ class PurchaseCoordinator: Coordinator {
 		} else if UIApplication.shared.canOpenURL(UpgradeChecker.upgradeURL) {
 			UIApplication.shared.open(UpgradeChecker.upgradeURL)
 		} else {
-			DDLogError("Preconditions for showing upgrade screen are not met")
+			showUpgradeFailedAlert()
 		}
 	}
 
@@ -79,5 +79,23 @@ class PurchaseCoordinator: Coordinator {
 
 	func getUpgradeCoordinator() -> UpgradeCoordinator {
 		return UpgradeCoordinator(navigationController: navigationController)
+	}
+
+	private func showUpgradeFailedAlert() {
+		let alertController = UIAlertController(title: LocalizedString.getValue("upgrade.notEligible.alert.title"),
+		                                        message: LocalizedString.getValue("upgrade.notEligible.alert.message"),
+		                                        preferredStyle: .alert)
+		let okAction = UIAlertAction(title: LocalizedString.getValue("common.button.download"), style: .default) { _ in
+			self.showCryptomatorLegacyAppInAppStore()
+		}
+		alertController.addAction(okAction)
+		alertController.addAction(UIAlertAction(title: LocalizedString.getValue("common.button.cancel"), style: .cancel))
+		alertController.preferredAction = okAction
+		navigationController.present(alertController, animated: true)
+	}
+
+	private func showCryptomatorLegacyAppInAppStore() {
+		let cryptomatorLegacyAppStoreURL = URL(string: "itms-apps://apple.com/app/id953086535")!
+		UIApplication.shared.open(cryptomatorLegacyAppStoreURL)
 	}
 }

--- a/Cryptomator/Purchase/PurchaseViewModel.swift
+++ b/Cryptomator/Purchase/PurchaseViewModel.swift
@@ -70,7 +70,7 @@ class PurchaseViewModel: BaseIAPViewModel<PurchaseSection, PurchaseButtonAction>
 	private lazy var _sections: [Section<PurchaseSection>] = {
 		let sections: [Section<PurchaseSection>?] = [
 			Section(id: .emptySection, elements: []),
-			upgradeChecker.couldBeEligibleForUpgrade() ? Section(id: .upgradeSection, elements: [upgradeButtonCellViewModel]) : nil,
+			Section(id: .upgradeSection, elements: [upgradeButtonCellViewModel]),
 			Section(id: .loadingSection, elements: [loadingCellViewModel]),
 			Section(id: .restoreSection, elements: [restorePurchaseButtonCellViewModel]),
 			Section(id: .decideLaterSection, elements: [decideLaterButtonCellViewModel])
@@ -90,7 +90,11 @@ class PurchaseViewModel: BaseIAPViewModel<PurchaseSection, PurchaseButtonAction>
 	override func getFooterTitle(for section: Int) -> String? {
 		switch sections[section].id {
 		case .upgradeSection:
-			return LocalizedString.getValue("purchase.upgrade.footer")
+			if upgradeChecker.couldBeEligibleForUpgrade() {
+				return LocalizedString.getValue("purchase.upgrade.footer")
+			} else {
+				return LocalizedString.getValue("purchase.upgrade.notEligible.footer")
+			}
 		case .trialSection:
 			return LocalizedString.getValue("purchase.beginFreeTrial.footer")
 		case .purchaseSection:

--- a/CryptomatorTests/Purchase/PurchaseViewModelTests.swift
+++ b/CryptomatorTests/Purchase/PurchaseViewModelTests.swift
@@ -27,26 +27,19 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 	// MARK: Sections
 
 	func testDefaultCellViewModelsNonEligibleUpgrade() {
-		let expectedSections: [Section<PurchaseSection>] = [
-			Section(id: .emptySection, elements: []),
-			Section(id: .loadingSection, elements: [viewModel.loadingCellViewModel]),
-			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
-			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
-		]
-		XCTAssertEqual(expectedSections, viewModel.sections)
+		assertHasInitialSections(viewModel: viewModel)
+
+		let upgradeSectionFooterTitle = viewModel.getFooterTitle(for: 1)
+		XCTAssertEqual(LocalizedString.getValue("purchase.upgrade.notEligible.footer"), upgradeSectionFooterTitle)
 		XCTAssertEqual(1, upgradeCheckerMock.couldBeEligibleForUpgradeCallsCount)
 	}
 
 	func testDefaultCellViewModelsEligibleUpgrade() {
 		upgradeCheckerMock.couldBeEligibleForUpgradeReturnValue = true
-		let expectedSections: [Section<PurchaseSection>] = [
-			Section(id: .emptySection, elements: []),
-			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
-			Section(id: .loadingSection, elements: [viewModel.loadingCellViewModel]),
-			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
-			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
-		]
-		XCTAssertEqual(expectedSections, viewModel.sections)
+		assertHasInitialSections(viewModel: viewModel)
+
+		let upgradeSectionFooterTitle = viewModel.getFooterTitle(for: 1)
+		XCTAssertEqual(LocalizedString.getValue("purchase.upgrade.footer"), upgradeSectionFooterTitle)
 		XCTAssertEqual(1, upgradeCheckerMock.couldBeEligibleForUpgradeCallsCount)
 	}
 
@@ -54,6 +47,7 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 		let expectation = XCTestExpectation()
 		let expectedSections: [Section<PurchaseSection>] = [
 			Section(id: .emptySection, elements: []),
+			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
 			Section(id: .trialSection, elements: [viewModel.freeTrialButtonCellViewModel]),
 			Section(id: .purchaseSection, elements: [viewModel.purchaseButtonCellViewModel]),
 			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
@@ -74,6 +68,7 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 		let expectation = XCTestExpectation()
 		let expectedSections: [Section<PurchaseSection>] = [
 			Section(id: .emptySection, elements: []),
+			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
 			Section(id: .purchaseSection, elements: [viewModel.purchaseButtonCellViewModel]),
 			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
 			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
@@ -297,13 +292,25 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 	private func assertShowReloadSectionAfterFetchProductFailed(viewModel: PurchaseViewModel) {
 		let expectedSections: [Section<PurchaseSection>] = [
 			Section(id: .emptySection, elements: []),
+			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
 			Section(id: .retrySection, elements: [viewModel.retryButtonCellViewModel]),
 			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
 			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
 		]
 		XCTAssertEqual(expectedSections, viewModel.sections)
 		XCTAssertEqual(LocalizedString.getValue("purchase.retry.button"), viewModel.retryButtonCellViewModel.title.value)
-		XCTAssertEqual(LocalizedString.getValue("purchase.retry.footer"), viewModel.getFooterTitle(for: 1))
+		XCTAssertEqual(LocalizedString.getValue("purchase.retry.footer"), viewModel.getFooterTitle(for: 2))
+	}
+
+	private func assertHasInitialSections(viewModel: PurchaseViewModel) {
+		let expectedSections: [Section<PurchaseSection>] = [
+			Section(id: .emptySection, elements: []),
+			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
+			Section(id: .loadingSection, elements: [viewModel.loadingCellViewModel]),
+			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
+			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
+		]
+		XCTAssertEqual(expectedSections, viewModel.sections)
 	}
 }
 

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -14,6 +14,7 @@
 "common.button.create" = "Create";
 "common.button.createFolder" = "Create Folder";
 "common.button.done" = "Done";
+"common.button.download" = "Download";
 "common.button.edit" = "Edit";
 "common.button.enable" = "Enable";
 "common.button.next" = "Next";
@@ -108,6 +109,7 @@
 "purchase.infoRunningTrial" = "Your trial expires on %@ and grants you write access to your vaults for a limited time. Consider unlocking the full version after the trial.";
 "purchase.infoExpiredTrial" = "Your trial has expired. Consider unlocking the full version to regain write access to your vaults.";
 "purchase.upgrade.footer" = "Cryptomator detected an older version. You are eligible for an upgrade to unlock the full version.";
+"purchase.upgrade.notEligible.footer" = "If you already bought an older version of Cryptomator, please re-download it from the App Store.";
 "purchase.beginFreeTrial.button" = "Begin 30-Day Trial for Free";
 "purchase.beginFreeTrial.footer" = "Try out the full version of Cryptomator for a limited time for free. You can unlock this trial only once.";
 "purchase.beginFreeTrial.alert.title" = "Trial Unlocked";
@@ -161,6 +163,8 @@
 "upgrade.freeUpgrade.button" = "Upgrade for Free";
 "upgrade.freeUpgrade.footer" = "No worries, you can also upgrade to the full version for free without any limitations.";
 "upgrade.decideLater.footer" = "You can upgrade to the full version of Cryptomator later in the settings and use it in read-only mode for now.";
+"upgrade.notEligible.alert.title" = "Upgrade Failed";
+"upgrade.notEligible.alert.message" = "Cryptomator couldn't detect an older version installed on your device. If you bought it, please re-download it from the App Store and try again.";
 
 "urlSession.error.httpError.401" = "Wrong username and/or password.";
 "urlSession.error.httpError.403" = "Insufficient rights to requested resource.";

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -109,7 +109,7 @@
 "purchase.infoRunningTrial" = "Your trial expires on %@ and grants you write access to your vaults for a limited time. Consider unlocking the full version after the trial.";
 "purchase.infoExpiredTrial" = "Your trial has expired. Consider unlocking the full version to regain write access to your vaults.";
 "purchase.upgrade.footer" = "Cryptomator detected an older version. You are eligible for an upgrade to unlock the full version.";
-"purchase.upgrade.notEligible.footer" = "If you already bought an older version of Cryptomator, please re-download it from the App Store.";
+"purchase.upgrade.notEligible.footer" = "If you already bought an older version of Cryptomator, re-download it from the App Store.";
 "purchase.beginFreeTrial.button" = "Begin 30-Day Trial for Free";
 "purchase.beginFreeTrial.footer" = "Try out the full version of Cryptomator for a limited time for free. You can unlock this trial only once.";
 "purchase.beginFreeTrial.alert.title" = "Trial Unlocked";


### PR DESCRIPTION
This PR adds a more detailed description regarding the upgrade from Cryptomator 1.x to the purchase screen.
Instead of displaying the _Upgrade from Cryptomator 1.x_ button only when a user is eligible for an upgrade because he has installed the current version of Cryptomator 1.x, it is now displayed to every user.
In addition, the user is informed that if they have already purchased an older version of Cryptomator, they must update it or download it again from the App Store. 

These changes were necessary because some users thought they had to tap _Restore Purchase_ if they had already purchased Cryptomator 1.x and wanted to unlock the full version.