### PR TITLE
Bugfix: remove item from working set after `startProvidingItem` has been called

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -47,6 +47,8 @@
 		4A1EB0D8268A6DE1006D072B /* AddLocalVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0D7268A6DE1006D072B /* AddLocalVaultViewController.swift */; };
 		4A2060CB2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */; };
 		4A2060CD2799645300DA6C62 /* FileProviderNotificatorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */; };
+		4A2060D1279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */; };
+		4A2060D3279AB38A00DA6C62 /* FileProviderNotificatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */; };
 		4A21B49226BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */; };
 		4A21B49426BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */; };
 		4A21B49626BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */; };
@@ -492,6 +494,8 @@
 		4A1EB0D7268A6DE1006D072B /* AddLocalVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLocalVaultViewController.swift; sourceTree = "<group>"; };
 		4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemUpdateDelegateMock.swift; sourceTree = "<group>"; };
 		4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorManager.swift; sourceTree = "<group>"; };
+		4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorManagerMock.swift; sourceTree = "<group>"; };
+		4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorMock.swift; sourceTree = "<group>"; };
 		4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedTextHeaderFooterView.swift; sourceTree = "<group>"; };
 		4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableAttributedTextHeaderFooterViewModel.swift; sourceTree = "<group>"; };
 		4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetailInfoFooterViewModel.swift; sourceTree = "<group>"; };
@@ -1429,6 +1433,8 @@
 				4AE791CB278F16BD00525913 /* VaultKeepUnlockedHelperMock.swift */,
 				4AE791CD278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift */,
 				4AB6A891278EFC730016B01E /* VaultManagerMock.swift */,
+				4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */,
+				4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2117,6 +2123,7 @@
 				4A248229266E2DD6002D9F59 /* FileProviderAdapterCreateDirectoryTests.swift in Sources */,
 				4A123EA824BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift in Sources */,
 				4A2060CB2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift in Sources */,
+				4A2060D1279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift in Sources */,
 				4AB6A892278EFC730016B01E /* VaultManagerMock.swift in Sources */,
 				4A511D492660EE3F000A0E01 /* DeletionTaskExecutorTests.swift in Sources */,
 				4A797F9624AC9936007DDBE1 /* CloudProviderMock.swift in Sources */,
@@ -2133,6 +2140,7 @@
 				4A24822F266FACF1002D9F59 /* FileProviderAdapterEnumerateItemTests.swift in Sources */,
 				4A4A3864253F2B1900EE3828 /* CachedFileManagerTests.swift in Sources */,
 				4AFE6AA82514B65800A4A315 /* CloudPath+NameCollision.swift in Sources */,
+				4A2060D3279AB38A00DA6C62 /* FileProviderNotificatorMock.swift in Sources */,
 				4A4F47F324B875070033328B /* URL+NameCollisionExtensionTests.swift in Sources */,
 				4AB6A894278F048D0016B01E /* FileProviderAdapterCacheTypeMock.swift in Sources */,
 				4A1673E8270C675B0075C724 /* FileProviderCacheManagerTests.swift in Sources */,

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -45,6 +45,8 @@
 		4A1EB0D02689C7F8006D072B /* DetectedVaultFailureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0CF2689C7F8006D072B /* DetectedVaultFailureView.swift */; };
 		4A1EB0D5268A5AA3006D072B /* VaultDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0D4268A5AA3006D072B /* VaultDetector.swift */; };
 		4A1EB0D8268A6DE1006D072B /* AddLocalVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1EB0D7268A6DE1006D072B /* AddLocalVaultViewController.swift */; };
+		4A2060CB2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */; };
+		4A2060CD2799645300DA6C62 /* FileProviderNotificatorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */; };
 		4A21B49226BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */; };
 		4A21B49426BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */; };
 		4A21B49626BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */; };
@@ -488,6 +490,8 @@
 		4A1EB0CF2689C7F8006D072B /* DetectedVaultFailureView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetectedVaultFailureView.swift; sourceTree = "<group>"; };
 		4A1EB0D4268A5AA3006D072B /* VaultDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetector.swift; sourceTree = "<group>"; };
 		4A1EB0D7268A6DE1006D072B /* AddLocalVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddLocalVaultViewController.swift; sourceTree = "<group>"; };
+		4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemUpdateDelegateMock.swift; sourceTree = "<group>"; };
+		4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorManager.swift; sourceTree = "<group>"; };
 		4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedTextHeaderFooterView.swift; sourceTree = "<group>"; };
 		4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableAttributedTextHeaderFooterViewModel.swift; sourceTree = "<group>"; };
 		4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetailInfoFooterViewModel.swift; sourceTree = "<group>"; };
@@ -1418,6 +1422,7 @@
 				4A123EA724BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift */,
 				4AB6A893278F048D0016B01E /* FileProviderAdapterCacheTypeMock.swift */,
 				4AB6A895278F07B20016B01E /* FileProviderAdapterTypeMock.swift */,
