### PR TITLE
Feature: Show device-specific enrolled biometrics within snapshots

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -2481,7 +2481,6 @@
 		4A136129276767D60077EB7F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2493,8 +2492,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Snapshots/Snapshots-Bridging-Header.h";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Debug;
@@ -2502,7 +2499,6 @@
 		4A13612A276767D60077EB7F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2514,7 +2510,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "Snapshots/Snapshots-Bridging-Header.h";
-				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Release;

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		4A53CC15267CC33100853BB3 /* CreateNewVaultPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A53CC14267CC33100853BB3 /* CreateNewVaultPasswordViewModel.swift */; };
 		4A53CC17267CDBFF00853BB3 /* CreateNewVaultChooseFolderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A53CC16267CDBFF00853BB3 /* CreateNewVaultChooseFolderViewModel.swift */; };
 		4A5580552755226100E525B8 /* StoreObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5580542755226100E525B8 /* StoreObserverTests.swift */; };
+		4A5811602779E1E000E89A62 /* SnapshotBiometrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 4A58115F2779E1E000E89A62 /* SnapshotBiometrics.m */; };
 		4A5AC4392758EC9400342AA7 /* FullVersionCheckerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AC4382758EC9400342AA7 /* FullVersionCheckerMock.swift */; };
 		4A5AC43B2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AC43A2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift */; };
 		4A5AC43D275A306F00342AA7 /* TrialExpiredNavigationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5AC43C275A306F00342AA7 /* TrialExpiredNavigationController.swift */; };
@@ -563,6 +564,9 @@
 		4A53CC14267CC33100853BB3 /* CreateNewVaultPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewVaultPasswordViewModel.swift; sourceTree = "<group>"; };
 		4A53CC16267CDBFF00853BB3 /* CreateNewVaultChooseFolderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateNewVaultChooseFolderViewModel.swift; sourceTree = "<group>"; };
 		4A5580542755226100E525B8 /* StoreObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreObserverTests.swift; sourceTree = "<group>"; };
+		4A58115D2779E1B700E89A62 /* Snapshots-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Snapshots-Bridging-Header.h"; sourceTree = "<group>"; };
+		4A58115E2779E1B700E89A62 /* SnapshotBiometrics.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SnapshotBiometrics.h; sourceTree = "<group>"; };
+		4A58115F2779E1E000E89A62 /* SnapshotBiometrics.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SnapshotBiometrics.m; sourceTree = "<group>"; };
 		4A5AC4382758EC9400342AA7 /* FullVersionCheckerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullVersionCheckerMock.swift; sourceTree = "<group>"; };
 		4A5AC43A2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift; sourceTree = "<group>"; };
 		4A5AC43C275A306F00342AA7 /* TrialExpiredNavigationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrialExpiredNavigationController.swift; sourceTree = "<group>"; };
@@ -868,6 +872,9 @@
 			children = (
 				4A13612C276768000077EB7F /* SnapshotHelper.swift */,
 				4A136123276767D60077EB7F /* Snapshots.swift */,
+				4A58115E2779E1B700E89A62 /* SnapshotBiometrics.h */,
+				4A58115F2779E1E000E89A62 /* SnapshotBiometrics.m */,
+				4A58115D2779E1B700E89A62 /* Snapshots-Bridging-Header.h */,
 			);
 			path = Snapshots;
 			sourceTree = "<group>";
@@ -1799,6 +1806,7 @@
 				TargetAttributes = {
 					4A136120276767D60077EB7F = {
 						CreatedOnToolsVersion = 13.1;
+						LastSwiftMigration = 1320;
 						TestTargetID = 4AE97DA724572E4900452814;
 					};
 					4A2245CF24A5E16300DBA437 = {
@@ -2021,6 +2029,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4A5811602779E1E000E89A62 /* SnapshotBiometrics.m in Sources */,
 				4A136124276767D60077EB7F /* Snapshots.swift in Sources */,
 				4A13612D276768000077EB7F /* SnapshotHelper.swift in Sources */,
 			);
@@ -2472,6 +2481,7 @@
 		4A136129276767D60077EB7F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2482,6 +2492,9 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Snapshots/Snapshots-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Debug;
@@ -2489,6 +2502,7 @@
 		4A13612A276767D60077EB7F /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = YZQJQUHA3L;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2499,6 +2513,8 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = org.cryptomator.ios.snapshots;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Snapshots/Snapshots-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
 				TEST_TARGET_NAME = Cryptomator;
 			};
 			name = Release;

