### PR TITLE
Feature: Improved ipad support for vault list

### DIFF
--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -78,7 +78,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		StoreObserver.shared.fallbackDelegate = coordinator
 		window = UIWindow(frame: UIScreen.main.bounds)
 		window?.tintColor = UIColor(named: "primary")
-		window?.rootViewController = navigationController
+		window?.rootViewController = coordinator?.rootViewController
 		window?.makeKeyAndVisible()
 		return true
 	}

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -68,10 +68,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		SKPaymentQueue.default().add(StoreObserver.shared)
 
 		// Create window
-		let navigationController = BaseNavigationController()
-		coordinator = MainCoordinator(navigationController: navigationController)
+		coordinator = MainCoordinator()
 		#if SNAPSHOTS
-		coordinator = SnapshotCoordinator(navigationController: navigationController)
+		coordinator = SnapshotCoordinator()
 		UIView.setAnimationsEnabled(false)
 		#endif
 		coordinator?.start()

--- a/Cryptomator/Common/BaseNavigationController.swift
+++ b/Cryptomator/Common/BaseNavigationController.swift
@@ -13,6 +13,21 @@ class BaseNavigationController: UINavigationController {
 		return .lightContent
 	}
 
+	override var modalPresentationStyle: UIModalPresentationStyle {
+		get {
+			if useDefaultModalPresentationStyle {
+				return .formSheet
+			}
+			return super.modalPresentationStyle
+		}
+		set {
+			useDefaultModalPresentationStyle = false
+			super.modalPresentationStyle = newValue
+		}
+	}
+
+	private var useDefaultModalPresentationStyle = true
+
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		let appearance = UINavigationBarAppearance()

--- a/Cryptomator/Common/Bindable.swift
+++ b/Cryptomator/Common/Bindable.swift
@@ -16,3 +16,15 @@ class Bindable<Value> {
 		self.value = value
 	}
 }
+
+extension Bindable: Equatable where Value: Equatable {
+	static func == (lhs: Bindable<Value>, rhs: Bindable<Value>) -> Bool {
+		return lhs.value == rhs.value
+	}
+}
+
+extension Bindable: Hashable where Value: Hashable {
+	func hash(into hasher: inout Hasher) {
+		hasher.combine(value)
+	}
+}

--- a/Cryptomator/Common/HeaderFooter/AttributedTextHeaderFooterView.swift
+++ b/Cryptomator/Common/HeaderFooter/AttributedTextHeaderFooterView.swift
@@ -65,14 +65,15 @@ class BindableAttributedTextHeaderFooterView: AttributedTextHeaderFooterView {
 		guard let viewModel = viewModel as? BindableAttributedTextHeaderFooterViewModel else {
 			return
 		}
+		textView.attributedText = viewModel.attributedText.value
 		viewModel.attributedText.$value.receive(on: DispatchQueue.main).sink(receiveValue: { [weak self] attributedText in
-			UIView.setAnimationsEnabled(false)
-			self?.tableView?.performBatchUpdates({
-				self?.textView.attributedText = attributedText
-				self?.textView.font = self?.textLabel?.font
-				self?.textView.textColor = self?.textLabel?.textColor
-			})
-			UIView.setAnimationsEnabled(true)
+			UIView.performWithoutAnimation {
+				self?.tableView?.performBatchUpdates({
+					self?.textView.attributedText = attributedText
+					self?.textView.font = self?.textLabel?.font
+					self?.textView.textColor = self?.textLabel?.textColor
+				})
+			}
 		}).store(in: &subscriber)
 	}
 }