+				4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */,
 				4A5AC4382758EC9400342AA7 /* FullVersionCheckerMock.swift */,
 				4AB6A898278F084E0016B01E /* MaintenanceManagerMock.swift */,
 				4AE791C9278F168E00525913 /* MasterkeyCacheManagerMock.swift */,
@@ -1558,6 +1563,7 @@
 				740375F32587AEB50023FF53 /* FileProviderItem.swift */,
 				740375FC2587AEB50023FF53 /* FileProviderItemList.swift */,
 				740375F02587AEB40023FF53 /* FileProviderNotificator.swift */,
+				4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */,
 				740375F42587AEB50023FF53 /* ItemStatus.swift */,
 				4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
@@ -2110,6 +2116,7 @@
 				4A49FABE271ECDE80069A0CC /* ItemEnumerationTaskManagerTests.swift in Sources */,
 				4A248229266E2DD6002D9F59 /* FileProviderAdapterCreateDirectoryTests.swift in Sources */,
 				4A123EA824BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift in Sources */,
+				4A2060CB2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift in Sources */,
 				4AB6A892278EFC730016B01E /* VaultManagerMock.swift in Sources */,
 				4A511D492660EE3F000A0E01 /* DeletionTaskExecutorTests.swift in Sources */,
 				4A797F9624AC9936007DDBE1 /* CloudProviderMock.swift in Sources */,
@@ -2422,6 +2429,7 @@
 				4A511D512661000F000A0E01 /* WorkflowFactory.swift in Sources */,
 				4A1673EA270C77CC0075C724 /* DocumentStorageURLProvider.swift in Sources */,
 				747F2F222587BC250072FB30 /* ItemMetadata.swift in Sources */,
+				4A2060CD2799645300DA6C62 /* FileProviderNotificatorManager.swift in Sources */,
 				4A49FABA271ECA530069A0CC /* ItemEnumerationTaskRecord.swift in Sources */,
 				4AE0D8DE2653F18900DF5D22 /* DeletionTaskExecutor.swift in Sources */,
 				4AE0D8DA2653D90C00DF5D22 /* ItemEnumerationTaskExecutor.swift in Sources */,