--- a/Cryptomator/Snapshots/SnapshotCoordinator.swift
+++ b/Cryptomator/Snapshots/SnapshotCoordinator.swift
@@ -10,6 +10,7 @@
 import CryptomatorCommonCore
 import FileProvider
 import Foundation
+import LocalAuthentication
 import Promises
 import UIKit
 
@@ -32,7 +33,7 @@ class SnapshotCoordinator: MainCoordinator {
 	override func showVaultDetail(for vaultInfo: VaultInfo) {
 		let snapshotFileProviderConnectorMock = SnapshotFileProviderConnectorMock()
 		snapshotFileProviderConnectorMock.proxy = SnapshotVaultLockingMock()
-		let viewModel = VaultDetailViewModel(vaultInfo: vaultInfo, vaultManager: VaultDBManager.shared, fileProviderConnector: snapshotFileProviderConnectorMock, passwordManager: VaultPasswordKeychainManager(), dbManager: DatabaseManager.shared)
+		let viewModel = VaultDetailViewModel(vaultInfo: vaultInfo, vaultManager: VaultDBManager.shared, fileProviderConnector: snapshotFileProviderConnectorMock, passwordManager: SnapshotVaultPasswordManagerMock(), dbManager: DatabaseManager.shared)
 		let vaultDetailViewController = VaultDetailViewController(viewModel: viewModel)
 		let detailNavigationController = BaseNavigationController(rootViewController: vaultDetailViewController)
 		rootViewController.showDetailViewController(detailNavigationController, sender: nil)
@@ -89,6 +90,20 @@ private class SnapshotVaultLockingMock: VaultLocking {
 
 	func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
 		fatalError()
+	}
+}
+
+class SnapshotVaultPasswordManagerMock: VaultPasswordManager {
+	func setPassword(_ password: String, forVaultUID vaultUID: String) throws {}
+
+	func getPassword(forVaultUID vaultUID: String, context: LAContext) throws -> String {
+		return ""
+	}
+
+	func removePassword(forVaultUID vaultUID: String) throws {}
+
+	func hasPassword(forVaultUID vaultUID: String) throws -> Bool {
+		return true
 	}
 }
 

--- a/FileProviderExtensionUI/Snapshots/FileProviderCoordinatorSnapshotMock.swift
+++ b/FileProviderExtensionUI/Snapshots/FileProviderCoordinatorSnapshotMock.swift
@@ -18,7 +18,6 @@ class FileProviderCoordinatorSnapshotMock: FileProviderCoordinator {
 		UnlockVaultViewController.changeUnlock
 		UnlockVaultViewController.setSnapshotAccessibilityIdentifier
 		UITextField.changePasswordFielCell
-		LAContext.activateFaceID
 		super.init(extensionContext: extensionContext, hostViewController: hostViewController)
 	}
 
@@ -92,28 +91,6 @@ extension UITextField {
 	@objc func swizzled_layoutSubviews() {
 		swizzled_layoutSubviews()
 		isSecureTextEntry = false
-	}
-}
-
-extension LAContext {
-	static let activateFaceID: Void = {
-		guard let originalMethod = class_getInstanceMethod(LAContext.self, #selector(canEvaluatePolicy(_:error:))),
-		      let swizzledMethod = class_getInstanceMethod(LAContext.self, #selector(swizzled_canEvaluatePolicy(_:error:)))
-		else { return }
-		method_exchangeImplementations(originalMethod, swizzledMethod)
-
-		guard let originalMethod2 = class_getInstanceMethod(LAContext.self, #selector(getter: biometryType)),
-		      let swizzledMethod2 = class_getInstanceMethod(LAContext.self, #selector(swizzled_getBiometryType))
-		else { return }
-		method_exchangeImplementations(originalMethod2, swizzledMethod2)
-	}()
-
-	@objc func swizzled_canEvaluatePolicy(_ policy: LAPolicy, error: NSErrorPointer) -> Bool {
-		return true
-	}
-
-	@objc func swizzled_getBiometryType() -> LABiometryType {
-		return .faceID
 	}
 }
 #endif

--- a/Snapshots/SnapshotBiometrics.h
+++ b/Snapshots/SnapshotBiometrics.h
@@ -1,0 +1,17 @@
+//
+//  SnapshotBiometrics.h
+//  Snapshots
+//
+//  Created by Philipp Schmid on 27.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SnapshotBiometrics: NSObject
++ (void)enrolled;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Snapshots/SnapshotBiometrics.h
+++ b/Snapshots/SnapshotBiometrics.h
@@ -10,8 +10,10 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface SnapshotBiometrics: NSObject
+@interface SnapshotBiometrics : NSObject
+
 + (void)enrolled;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Snapshots/SnapshotBiometrics.m
+++ b/Snapshots/SnapshotBiometrics.m
@@ -1,0 +1,21 @@
+//
+//  SnapshotBiometrics.m
+//  Snapshots
+//
+//  Created by Philipp Schmid on 27.12.21.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "notify.h"
+#import "SnapshotBiometrics.h"
+
+// Taken from: https://github.com/KaneCheshire/BiometricAutomationDemo/blob/main/BiometricsAutomationDemoUITests/Biometrics.m
+@implementation SnapshotBiometrics
++ (void) enrolled {
+	int token;
+	notify_register_check("com.apple.BiometricKit.enrollmentChanged", &token);
+	notify_set_state(token, 1);
+	notify_post("com.apple.BiometricKit.enrollmentChanged");
+}
+@end

--- a/Snapshots/SnapshotBiometrics.m
+++ b/Snapshots/SnapshotBiometrics.m
@@ -12,10 +12,12 @@
 
 // Taken from: https://github.com/KaneCheshire/BiometricAutomationDemo/blob/main/BiometricsAutomationDemoUITests/Biometrics.m
 @implementation SnapshotBiometrics
-+ (void) enrolled {
+
++ (void)enrolled {
 	int token;
 	notify_register_check("com.apple.BiometricKit.enrollmentChanged", &token);
 	notify_set_state(token, 1);
 	notify_post("com.apple.BiometricKit.enrollmentChanged");
 }
+
 @end

--- a/Snapshots/Snapshots-Bridging-Header.h
+++ b/Snapshots/Snapshots-Bridging-Header.h
@@ -1,0 +1,5 @@
+//
+//  Use this file to import your target's public headers that you would like to expose to Swift.
+//
+
+#import "SnapshotBiometrics.h"

--- a/Snapshots/Snapshots.swift
+++ b/Snapshots/Snapshots.swift
@@ -27,6 +27,7 @@ class Snapshots: XCTestCase {
 	}
 
 	func testSnapshots() throws {
+		enableBiometrics()
 		filesAppSnapshots()
 		mainAppSnapshots()
 	}
@@ -255,6 +256,10 @@ class Snapshots: XCTestCase {
 		let cryptomatorJPGFile = vaultRootFolderView.cells["Cryptomator, jpg"]
 		XCTAssert(cryptomatorJPGFile.waitForIsHittable(timeout: 10.0))
 		snapshot("07-Files-DirectoryList")
+	}
+
+	private func enableBiometrics() {
+		SnapshotBiometrics.enrolled()
 	}
 }
 


### PR DESCRIPTION
Adds the ability to display the correct biometric authentication (Touch ID or Face ID) for the device to the screenshot mocks.
This is done by enrolling the simulator programmatically for biometric authentication by setting  `com.apple.BiometricKit.enrollmentChanged` to `true` via a Darwin notification (see this [blog post](https://medium.com/kinandcartacreated/so-you-want-to-automate-ios-biometrics-81bd015f5d38) and the corresponding [repository](https://github.com/KaneCheshire/BiometricAutomationDemo) for more details).