--- a/Cryptomator/Common/HeaderFooter/BaseHeaderFooterView.swift
+++ b/Cryptomator/Common/HeaderFooter/BaseHeaderFooterView.swift
@@ -16,7 +16,8 @@ class BaseHeaderFooterView: UITableViewHeaderFooterView, HeaderFooterViewModelCo
 
 	func configure(with viewModel: HeaderFooterViewModel) {
 		textLabel?.numberOfLines = 0
-		subscriber = viewModel.title.$value.sink(receiveValue: { [weak self] text in
+		textLabel?.text = viewModel.title.value
+		subscriber = viewModel.title.$value.receive(on: DispatchQueue.main).sink(receiveValue: { [weak self] text in
 			UIView.setAnimationsEnabled(false)
 			self?.tableView?.performBatchUpdates({
 				self?.textLabel?.text = text

--- a/Cryptomator/Common/ListViewController.swift
+++ b/Cryptomator/Common/ListViewController.swift
@@ -20,8 +20,10 @@ class ListViewController<T: TableViewCellViewModel>: BaseUITableViewController {
 	lazy var header = EditableTableViewHeader(title: viewModel.headerTitle)
 	lazy var subscribers = Set<AnyCancellable>()
 	var dataSource: EditableDataSource<Section, T>?
-	private let viewModel: ListViewModel
+	private var viewModel: ListViewModel
 	private lazy var emptyListMessage = EmptyListMessage(message: viewModel.emptyListMessage)
+	private var firstTimeLoading = true
+	private var lastSelectedCellViewModel: T?
 
 	init(viewModel: ListViewModel) {
 		self.viewModel = viewModel
@@ -60,23 +62,22 @@ class ListViewController<T: TableViewCellViewModel>: BaseUITableViewController {
 		snapshot.appendItems(cells.compactMap({ $0 as? T }))
 		dataSource?.apply(snapshot, animatingDifferences: false) { [weak self] in
 			if snapshot.numberOfItems == 0 {
-				self?.header.isHidden = true
-				self?.tableView.backgroundView = self?.emptyListMessage
-				// Prevents `EmptyListMessage` from being placed under the navigation bar
-				self?.tableView.contentInsetAdjustmentBehavior = .never
-				self?.tableView.separatorStyle = .none
+				self?.hideHeaderAndShowEmptyListMessage()
 			} else {
 				self?.header.isHidden = false
 				self?.tableView.backgroundView = nil
 				self?.tableView.separatorStyle = .singleLine
 				self?.tableView.contentInsetAdjustmentBehavior = .automatic
+				self?.restoreSelection()
 			}
+			self?.firstTimeLoading = false
 		}
 	}
 
 	override func setEditing(_ editing: Bool, animated: Bool) {
 		super.setEditing(editing, animated: animated)
 		header.isEditing = editing
+		restoreSelection()
 	}
 
 	@objc func editButtonToggled() {
@@ -126,6 +127,10 @@ class ListViewController<T: TableViewCellViewModel>: BaseUITableViewController {
 		return configuration
 	}
 
+	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+		lastSelectedCellViewModel = dataSource?.itemIdentifier(for: indexPath)
+	}
+
 	// MARK: - Internal
 
 	func removeRow(at indexPath: IndexPath) throws {
@@ -164,6 +169,33 @@ class ListViewController<T: TableViewCellViewModel>: BaseUITableViewController {
 			}), completion: handler)
 		}.then { _ in
 			// no-op
+		}
+	}
+
+	func hideHeaderAndShowEmptyListMessage() {
+		hideHeaderAndShowEmptyListMessage(animated: !firstTimeLoading)
+	}
+
+	func hideHeaderAndShowEmptyListMessage(animated: Bool) {
+		if animated {
+			hideHeaderAnimated().then(showEmptyListMessageAnimated)
+		} else {
+			header.isHidden = true
+			tableView.backgroundView = emptyListMessage
+			// Prevents `EmptyListMessage` from being placed under the navigation bar
+			tableView.contentInsetAdjustmentBehavior = .never
+			tableView.separatorStyle = .none
+		}
+	}
+
+	private func restoreSelection() {
+		guard let splitViewController = splitViewController, !splitViewController.isCollapsed else {
+			return
+		}
+		let snapshot = dataSource?.snapshot()
+		let maybeLastSelectedCellViewModel = snapshot?.itemIdentifiers.first(where: { $0.hashValue == lastSelectedCellViewModel?.hashValue })
+		if let lastSelectedCellViewModel = maybeLastSelectedCellViewModel, let lastSelectedIndexPath = dataSource?.indexPath(for: lastSelectedCellViewModel) {
+			tableView.selectRow(at: lastSelectedIndexPath, animated: true, scrollPosition: .none)
 		}
 	}
 }

--- a/Cryptomator/Common/ListViewController.swift
+++ b/Cryptomator/Common/ListViewController.swift
@@ -20,7 +20,7 @@ class ListViewController<T: TableViewCellViewModel>: BaseUITableViewController {
 	lazy var header = EditableTableViewHeader(title: viewModel.headerTitle)
 	lazy var subscribers = Set<AnyCancellable>()
 	var dataSource: EditableDataSource<Section, T>?
-	private var viewModel: ListViewModel
+	private let viewModel: ListViewModel
 	private lazy var emptyListMessage = EmptyListMessage(message: viewModel.emptyListMessage)
 	private var firstTimeLoading = true
 	private var lastSelectedCellViewModel: T?

--- a/Cryptomator/MainCoordinator.swift
+++ b/Cryptomator/MainCoordinator.swift
@@ -11,7 +11,7 @@ import Promises
 import UIKit
 
 class MainCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
-	var navigationController: UINavigationController
+	var navigationController: UINavigationController = BaseNavigationController()
 	var childCoordinators = [Coordinator]()
 	lazy var rootViewController: UISplitViewController = {
 		let splitViewController = UISplitViewController()
@@ -21,11 +21,6 @@ class MainCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
 	}()
 
 	private weak var lastVaultInfo: VaultInfo?
-
-	init(navigationController: UINavigationController) {
-		self.navigationController = navigationController
-		super.init()
-	}
 
 	func start() {
 		let vaultListViewController = VaultListViewController(with: VaultListViewModel())

--- a/Cryptomator/MainCoordinator.swift
+++ b/Cryptomator/MainCoordinator.swift
@@ -13,15 +13,28 @@ import UIKit
 class MainCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
 	var navigationController: UINavigationController
 	var childCoordinators = [Coordinator]()
+	lazy var rootViewController: UISplitViewController = {
+		let splitViewController = UISplitViewController()
+		splitViewController.preferredDisplayMode = .oneBesideSecondary
+		splitViewController.delegate = self
+		return splitViewController
+	}()
+
+	private weak var lastVaultInfo: VaultInfo?
 
 	init(navigationController: UINavigationController) {
 		self.navigationController = navigationController
+		super.init()
 	}
 
 	func start() {
 		let vaultListViewController = VaultListViewController(with: VaultListViewModel())
 		vaultListViewController.coordinator = self
-		navigationController.pushViewController(vaultListViewController, animated: false)
+		navigationController.viewControllers = [vaultListViewController]
+		rootViewController.viewControllers = [
+			navigationController,
+			EmptyDetailViewController()
+		]
 	}
 
 	func showOnboarding() {
@@ -60,9 +73,13 @@ class MainCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
 	}
 
 	func showVaultDetail(for vaultInfo: VaultInfo) {
-		let child = VaultDetailCoordinator(vaultInfo: vaultInfo, navigationController: navigationController)
+		lastVaultInfo = vaultInfo
+		let detailNavigationController = BaseNavigationController()
+		let child = VaultDetailCoordinator(vaultInfo: vaultInfo, navigationController: detailNavigationController)
 		childCoordinators.append(child)
 		child.start()
+		child.removedVaultDelegate = self
+		rootViewController.showDetailViewController(detailNavigationController, sender: nil)
 	}
 
 	// MARK: - UINavigationControllerDelegate
@@ -77,6 +94,23 @@ class MainCoordinator: NSObject, Coordinator, UINavigationControllerDelegate {
 		if navigationController.viewControllers.contains(fromViewController) {
 			return
 		}
+	}
+
+	// MARK: - Internal
+
+	private func hideVaultDetail() {
+		rootViewController.showDetailViewController(EmptyDetailViewController(), sender: nil)
+	}
+}
+
+extension MainCoordinator: RemoveVaultDelegate {
+	func removedVault(_ vault: VaultInfo) {
+		if !rootViewController.isCollapsed, vault == lastVaultInfo {
+			hideVaultDetail()
+		} else if let navigationController = rootViewController.viewControllers.first as? UINavigationController {
+			navigationController.popToRootViewController(animated: true)
+		}
+		lastVaultInfo = nil
 	}
 }
 
@@ -117,5 +151,42 @@ extension MainCoordinator: StoreObserverDelegate {
 			}
 			return
 		}
+	}
+}
+
+extension MainCoordinator: UISplitViewControllerDelegate {
+	func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
+		return true
+	}
+}
+
+private class CryptoBotViewController: UIViewController {
+	override func viewDidLoad() {
+		super.viewDidLoad()
+		view.backgroundColor = UIColor(named: "background")
+		let imageView = UIImageView(image: UIImage(named: "bot"))
+		imageView.contentMode = .scaleAspectFit
+		imageView.translatesAutoresizingMaskIntoConstraints = false
+		view.addSubview(imageView)
+
+		NSLayoutConstraint.activate([
+			imageView.centerXAnchor.constraint(equalTo: view.layoutMarginsGuide.centerXAnchor),
+			imageView.centerYAnchor.constraint(equalTo: view.layoutMarginsGuide.centerYAnchor),
+			imageView.topAnchor.constraint(greaterThanOrEqualTo: view.layoutMarginsGuide.topAnchor),
+			imageView.bottomAnchor.constraint(lessThanOrEqualTo: view.layoutMarginsGuide.bottomAnchor),
+			imageView.leadingAnchor.constraint(greaterThanOrEqualTo: view.readableContentGuide.leadingAnchor),
+			imageView.trailingAnchor.constraint(lessThanOrEqualTo: view.readableContentGuide.trailingAnchor)
+		])
+	}
+}
+
+private class EmptyDetailViewController: BaseNavigationController {
+	init() {
+		super.init(rootViewController: CryptoBotViewController())
+	}
+
+	@available(*, unavailable)
+	required init?(coder aDecoder: NSCoder) {
+		fatalError("init(coder:) has not been implemented")
 	}
 }

--- a/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
+++ b/Cryptomator/Snapshots/SnapshotVaultListViewModel.swift
@@ -62,7 +62,7 @@ class SnapshotVaultListViewModel: VaultListViewModelProtocol {
 			let vaultListPosition = VaultListPosition(id: nil, position: index, vaultUID: vaultAccount.vaultUID)
 			let vaultInfo = VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
 			if index == 0 {
-				vaultInfo.vaultIsUnlocked = true
+				vaultInfo.vaultIsUnlocked.value = true
 			}
 			return vaultInfo
 		}

--- a/Cryptomator/VaultDetail/VaultDetailCoordinator.swift
+++ b/Cryptomator/VaultDetail/VaultDetailCoordinator.swift
@@ -18,6 +18,7 @@ class VaultDetailCoordinator: Coordinator {
 	var childCoordinators = [Coordinator]()
 
 	var navigationController: UINavigationController
+	weak var removedVaultDelegate: RemoveVaultDelegate?
 	private let vaultInfo: VaultInfo
 
 	init(vaultInfo: VaultInfo, navigationController: UINavigationController) {
@@ -71,6 +72,10 @@ class VaultDetailCoordinator: Coordinator {
 		child.start()
 	}
 
+	func removedVault() {
+		removedVaultDelegate?.removedVault(vaultInfo)
+	}
+
 	func changeVaultPassword() {
 		let maintenanceManager: MaintenanceManager
 		do {
@@ -121,4 +126,8 @@ extension VaultDetailCoordinator: VaultPasswordChanging {
 		}
 		navigationController.popViewController(animated: true)
 	}
+}
+
+protocol RemoveVaultDelegate: AnyObject {
+	func removedVault(_ vault: VaultInfo)
 }

--- a/Cryptomator/VaultDetail/VaultDetailViewController.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewController.swift
@@ -77,7 +77,7 @@ class VaultDetailViewController: BaseUITableViewController {
 			let okAction = UIAlertAction(title: LocalizedString.getValue("common.button.remove"), style: .destructive) { _ in
 				do {
 					try self.viewModel.removeVault()
-					self.navigationController?.popViewController(animated: true)
+					self.coordinator?.removedVault()
 				} catch {
 					self.coordinator?.handleError(error, for: self)
 				}

--- a/Cryptomator/VaultList/VaultCellViewModel.swift
+++ b/Cryptomator/VaultList/VaultCellViewModel.swift
@@ -28,11 +28,10 @@ class VaultCellViewModel: TableViewCellViewModel, VaultCellViewModelProtocol {
 	}
 
 	var lockButtonIsHidden: AnyPublisher<Bool, Never> {
-		return lockButtonIsHiddenPublisher.eraseToAnyPublisher()
+		return vault.vaultIsUnlocked.$value.map { !$0 }.eraseToAnyPublisher()
 	}
 
 	let vault: VaultInfo
-	private lazy var lockButtonIsHiddenPublisher = CurrentValueSubject<Bool, Never>(!vault.vaultIsUnlocked)
 	private lazy var errorPublisher = PassthroughSubject<Error, Never>()
 	private let fileProviderConnector: FileProviderConnector
 
@@ -54,12 +53,11 @@ class VaultCellViewModel: TableViewCellViewModel, VaultCellViewModelProtocol {
 	}
 
 	func setVaultUnlockStatus(unlocked: Bool) {
-		vault.vaultIsUnlocked = unlocked
-		lockButtonIsHiddenPublisher.send(!unlocked)
+		vault.vaultIsUnlocked.value = unlocked
 	}
 
 	override func hash(into hasher: inout Hasher) {
-		hasher.combine(vault)
+		hasher.combine(vault.vaultUID)
 	}
 
 	static func == (lhs: VaultCellViewModel, rhs: VaultCellViewModel) -> Bool {

--- a/Cryptomator/VaultList/VaultInfo.swift
+++ b/Cryptomator/VaultList/VaultInfo.swift
@@ -15,7 +15,7 @@ public class VaultInfo: Decodable, FetchableRecord {
 	var vaultAccount: VaultAccount
 	let cloudProviderAccount: CloudProviderAccount
 	private(set) var vaultListPosition: VaultListPosition
-	var vaultIsUnlocked = false
+	let vaultIsUnlocked = Bindable(false)
 
 	enum CodingKeys: String, CodingKey {
 		case vaultAccount

--- a/Cryptomator/VaultList/VaultListViewController.swift
+++ b/Cryptomator/VaultList/VaultListViewController.swift
@@ -82,6 +82,14 @@ class VaultListViewController: ListViewController<VaultCellViewModel> {
 		header.isEditing = editing
 	}
 
+	override func removeRow(at indexPath: IndexPath) throws {
+		guard let vaultCellViewModel = dataSource?.itemIdentifier(for: indexPath) else {
+			return
+		}
+		try super.removeRow(at: indexPath)
+		coordinator?.removedVault(vaultCellViewModel.vault)
+	}
+
 	@objc func addNewVault() {
 		setEditing(false, animated: true)
 		coordinator?.addVault()
@@ -93,7 +101,7 @@ class VaultListViewController: ListViewController<VaultCellViewModel> {
 	}
 
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-		tableView.deselectRow(at: indexPath, animated: true)
+		super.tableView(tableView, didSelectRowAt: indexPath)
 		if let vaultCellViewModel = dataSource?.itemIdentifier(for: indexPath) {
 			coordinator?.showVaultDetail(for: vaultCellViewModel.vault)
 		}

--- a/Cryptomator/VaultList/VaultListViewModel.swift
+++ b/Cryptomator/VaultList/VaultListViewModel.swift
@@ -97,7 +97,7 @@ class VaultListViewModel: ViewModel, VaultListViewModelProtocol {
 		return getProxyPromise.then { proxy in
 			proxy.lockVault(domainIdentifier: domainIdentifier)
 		}.then {
-			vaultInfo.vaultIsUnlocked = false
+			vaultInfo.vaultIsUnlocked.value = false
 		}
 	}
 

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -134,7 +134,7 @@ class VaultListViewModelTests: XCTestCase {
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		try vaultListViewModel.refreshItems()
 
-		XCTAssertTrue(vaultListViewModel.getVaults().allSatisfy({ !$0.vaultIsUnlocked }))
+		XCTAssertTrue(vaultListViewModel.getVaults().allSatisfy({ !$0.vaultIsUnlocked.value }))
 
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
@@ -147,7 +147,7 @@ class VaultListViewModelTests: XCTestCase {
 			XCTAssertEqual(NSFileProviderServiceName("org.cryptomator.ios.vault-locking"), self.fileProviderConnectorMock.passedServiceName)
 
 			XCTAssertEqual(1, vaultLockingMock.unlockedVaults.count)
-			let unlockedVaults = vaultListViewModel.getVaults().filter({ $0.vaultIsUnlocked })
+			let unlockedVaults = vaultListViewModel.getVaults().filter({ $0.vaultIsUnlocked.value })
 			XCTAssertEqual(1, unlockedVaults.count)
 			XCTAssertTrue(unlockedVaults.contains(where: { $0.vaultUID == "vault1" }))
 		}.catch { error in

--- a/Snapshots/Snapshots.swift
+++ b/Snapshots/Snapshots.swift
@@ -103,9 +103,10 @@ class Snapshots: XCTestCase {
 
 	private func navigateFromVaultDetailToOpenExistingVault() {
 		let tablesQuery = app.tables
-		// Tap on Back
-		app.navigationBars.buttons.element(boundBy: 0).tap()
-
+		if UIDevice.current.userInterfaceIdiom == .phone {
+			// Tap on Back
+			app.navigationBars.buttons.element(boundBy: 0).tap()
+		}
 		// Tap on the + symbol
 		app.navigationBars.buttons.element(boundBy: 1).tap()
 


### PR DESCRIPTION
The vault list is now displayed in a `UISplitViewController`, which allows us on the iPad to display the vault list on the left side of the screen and, if selected, the associated vault detail screen on the right side.

The flickering of the footer texts in the vault detail screen has also been fixed.