--- a/CryptomatorFileProvider/FileProviderNotificator.swift
+++ b/CryptomatorFileProvider/FileProviderNotificator.swift
@@ -11,26 +11,87 @@ import FileProvider
 import Foundation
 
 public class FileProviderNotificator: FileProviderItemUpdateDelegate {
-	public var fileProviderSignalDeleteContainerItemIdentifier = [NSFileProviderItemIdentifier: NSFileProviderItemIdentifier]()
-	public var fileProviderSignalUpdateContainerItem = [NSFileProviderItemIdentifier: FileProviderItem]()
-	public var fileProviderSignalDeleteWorkingSetItemIdentifier = [NSFileProviderItemIdentifier: NSFileProviderItemIdentifier]()
-	public var fileProviderSignalUpdateWorkingSetItem = [NSFileProviderItemIdentifier: FileProviderItem]()
+	private var signalDeleteContainerItemIdentifier = Set<NSFileProviderItemIdentifier>()
+	private var signalUpdateContainerItem = [NSFileProviderItemIdentifier: NSFileProviderItem]()
+	private var signalDeleteWorkingSetItemIdentifier = Set<NSFileProviderItemIdentifier>()
+	private var signalUpdateWorkingSetItem = [NSFileProviderItemIdentifier: NSFileProviderItem]()
 
-	public private(set) var currentAnchor: UInt64
+	/**
+	 The current sync anchor for all FileProviderEnumerators.
+
+	 The current anchor is the date and time of the `signalEnumerator` call as this guarantees us a different sync anchor each time  `signalEnumerator` gets called.
+	 This is necessary as `finishEnumeratingChanges(upTo:, moreComing:)` expects "[...] that the sync anchor passed here be different than the sync
+	 anchor that the enumeration started at, unless the client was already up to
+	 date on all the changes on the server, and didn't have any pending updates or deletions." (from the SDK documentation).
+	 */
+	public var currentSyncAnchor: Data {
+		do {
+			return try JSONEncoder().encode(currentAnchor)
+		} catch {
+			return Data()
+		}
+	}
+
+	private(set) var currentAnchor: Date
+	private var invalidateWorkingSetCount = 0
+
+	private let queue = DispatchQueue(label: "FileProviderNotificator", attributes: .concurrent)
 
 	private let manager: NSFileProviderManager
 
 	public init(manager: NSFileProviderManager) {
 		self.manager = manager
-		self.currentAnchor = 0
+		self.currentAnchor = Date()
+	}
+
+	public func invalidatedWorkingSet() {
+		queue.sync(flags: .barrier) {
+			signalDeleteContainerItemIdentifier.removeAll()
+			signalUpdateWorkingSetItem.removeAll()
+		}
+	}
+
+	public func refreshWorkingSet() {
+		signalEnumerator(for: [.workingSet])
+	}
+
+	public func getItemIdentifiersToDeleteFromWorkingSet() -> [NSFileProviderItemIdentifier] {
+		return queue.sync {
+			return Array(signalDeleteWorkingSetItemIdentifier)
+		}
+	}
+
+	public func popDeleteContainerItemIdentifiers() -> [NSFileProviderItemIdentifier] {
+		return queue.sync(flags: .barrier) {
+			let identifiers = Array(signalDeleteContainerItemIdentifier)
+			signalDeleteContainerItemIdentifier.removeAll()
+			return identifiers
+		}
+	}
+
+	public func popUpdateWorkingSetItems() -> [NSFileProviderItem] {
+		return queue.sync(flags: .barrier) {
+			let items = signalUpdateWorkingSetItem.map { $0.value }
+			signalUpdateWorkingSetItem.removeAll()
+			return items
+		}
+	}
+
+	public func popUpdateContainerItems() -> [NSFileProviderItem] {
+		return queue.sync(flags: .barrier) {
+			let items = signalUpdateContainerItem.map { $0.value }
+			signalUpdateContainerItem.removeAll()
+			return items
+		}
 	}
 
 	/**
 	 Signal the enumerator with a small delay of 0.2 seconds, because otherwise some items in the `FileProvider` are not updated correctly.
 	 */
 	public func signalEnumerator(for containerItemIdentifiers: [NSFileProviderItemIdentifier]) {
+		DDLogDebug("Signal enumerator for: \(containerItemIdentifiers)")
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-			self.currentAnchor += 1
+			self.currentAnchor = Date()
 			for containerItemIdentifier in containerItemIdentifiers {
 				self.manager.signalEnumerator(for: containerItemIdentifier) { error in
 					if let error = error {
@@ -41,12 +102,31 @@ public class FileProviderNotificator: FileProviderItemUpdateDelegate {
 		}
 	}
 
-	func signalUpdate(for item: FileProviderItem) {
-		fileProviderSignalUpdateContainerItem[item.itemIdentifier] = item
+	func signalUpdate(for item: NSFileProviderItem) {
+		appendItemToUpdateContainer(item)
 		signalEnumerator(for: [item.parentItemIdentifier, item.itemIdentifier])
+	}
+
+	func removeItemFromWorkingSet(with identifier: NSFileProviderItemIdentifier) {
+		appendIdentifierToDeleteWorkingSet(identifier)
+		signalEnumerator(for: [.workingSet])
+	}
+
+	private func appendIdentifierToDeleteWorkingSet(_ identifier: NSFileProviderItemIdentifier) {
+		queue.sync(flags: .barrier) {
+			_ = signalDeleteWorkingSetItemIdentifier.insert(identifier)
+		}
+	}
+
+	private func appendItemToUpdateContainer(_ item: NSFileProviderItem) {
+		queue.sync(flags: .barrier) {
+			signalUpdateContainerItem[item.itemIdentifier] = item
+		}
 	}
 }
 
 protocol FileProviderItemUpdateDelegate: AnyObject {
-	func signalUpdate(for item: FileProviderItem)
+	func signalUpdate(for item: NSFileProviderItem)
+	func removeItemFromWorkingSet(with identifier: NSFileProviderItemIdentifier)
+	func refreshWorkingSet()
 }

--- a/CryptomatorFileProvider/FileProviderNotificatorManager.swift
+++ b/CryptomatorFileProvider/FileProviderNotificatorManager.swift
@@ -10,7 +10,7 @@ import FileProvider
 import Foundation
 
 protocol FileProviderNotificatorManagerType {
-	func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificator
+	func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificatorType
 }
 
 enum FileProviderNotificatorManagerError: Error {
@@ -20,9 +20,9 @@ enum FileProviderNotificatorManagerError: Error {
 public class FileProviderNotificatorManager: FileProviderNotificatorManagerType {
 	public static let shared = FileProviderNotificatorManager()
 	private let queue = DispatchQueue(label: "FileProviderNotificatorManager")
-	private var cache = [NSFileProviderDomainIdentifier: FileProviderNotificator]()
+	private var cache = [NSFileProviderDomainIdentifier: FileProviderNotificatorType]()
 
-	public func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificator {
+	public func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificatorType {
 		let domainIdentifier = domain.identifier
 		return try queue.sync {
 			if let cachedNotificator = cache[domainIdentifier] {

--- a/CryptomatorFileProvider/FileProviderNotificatorManager.swift
+++ b/CryptomatorFileProvider/FileProviderNotificatorManager.swift
@@ -1,0 +1,39 @@
+//
+//  FileProviderNotificatorManager.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 20.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+protocol FileProviderNotificatorManagerType {
+	func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificator
+}
+
+enum FileProviderNotificatorManagerError: Error {
+	case fileProviderManagerInitError
+}
+
+public class FileProviderNotificatorManager: FileProviderNotificatorManagerType {
+	public static let shared = FileProviderNotificatorManager()
+	private let queue = DispatchQueue(label: "FileProviderNotificatorManager")
+	private var cache = [NSFileProviderDomainIdentifier: FileProviderNotificator]()
+
+	public func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificator {
+		let domainIdentifier = domain.identifier
+		return try queue.sync {
+			if let cachedNotificator = cache[domainIdentifier] {
+				return cachedNotificator
+			}
+			guard let manager = NSFileProviderManager(for: domain) else {
+				throw FileProviderNotificatorManagerError.fileProviderManagerInitError
+			}
+			let notificator = FileProviderNotificator(manager: manager)
+			cache[domainIdentifier] = notificator
+			return notificator
+		}
+	}
+}

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
@@ -34,6 +34,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		assertItemRemovedFromWorkingSet()
 	}
 
 	func testStartProvidingItemWithUpToDateLocalVersion() throws {
@@ -47,6 +48,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		assertItemRemovedFromWorkingSet()
 	}
 
 	func testStartProvidingItemWithOlderLocalVersion() throws {
@@ -63,6 +65,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		assertItemRemovedFromWorkingSet()
 	}
 
 	func testStartProvidingItemWithConflictingLocalVersion() throws {
@@ -114,6 +117,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		assertItemRemovedFromWorkingSet()
 	}
 
 	func assertNewestVersionDownloaded(localURL: URL, cloudPath: CloudPath, itemID: Int64) {
@@ -127,11 +131,16 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 		let lastModifiedDate = localCachedFileInfo?.lastModifiedDate
 		XCTAssertNotNil(lastModifiedDate)
 		XCTAssertEqual(cloudProviderMock.lastModifiedDate[cloudPath.path], lastModifiedDate)
+		assertItemRemovedFromWorkingSet()
 	}
 
 	func assertMetadataUpdated() {
 		XCTAssertEqual(1, metadataManagerMock.updatedMetadata.count)
 		XCTAssertEqual(ItemStatus.isUploaded, metadataManagerMock.updatedMetadata[0].statusCode)
+	}
+
+	private func assertItemRemovedFromWorkingSet() {
+		XCTAssertEqual([String(itemID)], fileProviderItemUpdateDelegateMock.removeItemFromWorkingSetWithReceivedInvocations.map { $0.rawValue })
 	}
 
 	private func simulateExistingLocalFileByDownloadingFile() {
@@ -142,6 +151,9 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		assertItemRemovedFromWorkingSet()
+		// Reset fileProviderItemUpdateDelegateMock
+		fileProviderItemUpdateDelegateMock.removeItemFromWorkingSetWithReceivedInvocations = []
 	}
 
 	private func simulateFileChangeInTheCloud() {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -15,12 +15,26 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	var adapter: FileProviderAdapter!
 	var localURLProviderMock: LocalURLProviderMock!
 	var fullVersionCheckerMock: FullVersionCheckerMock!
+	var fileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegateMock!
+
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		localURLProviderMock = LocalURLProviderMock()
+		fileProviderItemUpdateDelegateMock = FileProviderItemUpdateDelegateMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
-		adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowScheduler(maxParallelUploads: 1, maxParallelDownloads: 1), provider: cloudProviderMock, localURLProvider: localURLProviderMock, fullVersionChecker: fullVersionCheckerMock)
+		adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock,
+		                              cachedFileManager: cachedFileManagerMock,
+		                              itemMetadataManager: metadataManagerMock,
+		                              reparentTaskManager: reparentTaskManagerMock,
+		                              deletionTaskManager: deletionTaskManagerMock,
+		                              itemEnumerationTaskManager: itemEnumerationTaskManagerMock,
+		                              downloadTaskManager: downloadTaskManagerMock,
+		                              scheduler: WorkflowScheduler(maxParallelUploads: 1, maxParallelDownloads: 1),
+		                              provider: cloudProviderMock,
+		                              notificator: fileProviderItemUpdateDelegateMock,
+		                              localURLProvider: localURLProviderMock,
+		                              fullVersionChecker: fullVersionCheckerMock)
 	}
 
 	class LocalURLProviderMock: LocalURLProvider {

--- a/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
@@ -1,0 +1,63 @@
+//
+//  FileProviderItemUpdateDelegateMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 19.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@testable import CryptomatorFileProvider
+
+final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
+	// MARK: - signalUpdate
+
+	var signalUpdateForCallsCount = 0
+	var signalUpdateForCalled: Bool {
+		signalUpdateForCallsCount > 0
+	}
+
+	var signalUpdateForReceivedItem: NSFileProviderItem?
+	var signalUpdateForReceivedInvocations: [NSFileProviderItem] = []
+	var signalUpdateForClosure: ((NSFileProviderItem) -> Void)?
+
+	func signalUpdate(for item: NSFileProviderItem) {
+		signalUpdateForCallsCount += 1
+		signalUpdateForReceivedItem = item
+		signalUpdateForReceivedInvocations.append(item)
+		signalUpdateForClosure?(item)
+	}
+
+	// MARK: - removeItemFromWorkingSet
+
+	var removeItemFromWorkingSetWithCallsCount = 0
+	var removeItemFromWorkingSetWithCalled: Bool {
+		removeItemFromWorkingSetWithCallsCount > 0
+	}
+
+	var removeItemFromWorkingSetWithReceivedIdentifier: NSFileProviderItemIdentifier?
+	var removeItemFromWorkingSetWithReceivedInvocations: [NSFileProviderItemIdentifier] = []
+	var removeItemFromWorkingSetWithClosure: ((NSFileProviderItemIdentifier) -> Void)?
+
+	func removeItemFromWorkingSet(with identifier: NSFileProviderItemIdentifier) {
+		removeItemFromWorkingSetWithCallsCount += 1
+		removeItemFromWorkingSetWithReceivedIdentifier = identifier
+		removeItemFromWorkingSetWithReceivedInvocations.append(identifier)
+		removeItemFromWorkingSetWithClosure?(identifier)
+	}
+
+	// MARK: - refreshWorkingSet
+
+	var refreshWorkingSetCallsCount = 0
+	var refreshWorkingSetCalled: Bool {
+		refreshWorkingSetCallsCount > 0
+	}
+
+	var refreshWorkingSetClosure: (() -> Void)?
+
+	func refreshWorkingSet() {
+		refreshWorkingSetCallsCount += 1
+		refreshWorkingSetClosure?()
+	}
+}

--- a/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorManagerMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorManagerMock.swift
@@ -1,0 +1,36 @@
+//
+//  FileProviderNotificatorManagerMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 21.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@testable import CryptomatorFileProvider
+
+final class FileProviderNotificatorManagerTypeMock: FileProviderNotificatorManagerType {
+	// MARK: - getFileProviderNotificator
+
+	var getFileProviderNotificatorForThrowableError: Error?
+	var getFileProviderNotificatorForCallsCount = 0
+	var getFileProviderNotificatorForCalled: Bool {
+		getFileProviderNotificatorForCallsCount > 0
+	}
+
+	var getFileProviderNotificatorForReceivedDomain: NSFileProviderDomain?
+	var getFileProviderNotificatorForReceivedInvocations: [NSFileProviderDomain] = []
+	var getFileProviderNotificatorForReturnValue: FileProviderNotificatorType!
+	var getFileProviderNotificatorForClosure: ((NSFileProviderDomain) throws -> FileProviderNotificatorType)?
+
+	func getFileProviderNotificator(for domain: NSFileProviderDomain) throws -> FileProviderNotificatorType {
+		if let error = getFileProviderNotificatorForThrowableError {
+			throw error
+		}
+		getFileProviderNotificatorForCallsCount += 1
+		getFileProviderNotificatorForReceivedDomain = domain
+		getFileProviderNotificatorForReceivedInvocations.append(domain)
+		return try getFileProviderNotificatorForClosure.map({ try $0(domain) }) ?? getFileProviderNotificatorForReturnValue
+	}
+}

--- a/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorMock.swift
@@ -1,0 +1,149 @@
+//
+//  FileProviderNotificatorMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 21.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorFileProvider
+import FileProvider
+import Foundation
+
+// swiftlint:disable all
+public final class FileProviderNotificatorTypeMock: FileProviderNotificatorType {
+	// MARK: - currentSyncAnchor
+
+	public var currentSyncAnchor: Data {
+		get { underlyingCurrentSyncAnchor }
+		set(value) { underlyingCurrentSyncAnchor = value }
+	}
+
+	private var underlyingCurrentSyncAnchor: Data!
+
+	// MARK: - invalidatedWorkingSet
+
+	var invalidatedWorkingSetCallsCount = 0
+	var invalidatedWorkingSetCalled: Bool {
+		invalidatedWorkingSetCallsCount > 0
+	}
+
+	var invalidatedWorkingSetClosure: (() -> Void)?
+
+	public func invalidatedWorkingSet() {
+		invalidatedWorkingSetCallsCount += 1
+		invalidatedWorkingSetClosure?()
+	}
+
+	// MARK: - getItemIdentifiersToDeleteFromWorkingSet
+
+	var getItemIdentifiersToDeleteFromWorkingSetCallsCount = 0
+	var getItemIdentifiersToDeleteFromWorkingSetCalled: Bool {
+		getItemIdentifiersToDeleteFromWorkingSetCallsCount > 0
+	}
+
+	var getItemIdentifiersToDeleteFromWorkingSetReturnValue: [NSFileProviderItemIdentifier]!
+	var getItemIdentifiersToDeleteFromWorkingSetClosure: (() -> [NSFileProviderItemIdentifier])?
+
+	public func getItemIdentifiersToDeleteFromWorkingSet() -> [NSFileProviderItemIdentifier] {
+		getItemIdentifiersToDeleteFromWorkingSetCallsCount += 1
+		return getItemIdentifiersToDeleteFromWorkingSetClosure.map({ $0() }) ?? getItemIdentifiersToDeleteFromWorkingSetReturnValue
+	}
+
+	// MARK: - popDeleteContainerItemIdentifiers
+
+	var popDeleteContainerItemIdentifiersCallsCount = 0
+	var popDeleteContainerItemIdentifiersCalled: Bool {
+		popDeleteContainerItemIdentifiersCallsCount > 0
+	}
+
+	var popDeleteContainerItemIdentifiersReturnValue: [NSFileProviderItemIdentifier]!
+	var popDeleteContainerItemIdentifiersClosure: (() -> [NSFileProviderItemIdentifier])?
+
+	public func popDeleteContainerItemIdentifiers() -> [NSFileProviderItemIdentifier] {
+		popDeleteContainerItemIdentifiersCallsCount += 1
+		return popDeleteContainerItemIdentifiersClosure.map({ $0() }) ?? popDeleteContainerItemIdentifiersReturnValue
+	}
+
+	// MARK: - popUpdateWorkingSetItems
+
+	var popUpdateWorkingSetItemsCallsCount = 0
+	var popUpdateWorkingSetItemsCalled: Bool {
+		popUpdateWorkingSetItemsCallsCount > 0
+	}
+
+	var popUpdateWorkingSetItemsReturnValue: [NSFileProviderItem]!
+	var popUpdateWorkingSetItemsClosure: (() -> [NSFileProviderItem])?
+
+	public func popUpdateWorkingSetItems() -> [NSFileProviderItem] {
+		popUpdateWorkingSetItemsCallsCount += 1
+		return popUpdateWorkingSetItemsClosure.map({ $0() }) ?? popUpdateWorkingSetItemsReturnValue
+	}
+
+	// MARK: - popUpdateContainerItems
+
+	var popUpdateContainerItemsCallsCount = 0
+	var popUpdateContainerItemsCalled: Bool {
+		popUpdateContainerItemsCallsCount > 0
+	}
+
+	var popUpdateContainerItemsReturnValue: [NSFileProviderItem]!
+	var popUpdateContainerItemsClosure: (() -> [NSFileProviderItem])?
+
+	public func popUpdateContainerItems() -> [NSFileProviderItem] {
+		popUpdateContainerItemsCallsCount += 1
+		return popUpdateContainerItemsClosure.map({ $0() }) ?? popUpdateContainerItemsReturnValue
+	}
+
+	// MARK: - signalUpdate
+
+	var signalUpdateForCallsCount = 0
+	var signalUpdateForCalled: Bool {
+		signalUpdateForCallsCount > 0
+	}
+
+	var signalUpdateForReceivedItem: NSFileProviderItem?
+	var signalUpdateForReceivedInvocations: [NSFileProviderItem] = []
+	var signalUpdateForClosure: ((NSFileProviderItem) -> Void)?
+
+	public func signalUpdate(for item: NSFileProviderItem) {
+		signalUpdateForCallsCount += 1
+		signalUpdateForReceivedItem = item
+		signalUpdateForReceivedInvocations.append(item)
+		signalUpdateForClosure?(item)
+	}
+
+	// MARK: - removeItemFromWorkingSet
+
+	var removeItemFromWorkingSetWithCallsCount = 0
+	var removeItemFromWorkingSetWithCalled: Bool {
+		removeItemFromWorkingSetWithCallsCount > 0
+	}
+
+	var removeItemFromWorkingSetWithReceivedIdentifier: NSFileProviderItemIdentifier?
+	var removeItemFromWorkingSetWithReceivedInvocations: [NSFileProviderItemIdentifier] = []
+	var removeItemFromWorkingSetWithClosure: ((NSFileProviderItemIdentifier) -> Void)?
+
+	public func removeItemFromWorkingSet(with identifier: NSFileProviderItemIdentifier) {
+		removeItemFromWorkingSetWithCallsCount += 1
+		removeItemFromWorkingSetWithReceivedIdentifier = identifier
+		removeItemFromWorkingSetWithReceivedInvocations.append(identifier)
+		removeItemFromWorkingSetWithClosure?(identifier)
+	}
+
+	// MARK: - refreshWorkingSet
+
+	var refreshWorkingSetCallsCount = 0
+	var refreshWorkingSetCalled: Bool {
+		refreshWorkingSetCallsCount > 0
+	}
+
+	var refreshWorkingSetClosure: (() -> Void)?
+
+	public func refreshWorkingSet() {
+		refreshWorkingSetCallsCount += 1
+		refreshWorkingSetClosure?()
+	}
+}
+
+// swiftlint:enable all

--- a/FileProviderExtension/FileProviderEnumerator.swift
+++ b/FileProviderExtension/FileProviderEnumerator.swift
@@ -14,15 +14,13 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 	private let enumeratedItemIdentifier: NSFileProviderItemIdentifier
 	private let notificator: FileProviderNotificator
 	private let domain: NSFileProviderDomain
-	private let manager: NSFileProviderManager
 	private let dbPath: URL
 	private weak var localURLProvider: LocalURLProvider?
 
-	init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificator, domain: NSFileProviderDomain, manager: NSFileProviderManager, dbPath: URL, localURLProvider: LocalURLProvider?) {
+	init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificator, domain: NSFileProviderDomain, dbPath: URL, localURLProvider: LocalURLProvider?) {
 		self.enumeratedItemIdentifier = enumeratedItemIdentifier
 		self.notificator = notificator
 		self.domain = domain
-		self.manager = manager
 		self.dbPath = dbPath
 		self.localURLProvider = localURLProvider
 		super.init()
@@ -55,22 +53,19 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 		 - inform the observer about the items returned by the server (possibly multiple times)
 		 - inform the observer that you are finished with this page
 		 */
-		DDLogDebug("enumerateItems called for identifier: \(enumeratedItemIdentifier)")
+
 		var pageToken: String?
 		if page != NSFileProviderPage.initialPageSortedByDate as NSFileProviderPage, page != NSFileProviderPage.initialPageSortedByName as NSFileProviderPage {
-			pageToken = String(data: page.rawValue, encoding: .utf8)!
+			pageToken = String(data: page.rawValue, encoding: .utf8)
 		}
+		DDLogDebug("enumerateItems called for identifier: \(enumeratedItemIdentifier) - initialPage \(pageToken == nil)")
 		DispatchQueue.global(qos: .userInitiated).async {
 			FileProviderAdapterManager.shared.semaphore.wait()
 			let adapter: FileProviderAdapterType
 			do {
 				adapter = try FileProviderAdapterManager.shared.getAdapter(forDomain: self.domain, dbPath: self.dbPath, delegate: self.localURLProvider, notificator: self.notificator)
 			} catch {
-				DDLogError("enumerateItems getAdapter failed with: \(error) for identifier: \(self.enumeratedItemIdentifier)")
-				DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
-					let wrappedError = ErrorWrapper.wrapError(error, domain: self.domain)
-					observer.finishEnumeratingWithError(wrappedError)
-				}
+				self.handleEnumerateItemsError(error, for: observer)
 				return
 			}
 			adapter.enumerateItems(for: self.enumeratedItemIdentifier, withPageToken: pageToken).then { itemList in
@@ -94,44 +89,54 @@ class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 		 - inform the observer when you have finished enumerating up to a subsequent sync anchor
 		 */
 
-		DDLogDebug("FPExt: enumerate now changes for: \(enumeratedItemIdentifier)")
+		DDLogDebug("Enumerate changes for: \(enumeratedItemIdentifier.rawValue)")
 		var itemsDelete = [NSFileProviderItemIdentifier]()
-		var itemsUpdate = [FileProviderItem]()
+		var itemsUpdate = [NSFileProviderItem]()
 
 		// Report the deleted items
 		if enumeratedItemIdentifier == .workingSet {
-			for (itemIdentifier, _) in notificator.fileProviderSignalDeleteWorkingSetItemIdentifier {
-				itemsDelete.append(itemIdentifier)
-			}
-			notificator.fileProviderSignalDeleteWorkingSetItemIdentifier.removeAll()
+			itemsDelete.append(contentsOf: notificator.getItemIdentifiersToDeleteFromWorkingSet())
+			DDLogDebug("Remove \(itemsDelete.count) items from the working set")
 		} else {
-			for (itemIdentifier, _) in notificator.fileProviderSignalDeleteContainerItemIdentifier {
-				itemsDelete.append(itemIdentifier)
-			}
-			notificator.fileProviderSignalDeleteContainerItemIdentifier.removeAll()
+			itemsDelete.append(contentsOf: notificator.popDeleteContainerItemIdentifiers())
 		}
 
 		// Report the updated items
 		if enumeratedItemIdentifier == .workingSet {
-			for (_, item) in notificator.fileProviderSignalUpdateWorkingSetItem {
-				itemsUpdate.append(item)
-			}
-			notificator.fileProviderSignalUpdateWorkingSetItem.removeAll()
+			itemsUpdate.append(contentsOf: notificator.popUpdateWorkingSetItems())
 		} else {
-			for (_, item) in notificator.fileProviderSignalUpdateContainerItem {
-				itemsUpdate.append(item)
-			}
-			notificator.fileProviderSignalUpdateContainerItem.removeAll()
+			itemsUpdate.append(contentsOf: notificator.popUpdateContainerItems())
 		}
 		observer.didDeleteItems(withIdentifiers: itemsDelete)
 		observer.didUpdate(itemsUpdate)
 
-		let data = "\(notificator.currentAnchor)".data(using: .utf8)
-		observer.finishEnumeratingChanges(upTo: NSFileProviderSyncAnchor(data!), moreComing: false)
+		let syncAnchor = NSFileProviderSyncAnchor(notificator.currentSyncAnchor)
+		observer.finishEnumeratingChanges(upTo: syncAnchor, moreComing: false)
 	}
 
 	func currentSyncAnchor(completionHandler: @escaping (NSFileProviderSyncAnchor?) -> Void) {
-		let data = "\(notificator.currentAnchor)".data(using: .utf8)
-		completionHandler(NSFileProviderSyncAnchor(data!))
+		let syncAnchor = NSFileProviderSyncAnchor(notificator.currentSyncAnchor)
+		completionHandler(syncAnchor)
+	}
+
+	/**
+	 Handle errors from `enumerateItems(for:, startingAt:)` calls.
+
+	 If this gets called for an working set enumerator, the working set cache gets invalidated by calling `finishEnumeratingWithError` with `NSFileProviderErrorSyncAnchorExpired`.
+	 Invalidating the working set cache is necessary as otherwise recently accessed items can be found in the global siri search even if the vault is locked.
+
+	 For all other enumerators the error gets wrapped and reported with 1s delay as the Files app has problems with too fast reporting of an `notAuthenticated` error.
+	 */
+	private func handleEnumerateItemsError(_ error: Error, for observer: NSFileProviderEnumerationObserver) {
+		DDLogError("enumerateItems getAdapter failed with: \(error) for identifier: \(enumeratedItemIdentifier)")
+		guard enumeratedItemIdentifier != .workingSet else {
+			observer.finishEnumeratingWithError(NSFileProviderError(.syncAnchorExpired))
+			notificator.invalidatedWorkingSet()
+			return
+		}
+		DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + 1) {
+			let wrappedError = ErrorWrapper.wrapError(error, domain: self.domain)
+			observer.finishEnumeratingWithError(wrappedError)
+		}
 	}
 }

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -17,7 +17,7 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 	var observation: NSKeyValueObservation?
 	var managerFoo: NSFileProviderManager?
 	var dbPath: URL?
-	var notificator: FileProviderNotificator?
+	var notificator: FileProviderNotificatorType?
 	static var databaseError: Error?
 	static var sharedDatabaseInitialized = false
 	override init() {

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -15,7 +15,7 @@ import MSAL
 
 class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 	var observation: NSKeyValueObservation?
-	var manager: NSFileProviderManager?
+	var managerFoo: NSFileProviderManager?
 	var dbPath: URL?
 	var notificator: FileProviderNotificator?
 	static var databaseError: Error?
@@ -62,6 +62,8 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 	}
 
 	deinit {
+		DDLogDebug("Deinit called for \(String(describing: domain))")
+		notificator?.refreshWorkingSet()
 		observation?.invalidate()
 	}
 
@@ -228,12 +230,12 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 		#else
 		// TODO: Change error handling here
 		DDLogDebug("FPExt: enumerator(for: \(containerItemIdentifier)) called")
-		guard let manager = manager, let domain = domain, let dbPath = dbPath, let notificator = notificator else {
+		guard let domain = domain, let dbPath = dbPath, let notificator = notificator else {
 			// no domain ==> no installed vault
 			DDLogError("enumerator(for: \(containerItemIdentifier)) failed as the extension is not initialized")
 			throw NSFileProviderError(.notAuthenticated)
 		}
-		return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier, notificator: notificator, domain: domain, manager: manager, dbPath: dbPath, localURLProvider: self)
+		return FileProviderEnumerator(enumeratedItemIdentifier: containerItemIdentifier, notificator: notificator, domain: domain, dbPath: dbPath, localURLProvider: self)
 		#endif
 	}
 
@@ -242,11 +244,11 @@ class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 			guard let manager = NSFileProviderManager(for: domain) else {
 				throw FileProviderDecoratorSetupError.fileProviderManagerIsNil
 			}
-			self.manager = manager
 			let dbPath = manager.documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true).appendingPathComponent("db.sqlite")
 			self.dbPath = dbPath
-			let notificator = FileProviderNotificator(manager: manager)
+			let notificator = try FileProviderNotificatorManager.shared.getFileProviderNotificator(for: domain)
 			self.notificator = notificator
+			notificator.refreshWorkingSet()
 		} else {
 			DDLogInfo("setUpDecorator called with nil domain")
 			throw FileProviderDecoratorSetupError.domainIsNil

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -15,7 +15,6 @@ import MSAL
 
 class FileProviderExtension: NSFileProviderExtension, LocalURLProvider {
 	var observation: NSKeyValueObservation?
-	var managerFoo: NSFileProviderManager?
 	var dbPath: URL?
 	var notificator: FileProviderNotificatorType?
 	static var databaseError: Error?

--- a/FileProviderExtension/VaultLockingServiceSource.swift
+++ b/FileProviderExtension/VaultLockingServiceSource.swift
@@ -44,7 +44,7 @@ class VaultLockingServiceSource: NSObject, NSFileProviderServiceSource, NSXPCLis
 	// MARK: - VaultLocking
 
 	func lockVault(domainIdentifier: NSFileProviderDomainIdentifier) {
-		FileProviderAdapterManager.shared.lockVault(with: domainIdentifier)
+		FileProviderAdapterManager.shared.forceLockVault(with: domainIdentifier)
 		DDLogInfo("Locked vault \(domainIdentifier.rawValue)")
 	}
 


### PR DESCRIPTION
This PR prevents previously viewed items from being visible in the Siri search and thus fixes #153.

To counter timing issues, whenever the working set gets refreshed, all `NSFileProviderItemIdentifiers` of the items called since the last lock are removed from the working set. 

Additionally, the complete cache of the working set is invalidated as soon as the vault gets locked.