### PR TITLE
Feature: set favorite and tags

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -211,6 +211,9 @@
 		4A9BED64268F1DB000721BAA /* VaultUnlockingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */; };
 		4A9BED66268F2D9D00721BAA /* UnlockVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */; };
 		4A9BED67268F379300721BAA /* libCryptomatorFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */; };
+		4A9C8DFD27A007C2000063E4 /* FileProviderNotificatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C8DFC27A007C2000063E4 /* FileProviderNotificatorTests.swift */; };
+		4A9C8E0127A0104E000063E4 /* EnumerationSignalingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C8E0027A0104E000063E4 /* EnumerationSignalingMock.swift */; };
+		4A9C8E0327A016CF000063E4 /* WorkingSetObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C8E0227A016CF000063E4 /* WorkingSetObserverTests.swift */; };
 		4A9CD5622699C23D00E6C104 /* VaultPasswordKeychainManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9CD5612699C23D00E6C104 /* VaultPasswordKeychainManagerTests.swift */; };
 		4A9D1237261DAC5D00A670E2 /* WebDAVAuthenticationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9D1236261DAC5D00A670E2 /* WebDAVAuthenticationViewModel.swift */; };
 		4A9D123F261E1DD400A670E2 /* WebDAVAuthenticating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9D123E261E1DD400A670E2 /* WebDAVAuthenticating.swift */; };
@@ -666,6 +669,9 @@
 		4A91D8CD272ADC78003F8BD8 /* ChangePasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangePasswordViewModel.swift; sourceTree = "<group>"; };
 		4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockingServiceSource.swift; sourceTree = "<group>"; };
 		4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockVaultViewController.swift; sourceTree = "<group>"; };
+		4A9C8DFC27A007C2000063E4 /* FileProviderNotificatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorTests.swift; sourceTree = "<group>"; };
+		4A9C8E0027A0104E000063E4 /* EnumerationSignalingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EnumerationSignalingMock.swift; sourceTree = "<group>"; };
+		4A9C8E0227A016CF000063E4 /* WorkingSetObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetObserverTests.swift; sourceTree = "<group>"; };
 		4A9CD5612699C23D00E6C104 /* VaultPasswordKeychainManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultPasswordKeychainManagerTests.swift; sourceTree = "<group>"; };
 		4A9D1236261DAC5D00A670E2 /* WebDAVAuthenticationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVAuthenticationViewModel.swift; sourceTree = "<group>"; };
 		4A9D123E261E1DD400A670E2 /* WebDAVAuthenticating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVAuthenticating.swift; sourceTree = "<group>"; };
@@ -995,8 +1001,10 @@
 				4A1673E7270C675B0075C724 /* FileProviderCacheManagerTests.swift */,
 				4AEECD38279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift */,
 				4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */,
+				4A9C8DFC27A007C2000063E4 /* FileProviderNotificatorTests.swift */,
 				4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */,
 				4A4F47F224B875070033328B /* URL+NameCollisionExtensionTests.swift */,
+				4A9C8E0227A016CF000063E4 /* WorkingSetObserverTests.swift */,
 				4AF69E2924ACCED000A7174C /* DB */,
 				4A8F14A3266A302E00ADBCE4 /* FileProviderAdapter */,
 				4AB1C32E265CF59100DC7A49 /* Middleware */,
@@ -1456,6 +1464,7 @@
 				4AB6A891278EFC730016B01E /* VaultManagerMock.swift */,
 				4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */,
 				4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */,
+				4A9C8E0027A0104E000063E4 /* EnumerationSignalingMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -2180,18 +2189,21 @@
 				4A511D5326615439000A0E01 /* ReparentTaskExecutorTests.swift in Sources */,
 				4A248227266E27C5002D9F59 /* FolderCreationTaskExecutorTests.swift in Sources */,
 				4AE791CE278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift in Sources */,
+				4A9C8DFD27A007C2000063E4 /* FileProviderNotificatorTests.swift in Sources */,
 				4AB1C325265CE69700DC7A49 /* DownloadTaskExecutorTests.swift in Sources */,
 				4AEECD3B279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift in Sources */,
 				4A8F149C266A29E400ADBCE4 /* OnlineItemNameCollisionHandlerTests.swift in Sources */,
 				4A8F14A2266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift in Sources */,
 				4A3E2FEC271DC9670090BD44 /* MaintenanceManagerTests.swift in Sources */,
 				4A717CD924C835740048E08F /* ReparentTaskManagerTests.swift in Sources */,
+				4A9C8E0327A016CF000063E4 /* WorkingSetObserverTests.swift in Sources */,
 				4AB1C33A265E9D8600DC7A49 /* UploadTaskExecutorTests.swift in Sources */,
 				4A2245DC24A5E1C600DBA437 /* MetadataManagerTests.swift in Sources */,
 				4AB6A896278F07B20016B01E /* FileProviderAdapterTypeMock.swift in Sources */,
 				4AEECD39279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift in Sources */,
 				4A797F8F24AC6731007DDBE1 /* FileProviderItemTests.swift in Sources */,
 				4A5AC4392758EC9400342AA7 /* FullVersionCheckerMock.swift in Sources */,
+				4A9C8E0127A0104E000063E4 /* EnumerationSignalingMock.swift in Sources */,
 				4AEECD2F279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift in Sources */,
 				4AEECD3D279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift in Sources */,
 			);

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		4A2060CD2799645300DA6C62 /* FileProviderNotificatorManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */; };
 		4A2060D1279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */; };
 		4A2060D3279AB38A00DA6C62 /* FileProviderNotificatorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */; };
+		4A2060D5279AF67C00DA6C62 /* WorkingSetObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2060D4279AF67C00DA6C62 /* WorkingSetObserver.swift */; };
 		4A21B49226BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */; };
 		4A21B49426BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */; };
 		4A21B49626BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */; };
@@ -219,7 +220,6 @@
 		4AA22C16261CA8D800A17486 /* URLFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA22C15261CA8D800A17486 /* URLFieldCell.swift */; };
 		4AA22C1E261CA94700A17486 /* UsernameFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA22C1D261CA94700A17486 /* UsernameFieldCell.swift */; };
 		4AA621D9249A6A8400A0BCBD /* FileProviderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */; };
-		4AA621DD249A6A8400A0BCBD /* FileProviderEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA621DC249A6A8400A0BCBD /* FileProviderEnumerator.swift */; };
 		4AA8613725C19D4F002A59F5 /* DetectedMasterkeyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA8613625C19D4F002A59F5 /* DetectedMasterkeyViewModel.swift */; };
 		4AA8614825C1C670002A59F5 /* OpenExistingVaultChooseFolderViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA8614725C1C670002A59F5 /* OpenExistingVaultChooseFolderViewController.swift */; };
 		4AA8615125C1DB5E002A59F5 /* OpenExistingVaultPasswordViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA8615025C1DB5E002A59F5 /* OpenExistingVaultPasswordViewController.swift */; };
@@ -271,6 +271,15 @@
 		4AEBE8C726540EBF0031487F /* MovingItemPathLockHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEBE8C626540EBF0031487F /* MovingItemPathLockHandler.swift */; };
 		4AEE468F25263B2E0045DA9F /* FileProviderExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4AEE469225263B2E0045DA9F /* FileProviderExtensionUI.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621E4249A6A8400A0BCBD /* FileProviderExtensionUI.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4AEECD2F279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */; };
+		4AEECD31279EA50D00C6E2B5 /* WorkingSetObservingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */; };
+		4AEECD33279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */; };
+		4AEECD35279EB0FD00C6E2B5 /* FileProviderEnumerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD34279EB0FD00C6E2B5 /* FileProviderEnumerator.swift */; };
+		4AEECD37279EB15400C6E2B5 /* ErrorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD36279EB15400C6E2B5 /* ErrorWrapper.swift */; };
+		4AEECD39279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD38279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift */; };
+		4AEECD3B279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD3A279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift */; };
+		4AEECD3D279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */; };
+		4AEECD3F279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD3E279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift */; };
 		4AEFF7F227145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */; };
 		4AEFF7F427145CB500D6CB99 /* LogLevelUpdatingServiceSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */; };
 		4AEFF7F627145F5A00D6CB99 /* FileProviderConnectorMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEFF7F527145F5A00D6CB99 /* FileProviderConnectorMock.swift */; };
@@ -295,7 +304,6 @@
 		4AFCE53A25B9D6A60069C4FC /* CloudAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFCE53925B9D6A60069C4FC /* CloudAuthenticator.swift */; };
 		4AFCE56A25BAEE890069C4FC /* AccountListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFCE56925BAEE890069C4FC /* AccountListViewModelTests.swift */; };
 		4AFD8C0F269304A700F77BA6 /* UnlockVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */; };
-		4AFD8C112693204900F77BA6 /* ErrorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFD8C102693204900F77BA6 /* ErrorWrapper.swift */; };
 		4AFE6AA82514B65800A4A315 /* CloudPath+NameCollision.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFE6AA72514B65800A4A315 /* CloudPath+NameCollision.swift */; };
 		4AFF1BB1272C337A00F41E1B /* XCTest+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFF1BB0272C337A00F41E1B /* XCTest+Combine.swift */; };
 		740376292587AFF70023FF53 /* libCryptomatorFileProvider.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */; };
@@ -496,6 +504,7 @@
 		4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorManager.swift; sourceTree = "<group>"; };
 		4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorManagerMock.swift; sourceTree = "<group>"; };
 		4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderNotificatorMock.swift; sourceTree = "<group>"; };
+		4A2060D4279AF67C00DA6C62 /* WorkingSetObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetObserver.swift; sourceTree = "<group>"; };
 		4A21B49126BBFFE9000D13DF /* AttributedTextHeaderFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttributedTextHeaderFooterView.swift; sourceTree = "<group>"; };
 		4A21B49326BC0127000D13DF /* BindableAttributedTextHeaderFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableAttributedTextHeaderFooterViewModel.swift; sourceTree = "<group>"; };
 		4A21B49526BC0270000D13DF /* VaultDetailInfoFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetailInfoFooterViewModel.swift; sourceTree = "<group>"; };
@@ -669,7 +678,6 @@
 		4AA22C1D261CA94700A17486 /* UsernameFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameFieldCell.swift; sourceTree = "<group>"; };
 		4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FileProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderExtension.swift; sourceTree = "<group>"; };
-		4AA621DC249A6A8400A0BCBD /* FileProviderEnumerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumerator.swift; sourceTree = "<group>"; };
 		4AA621DE249A6A8400A0BCBD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		4AA621DF249A6A8400A0BCBD /* FileProviderExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FileProviderExtension.entitlements; sourceTree = "<group>"; };
 		4AA621E4249A6A8400A0BCBD /* FileProviderExtensionUI.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FileProviderExtensionUI.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -731,6 +739,15 @@
 		4AEBE8BD2653F4280031487F /* UploadTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTaskExecutor.swift; sourceTree = "<group>"; };
 		4AEBE8C12653FAD40031487F /* WorkflowMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowMiddleware.swift; sourceTree = "<group>"; };
 		4AEBE8C626540EBF0031487F /* MovingItemPathLockHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovingItemPathLockHandler.swift; sourceTree = "<group>"; };
+		4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetTagDataTests.swift; sourceTree = "<group>"; };
+		4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetObservingMock.swift; sourceTree = "<group>"; };
+		4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetFavoriteRankTests.swift; sourceTree = "<group>"; };
+		4AEECD34279EB0FD00C6E2B5 /* FileProviderEnumerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumerator.swift; sourceTree = "<group>"; };
+		4AEECD36279EB15400C6E2B5 /* ErrorWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWrapper.swift; sourceTree = "<group>"; };
+		4AEECD38279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderEnumeratorTests.swift; sourceTree = "<group>"; };
+		4AEECD3A279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSFileProviderEnumerationObserverMock.swift; sourceTree = "<group>"; };
+		4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterProvidingMock.swift; sourceTree = "<group>"; };
+		4AEECD3E279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NSFileProviderChangeObserverMock.swift; sourceTree = "<group>"; };
 		4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelUpdatingServiceSource.swift; sourceTree = "<group>"; };
 		4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogLevelUpdatingServiceSourceTests.swift; sourceTree = "<group>"; };
 		4AEFF7F527145F5A00D6CB99 /* FileProviderConnectorMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderConnectorMock.swift; sourceTree = "<group>"; };
@@ -755,7 +772,6 @@
 		4AFCE53925B9D6A60069C4FC /* CloudAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudAuthenticator.swift; sourceTree = "<group>"; };
 		4AFCE56925BAEE890069C4FC /* AccountListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListViewModelTests.swift; sourceTree = "<group>"; };
 		4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockVaultViewModel.swift; sourceTree = "<group>"; };
-		4AFD8C102693204900F77BA6 /* ErrorWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorWrapper.swift; sourceTree = "<group>"; };
 		4AFE6AA72514B65800A4A315 /* CloudPath+NameCollision.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CloudPath+NameCollision.swift"; sourceTree = "<group>"; };
 		4AFF1BB0272C337A00F41E1B /* XCTest+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTest+Combine.swift"; sourceTree = "<group>"; };
 		740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCryptomatorFileProvider.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -977,6 +993,7 @@
 				4AFE6AA72514B65800A4A315 /* CloudPath+NameCollision.swift */,
 				4AB6A88F278E1E5D0016B01E /* FileProviderAdapterManagerTests.swift */,
 				4A1673E7270C675B0075C724 /* FileProviderCacheManagerTests.swift */,
+				4AEECD38279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift */,
 				4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */,
 				4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */,
 				4A4F47F224B875070033328B /* URL+NameCollisionExtensionTests.swift */,
@@ -1303,8 +1320,10 @@
 				4A8F149F266A2FD500ADBCE4 /* FileProviderAdapterGetItemTests.swift */,
 				4A248220266B8D37002D9F59 /* FileProviderAdapterImportDocumentTests.swift */,
 				4A24822A266E362C002D9F59 /* FileProviderAdapterMoveItemTests.swift */,
-				4A248230266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift */,
+				4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */,
+				4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */,
 				4A5AC43A2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift */,
+				4A248230266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift */,
 				4A8F14A1266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift */,
 			);
 			path = FileProviderAdapter;
@@ -1366,9 +1385,7 @@
 				4AE7D79325826A0900C5E1D8 /* FileProviderValidationServiceSource.h */,
 				4AE7D79425826A0900C5E1D8 /* FileProviderValidationServiceSource.m */,
 				4AA621DE249A6A8400A0BCBD /* Info.plist */,
-				4AFD8C102693204900F77BA6 /* ErrorWrapper.swift */,
 				4AD0F61B24AF203F0026B765 /* FileProvider+Actions.swift */,
-				4AA621DC249A6A8400A0BCBD /* FileProviderEnumerator.swift */,
 				4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */,
 				4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */,
 				4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */,
@@ -1427,14 +1444,18 @@
 				4AB6A893278F048D0016B01E /* FileProviderAdapterCacheTypeMock.swift */,
 				4AB6A895278F07B20016B01E /* FileProviderAdapterTypeMock.swift */,
 				4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */,
+				4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */,
+				4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */,
 				4A5AC4382758EC9400342AA7 /* FullVersionCheckerMock.swift */,
 				4AB6A898278F084E0016B01E /* MaintenanceManagerMock.swift */,
 				4AE791C9278F168E00525913 /* MasterkeyCacheManagerMock.swift */,
+				4AEECD3A279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift */,
+				4AEECD3E279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift */,
 				4AE791CB278F16BD00525913 /* VaultKeepUnlockedHelperMock.swift */,
 				4AE791CD278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift */,
 				4AB6A891278EFC730016B01E /* VaultManagerMock.swift */,
-				4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */,
-				4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */,
+				4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */,
+				4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1562,10 +1583,12 @@
 				740375FA2587AEB50023FF53 /* CloudPath+NameCollision.swift */,
 				4A511D582664F290000A0E01 /* DeleteItemHelper.swift */,
 				4A1673E9270C77CC0075C724 /* DocumentStorageURLProvider.swift */,
+				4AEECD36279EB15400C6E2B5 /* ErrorWrapper.swift */,
 				4A8F149D266A2A8200ADBCE4 /* FileProviderAdapter.swift */,
 				740375F12587AEB40023FF53 /* FileProviderAdapterError.swift */,
 				4A2482322670D6FB002D9F59 /* FileProviderAdapterManager.swift */,
 				4A1673E4270C5E6C0075C724 /* FileProviderCacheManager.swift */,
+				4AEECD34279EB0FD00C6E2B5 /* FileProviderEnumerator.swift */,
 				740375F32587AEB50023FF53 /* FileProviderItem.swift */,
 				740375FC2587AEB50023FF53 /* FileProviderItemList.swift */,
 				740375F02587AEB40023FF53 /* FileProviderNotificator.swift */,
@@ -1614,6 +1637,7 @@
 				4A511D5C26668E47000A0E01 /* ReparentTaskRecord.swift */,
 				740376052587AEB60023FF53 /* UploadTaskDBManager.swift */,
 				4A511D5A26668E0C000A0E01 /* UploadTaskRecord.swift */,
+				4A2060D4279AF67C00DA6C62 /* WorkingSetObserver.swift */,
 			);
 			path = DB;
 			sourceTree = "<group>";
@@ -2124,8 +2148,11 @@
 				4A123EA824BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift in Sources */,
 				4A2060CB2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift in Sources */,
 				4A2060D1279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift in Sources */,
+				4AEECD3F279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift in Sources */,
 				4AB6A892278EFC730016B01E /* VaultManagerMock.swift in Sources */,
+				4AEECD31279EA50D00C6E2B5 /* WorkingSetObservingMock.swift in Sources */,
 				4A511D492660EE3F000A0E01 /* DeletionTaskExecutorTests.swift in Sources */,
+				4AEECD33279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift in Sources */,
 				4A797F9624AC9936007DDBE1 /* CloudProviderMock.swift in Sources */,
 				4A24822B266E362C002D9F59 /* FileProviderAdapterMoveItemTests.swift in Sources */,
 				4A24822D266F85FD002D9F59 /* FileProviderAdapterDeleteItemTests.swift in Sources */,
@@ -2154,6 +2181,7 @@
 				4A248227266E27C5002D9F59 /* FolderCreationTaskExecutorTests.swift in Sources */,
 				4AE791CE278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift in Sources */,
 				4AB1C325265CE69700DC7A49 /* DownloadTaskExecutorTests.swift in Sources */,
+				4AEECD3B279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift in Sources */,
 				4A8F149C266A29E400ADBCE4 /* OnlineItemNameCollisionHandlerTests.swift in Sources */,
 				4A8F14A2266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift in Sources */,
 				4A3E2FEC271DC9670090BD44 /* MaintenanceManagerTests.swift in Sources */,
@@ -2161,8 +2189,11 @@
 				4AB1C33A265E9D8600DC7A49 /* UploadTaskExecutorTests.swift in Sources */,
 				4A2245DC24A5E1C600DBA437 /* MetadataManagerTests.swift in Sources */,
 				4AB6A896278F07B20016B01E /* FileProviderAdapterTypeMock.swift in Sources */,
+				4AEECD39279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift in Sources */,
 				4A797F8F24AC6731007DDBE1 /* FileProviderItemTests.swift in Sources */,
 				4A5AC4392758EC9400342AA7 /* FullVersionCheckerMock.swift in Sources */,
+				4AEECD2F279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift in Sources */,
+				4AEECD3D279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2180,14 +2211,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A80408027694C6600D7D999 /* VaultUnlockingServiceSourceSnapshotMock.swift in Sources */,
-				4AFD8C112693204900F77BA6 /* ErrorWrapper.swift in Sources */,
 				4AE7D79525826A0900C5E1D8 /* FileProviderValidationServiceSource.m in Sources */,
 				4A80407D27692A0100D7D999 /* FileProviderEnumeratorSnapshotMock.swift in Sources */,
 				4AA621D9249A6A8400A0BCBD /* FileProviderExtension.swift in Sources */,
 				4A24001A26AE9F3A009DBC2E /* VaultLockingServiceSource.swift in Sources */,
 				4A9BED64268F1DB000721BAA /* VaultUnlockingServiceSource.swift in Sources */,
 				4AD0F61C24AF203F0026B765 /* FileProvider+Actions.swift in Sources */,
-				4AA621DD249A6A8400A0BCBD /* FileProviderEnumerator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2445,7 +2474,9 @@
 				747F2F232587BC250072FB30 /* ItemMetadataDBManager.swift in Sources */,
 				4A511D47265FEFBE000A0E01 /* DownloadTask.swift in Sources */,
 				4A09E54E27071F4F0056D32A /* ErrorMapper.swift in Sources */,
+				4AEECD35279EB0FD00C6E2B5 /* FileProviderEnumerator.swift in Sources */,
 				4AE0D8DC2653DF1300DF5D22 /* DownloadTaskExecutor.swift in Sources */,
+				4AEECD37279EB15400C6E2B5 /* ErrorWrapper.swift in Sources */,
 				747F2F242587BC250072FB30 /* CachedFileDBManager.swift in Sources */,
 				4A511D4C2660FEFE000A0E01 /* Workflow.swift in Sources */,
 				4AEBE8C726540EBF0031487F /* MovingItemPathLockHandler.swift in Sources */,
@@ -2459,6 +2490,7 @@
 				747F2F282587BC250072FB30 /* ReparentTaskDBManager.swift in Sources */,
 				4A511D4E2660FF9E000A0E01 /* WorkflowScheduler.swift in Sources */,
 				4A2482352671110A002D9F59 /* DBManagerError.swift in Sources */,
+				4A2060D5279AF67C00DA6C62 /* WorkingSetObserver.swift in Sources */,
 				4A511D5B26668E0C000A0E01 /* UploadTaskRecord.swift in Sources */,
 				4A511D5F26668E68000A0E01 /* DeletionTaskRecord.swift in Sources */,
 				4A248223266E266E002D9F59 /* FolderCreationTask.swift in Sources */,

--- a/CryptomatorFileProvider/DB/ItemMetadata.swift
+++ b/CryptomatorFileProvider/DB/ItemMetadata.swift
@@ -90,6 +90,10 @@ public class ItemMetadata: Record, Codable {
 	enum Columns: String, ColumnExpression {
 		case id, name, type, size, parentID, lastModifiedDate, statusCode, cloudPath, isPlaceholderItem, isMaybeOutdated, favoriteRank, tagData
 	}
+
+	static func filterWorkingSet() -> QueryInterfaceRequest<ItemMetadata> {
+		return ItemMetadata.filter(ItemMetadata.Columns.tagData != nil || ItemMetadata.Columns.favoriteRank != nil)
+	}
 }
 
 extension ItemStatus: DatabaseValueConvertible {}

--- a/CryptomatorFileProvider/DB/ItemMetadata.swift
+++ b/CryptomatorFileProvider/DB/ItemMetadata.swift
@@ -29,6 +29,8 @@ public class ItemMetadata: Record, Codable {
 	var cloudPath: CloudPath
 	var isPlaceholderItem: Bool
 	var isMaybeOutdated: Bool
+	var favoriteRank: Int64?
+	var tagData: Data?
 
 	required init(row: Row) {
 		self.id = row[Columns.id]
@@ -41,10 +43,16 @@ public class ItemMetadata: Record, Codable {
 		self.cloudPath = row[Columns.cloudPath]
 		self.isPlaceholderItem = row[Columns.isPlaceholderItem]
 		self.isMaybeOutdated = row[Columns.isMaybeOutdated]
+		self.favoriteRank = row[Columns.favoriteRank]
+		self.tagData = row[Columns.tagData]
 		super.init(row: row)
 	}
 
-	init(id: Int64? = nil, name: String, type: CloudItemType, size: Int?, parentID: Int64, lastModifiedDate: Date?, statusCode: ItemStatus, cloudPath: CloudPath, isPlaceholderItem: Bool, isCandidateForCacheCleanup: Bool = false) {
+	convenience init(item: CloudItemMetadata, withParentID parentID: Int64, isPlaceholderItem: Bool = false) {
+		self.init(name: item.name, type: item.itemType, size: item.size, parentID: parentID, lastModifiedDate: item.lastModifiedDate, statusCode: .isUploaded, cloudPath: item.cloudPath, isPlaceholderItem: isPlaceholderItem)
+	}
+
+	init(id: Int64? = nil, name: String, type: CloudItemType, size: Int?, parentID: Int64, lastModifiedDate: Date?, statusCode: ItemStatus, cloudPath: CloudPath, isPlaceholderItem: Bool, isCandidateForCacheCleanup: Bool = false, favoriteRank: Int64? = nil, tagData: Data? = nil) {
 		self.id = id
 		self.name = name
 		self.type = type
@@ -55,6 +63,8 @@ public class ItemMetadata: Record, Codable {
 		self.cloudPath = cloudPath
 		self.isPlaceholderItem = isPlaceholderItem
 		self.isMaybeOutdated = isCandidateForCacheCleanup
+		self.favoriteRank = favoriteRank
+		self.tagData = tagData
 		super.init()
 	}
 
@@ -73,11 +83,18 @@ public class ItemMetadata: Record, Codable {
 		container[Columns.cloudPath] = cloudPath
 		container[Columns.isPlaceholderItem] = isPlaceholderItem
 		container[Columns.isMaybeOutdated] = isMaybeOutdated
+		container[Columns.favoriteRank] = favoriteRank
+		container[Columns.tagData] = tagData
 	}
 
 	enum Columns: String, ColumnExpression {
-		case id, name, type, size, parentID, lastModifiedDate, statusCode, cloudPath, isPlaceholderItem, isMaybeOutdated
+		case id, name, type, size, parentID, lastModifiedDate, statusCode, cloudPath, isPlaceholderItem, isMaybeOutdated, favoriteRank, tagData
 	}
 }
 
 extension ItemStatus: DatabaseValueConvertible {}
+extension ItemMetadata: Equatable {
+	public static func == (lhs: ItemMetadata, rhs: ItemMetadata) -> Bool {
+		lhs.id == rhs.id && lhs.name == rhs.name && lhs.type == rhs.type && lhs.size == rhs.size && lhs.parentID == rhs.parentID && lhs.lastModifiedDate == rhs.lastModifiedDate && lhs.statusCode == rhs.statusCode && lhs.cloudPath == rhs.cloudPath && lhs.isPlaceholderItem == rhs.isPlaceholderItem && lhs.isMaybeOutdated == rhs.isMaybeOutdated && lhs.favoriteRank == rhs.favoriteRank && lhs.tagData == rhs.tagData
+	}
+}

--- a/CryptomatorFileProvider/DB/WorkingSetObserver.swift
+++ b/CryptomatorFileProvider/DB/WorkingSetObserver.swift
@@ -58,7 +58,7 @@ class WorkingSetObserver: WorkingSetObserving {
 			notificator.removeItemsFromWorkingSet(with: removedItems)
 		}
 		if currentWorkingSetItems != newWorkingSet {
-			newWorkingSet.forEach { notificator.updateWorkingSetItem($0) }
+			notificator.updateWorkingSetItems(Array(newWorkingSet))
 		}
 		if !removedItems.isEmpty || currentWorkingSetItems != newWorkingSet {
 			notificator.refreshWorkingSet()

--- a/CryptomatorFileProvider/DB/WorkingSetObserver.swift
+++ b/CryptomatorFileProvider/DB/WorkingSetObserver.swift
@@ -1,0 +1,79 @@
+//
+//  WorkingSetObserver.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 21.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import FileProvider
+import Foundation
+import GRDB
+
+protocol WorkingSetObserving {
+	func startObservation()
+}
+
+class WorkingSetObserver: WorkingSetObserving {
+	private var observer: TransactionObserver?
+	private let database: DatabaseReader
+	private let uploadTaskManager: UploadTaskManager
+	private let cachedFileManager: CachedFileManager
+	private let notificator: FileProviderNotificatorType
+	private var currentWorkingSetItems = Set<FileProviderItem>()
+
+	init(database: DatabaseReader, notificator: FileProviderNotificatorType, uploadTaskManager: UploadTaskManager, cachedFileManager: CachedFileManager) {
+		self.database = database
+		self.notificator = notificator
+		self.uploadTaskManager = uploadTaskManager
+		self.cachedFileManager = cachedFileManager
+	}
+
+	func startObservation() {
+		let observation = ValueObservation.tracking { db in
+			try ItemMetadata.filterWorkingSet().fetchAll(db)
+		}.removeDuplicates()
+		observer = observation.start(in: database, onError: { error in
+			DDLogError("Working set startObservation error: \(error)")
+		}, onChange: { [weak self] (metadataList: [ItemMetadata]) in
+			let items: [FileProviderItem]
+			do {
+				items = try self?.createFileProviderItems(from: metadataList) ?? []
+			} catch {
+				DDLogError("Working set onChange error: \(error)")
+				return
+			}
+			self?.handleWorkingSetUpdate(items: items)
+		})
+	}
+
+	func handleWorkingSetUpdate(items: [FileProviderItem]) {
+		let newWorkingSet = Set(items)
+		let currentWorkingSetItemIdentifiers = Set(currentWorkingSetItems.map { $0.itemIdentifier })
+		let newWorkingSetItemIdentifiers = Set(newWorkingSet.map { $0.itemIdentifier })
+		let removedItems = Array(currentWorkingSetItemIdentifiers.subtracting(newWorkingSetItemIdentifiers))
+
+		if !removedItems.isEmpty {
+			notificator.removeItemsFromWorkingSet(with: removedItems)
+		}
+		if currentWorkingSetItems != newWorkingSet {
+			newWorkingSet.forEach { notificator.updateWorkingSetItem($0) }
+		}
+		if !removedItems.isEmpty || currentWorkingSetItems != newWorkingSet {
+			notificator.refreshWorkingSet()
+		}
+		currentWorkingSetItems = newWorkingSet
+	}
+
+	func createFileProviderItems(from metadataList: [ItemMetadata]) throws -> [FileProviderItem] {
+		let uploadTasks = try uploadTaskManager.getTaskRecords(for: metadataList)
+		let items = try metadataList.enumerated().map { index, metadata -> FileProviderItem in
+			let localCachedFileInfo = try cachedFileManager.getLocalCachedFileInfo(for: metadata)
+			let newestVersionLocallyCached = localCachedFileInfo?.isCurrentVersion(lastModifiedDateInCloud: metadata.lastModifiedDate) ?? false
+			let localURL = localCachedFileInfo?.localURL
+			return FileProviderItem(metadata: metadata, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTasks[index]?.failedWithError)
+		}
+		return items
+	}
+}

--- a/CryptomatorFileProvider/ErrorWrapper.swift
+++ b/CryptomatorFileProvider/ErrorWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  ErrorWrapper.swift
-//  FileProviderExtension
+//  CryptomatorFileProvider
 //
 //  Created by Philipp Schmid on 05.07.21.
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
@@ -9,11 +9,11 @@
 import FileProvider
 import Foundation
 
-enum ErrorWrapper {
+public enum ErrorWrapper {
 	/**
 	 Wraps an  error in a NSFileProviderError.notAuthenticated object as only with this error the FileProvider UI (FPUIActionExtensionViewController) is called with a prepare(forError error: Error).
 	 */
-	static func wrapError(_ error: Error, domain: NSFileProviderDomain?) -> NSFileProviderError {
+	public static func wrapError(_ error: Error, domain: NSFileProviderDomain?) -> NSFileProviderError {
 		var userInfo = [String: Any]()
 		userInfo["internalError"] = error
 		if let vaultName = domain?.displayName {

--- a/CryptomatorFileProvider/FileProviderItem.swift
+++ b/CryptomatorFileProvider/FileProviderItem.swift
@@ -145,4 +145,12 @@ public class FileProviderItem: NSObject, NSFileProviderItem {
 		}
 		return error
 	}
+
+	public var favoriteRank: NSNumber? {
+		return metadata.favoriteRank as NSNumber?
+	}
+
+	public var tagData: Data? {
+		return metadata.tagData
+	}
 }

--- a/CryptomatorFileProvider/FileProviderNotificator.swift
+++ b/CryptomatorFileProvider/FileProviderNotificator.swift
@@ -129,10 +129,35 @@ public class FileProviderNotificator: FileProviderNotificatorType {
 			}
 		}
 	}
+
+	public func signalWorkingSetUpdate(for item: NSFileProviderItem) {
+		queue.sync(flags: .barrier) {
+			signalDeleteWorkingSetItemIdentifier.remove(item.itemIdentifier)
+			signalUpdateWorkingSetItem[item.itemIdentifier] = item
+		}
+		signalEnumerator(for: [.workingSet])
+	}
+
+	public func removeItemsFromWorkingSet(with identifiers: [NSFileProviderItemIdentifier]) {
+		identifiers.forEach { appendIdentifierToDeleteWorkingSet($0) }
+	}
+
+	public func updateWorkingSetItem(_ item: NSFileProviderItem) {
+		appendItemToWorkingSet(item)
+	}
+
+	private func appendItemToWorkingSet(_ item: NSFileProviderItem) {
+		queue.sync(flags: .barrier) {
+			signalUpdateWorkingSetItem[item.itemIdentifier] = item
+		}
+	}
 }
 
 public protocol FileProviderItemUpdateDelegate: AnyObject {
+	func signalWorkingSetUpdate(for item: NSFileProviderItem)
 	func signalUpdate(for item: NSFileProviderItem)
 	func removeItemFromWorkingSet(with identifier: NSFileProviderItemIdentifier)
+	func removeItemsFromWorkingSet(with identifiers: [NSFileProviderItemIdentifier])
 	func refreshWorkingSet()
+	func updateWorkingSetItem(_ item: NSFileProviderItem)
 }

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
@@ -81,7 +81,7 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 
 			var metadataList = [ItemMetadata]()
 			for cloudItem in itemList.items {
-				let fileProviderItemMetadata = ItemEnumerationTaskExecutor.createItemMetadata(for: cloudItem, withParentID: folderMetadata.id!)
+				let fileProviderItemMetadata = ItemMetadata(item: cloudItem, withParentID: folderMetadata.id!)
 				metadataList.append(fileProviderItemMetadata)
 			}
 			metadataList = try self.filterOutWaitingReparentTasks(parentID: folderMetadata.id!, for: metadataList)
@@ -129,7 +129,7 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 
 	func fetchItemMetadata(fileMetadata: ItemMetadata) -> Promise<FileProviderItemList> {
 		return provider.fetchItemMetadata(at: fileMetadata.cloudPath).then { cloudItem -> FileProviderItemList in
-			let fileProviderItemMetadata = ItemEnumerationTaskExecutor.createItemMetadata(for: cloudItem, withParentID: fileMetadata.parentID)
+			let fileProviderItemMetadata = ItemMetadata(item: cloudItem, withParentID: fileMetadata.parentID)
 			try self.itemMetadataManager.cacheMetadata(fileProviderItemMetadata)
 			assert(fileProviderItemMetadata.id == fileMetadata.id)
 			let localCachedFileInfo = try self.cachedFileManager.getLocalCachedFileInfo(for: fileProviderItemMetadata)
@@ -153,9 +153,5 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 				DDLogError("Removing outdated item \(outdatedItem.id!) with type \(outdatedItem.type) failed due to having unsynced edits")
 			}
 		}
-	}
-
-	static func createItemMetadata(for item: CloudItemMetadata, withParentID parentID: Int64, isPlaceholderItem: Bool = false) -> ItemMetadata {
-		ItemMetadata(name: item.name, type: item.itemType, size: item.size, parentID: parentID, lastModifiedDate: item.lastModifiedDate, statusCode: .isUploaded, cloudPath: item.cloudPath, isPlaceholderItem: isPlaceholderItem)
 	}
 }

--- a/CryptomatorFileProviderTests/DB/MetadataManagerTests.swift
+++ b/CryptomatorFileProviderTests/DB/MetadataManagerTests.swift
@@ -222,6 +222,86 @@ class MetadataManagerTests: XCTestCase {
 		XCTAssertEqual(fetchedMetadataForSensitivePath, fetchedMetadataForInSensitivePath)
 		XCTAssertEqual(cloudPath, fetchedMetadataForInSensitivePath.cloudPath)
 	}
+
+	// MARK: Set Tag Data
+
+	func testSetTagData() throws {
+		let cloudPath = CloudPath("/File.txt")
+		let itemMetadata = ItemMetadata(name: "File.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+		try manager.cacheMetadata(itemMetadata)
+		let tagData = "Foo".data(using: .utf8)!
+		let id = try XCTUnwrap(itemMetadata.id)
+		try manager.setTagData(to: tagData, forItemWithID: id)
+
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertEqual(tagData, cachedMetadata.tagData)
+	}
+
+	func testSetTagDataToNil() throws {
+		let cloudPath = CloudPath("/File.txt")
+		let tagData = "Foo".data(using: .utf8)!
+		let itemMetadata = ItemMetadata(name: "File.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false, tagData: tagData)
+		try manager.cacheMetadata(itemMetadata)
+
+		let id = try XCTUnwrap(itemMetadata.id)
+		try manager.setTagData(to: nil, forItemWithID: id)
+
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertNil(cachedMetadata.tagData)
+	}
+
+	func testCacheMetadataDoesNotOverwriteExistingTagData() throws {
+		let cloudPath = CloudPath("/File.txt")
+		let tagData = "Foo".data(using: .utf8)!
+		let itemMetadata = ItemMetadata(name: "File.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false, tagData: tagData)
+		try manager.cacheMetadata(itemMetadata)
+
+		itemMetadata.tagData = nil
+		try manager.cacheMetadata(itemMetadata)
+
+		let id = try XCTUnwrap(itemMetadata.id)
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertEqual(tagData, cachedMetadata.tagData)
+	}
+
+	// MARK: Set Favorite Rank
+
+	func testSetFavoriteRank() throws {
+		let cloudPath = CloudPath("/Folder")
+		let itemMetadata = ItemMetadata(name: "Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+		try manager.cacheMetadata(itemMetadata)
+		let favoriteRank: Int64 = 100
+		let id = try XCTUnwrap(itemMetadata.id)
+		try manager.setFavoriteRank(to: favoriteRank, forItemWithID: id)
+
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertEqual(favoriteRank, cachedMetadata.favoriteRank)
+	}
+
+	func testSetFavoriteRankToNil() throws {
+		let cloudPath = CloudPath("/Folder")
+		let itemMetadata = ItemMetadata(name: "Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false, favoriteRank: 100)
+		try manager.cacheMetadata(itemMetadata)
+		let id = try XCTUnwrap(itemMetadata.id)
+		try manager.setFavoriteRank(to: nil, forItemWithID: id)
+
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertNil(cachedMetadata.favoriteRank)
+	}
+
+	func testCacheMetadataDoesNotOverwriteExistingFavoriteRank() throws {
+		let cloudPath = CloudPath("/Folder")
+		let favoriteRank: Int64 = 100
+		let itemMetadata = ItemMetadata(name: "File.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false, favoriteRank: favoriteRank)
+		try manager.cacheMetadata(itemMetadata)
+
+		itemMetadata.favoriteRank = nil
+		try manager.cacheMetadata(itemMetadata)
+
+		let id = try XCTUnwrap(itemMetadata.id)
+		let cachedMetadata = try XCTUnwrap(try manager.getCachedMetadata(for: id))
+		XCTAssertEqual(favoriteRank, cachedMetadata.favoriteRank)
+	}
 }
 
 extension ItemMetadata: Comparable {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
@@ -13,7 +13,25 @@ import XCTest
 class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 	// MARK: Enumerate Working Set
 
-	func testWorkingSetReturnsEmptyItemList() {
+	func testWorkingSet() {
+		let mockMetadata = [
+			ItemMetadata(id: 2, name: "Test", type: .file, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: Data()),
+			ItemMetadata(id: 3, name: "TestFolder", type: .file, size: nil, parentID: 4, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Foo/TestFolder"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: 1, tagData: nil)
+		]
+		metadataManagerMock.workingSetMetadata = mockMetadata
+		let expectation = XCTestExpectation()
+		adapter.enumerateItems(for: .workingSet, withPageToken: nil).then { itemList in
+			XCTAssertEqual(mockMetadata.map { FileProviderItem(metadata: $0) }, itemList.items)
+			XCTAssertNil(itemList.nextPageToken)
+		}.catch { error in
+			XCTFail("Error in promise: \(error)")
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+	}
+
+	func testEmptyWorkingSet() {
 		let expectation = XCTestExpectation()
 		adapter.enumerateItems(for: .workingSet, withPageToken: nil).then { itemList in
 			XCTAssert(itemList.items.isEmpty)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetFavoriteRankTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetFavoriteRankTests.swift
@@ -1,0 +1,27 @@
+//
+//  FileProviderAdapterSetFavoriteRankTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import XCTest
+@testable import CryptomatorFileProvider
+
+class FileProviderAdapterSetFavoriteRankTests: FileProviderAdapterTestCase {
+	func testSetFavoriteRank() throws {
+		let expectation = XCTestExpectation()
+		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
+		let favoriteRank: NSNumber = 100
+		let itemIdentifier = NSFileProviderItemIdentifier("2")
+		adapter.setFavoriteRank(favoriteRank, forItemIdentifier: itemIdentifier) { item, error in
+			XCTAssertNil(error)
+			XCTAssertEqual(favoriteRank, item?.favoriteRank)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(favoriteRank.int64Value, metadataManagerMock.setFavoriteRank[2])
+	}
+}

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetTagDataTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetTagDataTests.swift
@@ -1,0 +1,47 @@
+//
+//  FileProviderAdapterSetTagDataTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import Foundation
+import XCTest
+@testable import CryptomatorFileProvider
+
+class FileProviderAdapterSetTagDataTests: FileProviderAdapterTestCase {
+	func testSetTagData() throws {
+		let expectation = XCTestExpectation()
+		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .file, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
+		let tagData = "Foo".data(using: .utf8)!
+		let itemIdentifier = NSFileProviderItemIdentifier("2")
+		adapter.setTagData(tagData, forItemIdentifier: itemIdentifier) { item, error in
+			XCTAssertNil(error)
+			XCTAssertEqual(tagData, item?.tagData)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(tagData, metadataManagerMock.setTagData[2])
+	}
+
+	func testSetEmptyTagData() throws {
+		let expectation = XCTestExpectation()
+		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .file, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
+		let emptyTagData = Data()
+		let itemIdentifier = NSFileProviderItemIdentifier("2")
+		adapter.setTagData(emptyTagData, forItemIdentifier: itemIdentifier) { item, error in
+			XCTAssertNil(error)
+			guard let item = item else {
+				XCTFail("FileProviderItem is nil")
+				return
+			}
+			let tagData: Data? = item.tagData ?? nil
+			XCTAssertNil(tagData)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertNil(metadataManagerMock.setTagData[2] ?? nil)
+	}
+}

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -1,0 +1,295 @@
+//
+//  FileProviderEnumeratorTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import FileProvider
+import Promises
+import XCTest
+@testable import CryptomatorFileProvider
+
+class FileProviderEnumeratorTests: XCTestCase {
+	var enumerationObserverMock: NSFileProviderEnumerationObserverMock!
+	var changeObserverMock: NSFileProviderChangeObserverMock!
+	var notificatorMock: FileProviderNotificatorTypeMock!
+	var adapterProvidingMock: FileProviderAdapterProvidingMock!
+	var adapterMock: FileProviderAdapterTypeMock!
+	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
+	let dbPath = FileManager.default.temporaryDirectory
+	let items: [FileProviderItem] = [
+		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false)),
+		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false))
+	]
+	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
+	let currentSyncAnchorDate = Date.distantFuture
+
+	override func setUpWithError() throws {
+		enumerationObserverMock = NSFileProviderEnumerationObserverMock()
+		changeObserverMock = NSFileProviderChangeObserverMock()
+		notificatorMock = FileProviderNotificatorTypeMock()
+		adapterProvidingMock = FileProviderAdapterProvidingMock()
+		adapterMock = FileProviderAdapterTypeMock()
+		adapterProvidingMock.semaphore = BiometricalUnlockSemaphore()
+	}
+
+	// MARK: Enumerate Items
+
+	func testEnumerateItemsFromScratch() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+		let itemList = FileProviderItemList(items: items, nextPageToken: nil)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		adapterMock.enumerateItemsForWithPageTokenReturnValue = Promise(itemList)
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingUpToClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		assertWaitForSemaphoreCalled()
+		assertEnumerateItemObserverSucceeded(itemList: itemList)
+		assertEnumerateItemsCalled(for: .rootContainer, pageToken: nil)
+	}
+
+	func testEnumerateItemsFromScratchWithNextPageToken() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+		let nextPageToken = "Foo"
+		let nextFileProviderPage = NSFileProviderPage(nextPageToken.data(using: .utf8)!)
+		let itemList = FileProviderItemList(items: items, nextPageToken: nextFileProviderPage)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		adapterMock.enumerateItemsForWithPageTokenReturnValue = Promise(itemList)
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingUpToClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		assertWaitForSemaphoreCalled()
+		assertEnumerateItemObserverSucceeded(itemList: itemList)
+		assertEnumerateItemsCalled(for: .rootContainer, pageToken: nil)
+	}
+
+	func testEnumerateItemsWithPageToken() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		let pageToken = "Foo"
+		let page = NSFileProviderPage(pageToken.data(using: .utf8)!)
+		let itemList = FileProviderItemList(items: items, nextPageToken: nil)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		adapterMock.enumerateItemsForWithPageTokenReturnValue = Promise(itemList)
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingUpToClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		assertWaitForSemaphoreCalled()
+		assertEnumerateItemObserverSucceeded(itemList: itemList)
+		assertEnumerateItemsCalled(for: .rootContainer, pageToken: pageToken)
+	}
+
+	func testEnumerateItemsFailed() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		adapterMock.enumerateItemsForWithPageTokenReturnValue = Promise(CloudProviderError.noInternetConnection)
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingWithErrorClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		assertWaitForSemaphoreCalled()
+		assertEnumerateItemsObserverFailed(with: .noInternetConnection)
+		assertEnumerateItemsCalled(for: .rootContainer, pageToken: nil)
+	}
+
+	func testEnumerateItemsFailedAdapterNotFound() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = FileProviderAdapterManagerError.cachedAdapterNotFound
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingWithErrorClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 2.0)
+		assertWaitForSemaphoreCalled()
+		assertErrorWrapped(.cachedAdapterNotFound)
+	}
+
+	func testEnumerateItemsFailedAdapterNotFoundForWorkingSet() {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .workingSet)
+		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = FileProviderAdapterManagerError.cachedAdapterNotFound
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
+		enumerationObserverMock.finishEnumeratingWithErrorClosure = { _ in
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 2.0)
+		assertWaitForSemaphoreCalled()
+		assertWorkingSetInvalidated()
+	}
+
+	// MARK: Enumerate Changes
+
+	func testEnumerateChanges() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .rootContainer)
+		notificatorMock.popUpdateContainerItemsReturnValue = items
+		let syncAnchor = try createSyncAnchor(from: .distantPast)
+		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
+		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, _ in
+			expectation.fulfill()
+		}
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertChangeObserverUpdated(deletedItems: [],
+		                            updatedItems: items,
+		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
+	}
+
+	func testEnumerateWorkingSet() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .workingSet)
+		let lastUnlockedDate = Date()
+		adapterMock.lastUnlockedDate = lastUnlockedDate
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+
+		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
+		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
+		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, _ in
+			expectation.fulfill()
+		}
+		let syncAnchor = try createSyncAnchor(from: lastUnlockedDate)
+		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
+		                            updatedItems: items,
+		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
+	}
+
+	func testEnumerateWorkingSetLastUnlockedDateDistantPast() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .workingSet)
+		let lastUnlockedDate = Date.distantPast
+		adapterMock.lastUnlockedDate = lastUnlockedDate
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+
+		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
+		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
+		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, _ in
+			expectation.fulfill()
+		}
+		let syncAnchor = try createSyncAnchor(from: Date())
+
+		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
+		                            updatedItems: items,
+		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
+	}
+
+	func testEnumerateWorkingSetChangesFailedAdapterNotFound() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .workingSet)
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = FileProviderAdapterManagerError.cachedAdapterNotFound
+		changeObserverMock.finishEnumeratingWithErrorClosure = { _ in
+			expectation.fulfill()
+		}
+		let syncAnchor = try createSyncAnchor(from: .distantPast)
+		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertWorkingSetInvalidatedForEnumerateChanges()
+	}
+
+	func testEnumerateWorkingSetUnlockedAfterLastUpdate() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createEnumerator(for: .workingSet)
+		adapterMock.lastUnlockedDate = Date()
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		changeObserverMock.finishEnumeratingWithErrorClosure = { _ in
+			expectation.fulfill()
+		}
+		let syncAnchor = try createSyncAnchor(from: Date.distantPast)
+		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertWorkingSetInvalidatedForEnumerateChanges()
+	}
+
+	private func createEnumerator(for itemIdentifier: NSFileProviderItemIdentifier) -> FileProviderEnumerator {
+		return FileProviderEnumerator(enumeratedItemIdentifier: itemIdentifier, notificator: notificatorMock, domain: domain, dbPath: dbPath, localURLProvider: nil, adapterProvider: adapterProvidingMock)
+	}
+
+	private func assertWaitForSemaphoreCalled() {
+		XCTAssertEqual(1, adapterProvidingMock.semaphoreGetterCallsCount)
+	}
+
+	private func assertEnumerateItemsCalled(for identifier: NSFileProviderItemIdentifier, pageToken: String?) {
+		XCTAssertEqual(1, adapterMock.enumerateItemsForWithPageTokenCallsCount)
+		XCTAssertEqual(identifier, adapterMock.enumerateItemsForWithPageTokenReceivedArguments?.identifier)
+		XCTAssertEqual(pageToken, adapterMock.enumerateItemsForWithPageTokenReceivedArguments?.pageToken)
+	}
+
+	private func assertEnumerateItemsNotCalled() {
+		XCTAssertFalse(adapterMock.enumerateItemsForWithPageTokenCalled)
+	}
+
+	private func assertEnumerateItemObserverSucceeded(itemList: FileProviderItemList) {
+		XCTAssertEqual([itemList.nextPageToken], enumerationObserverMock.finishEnumeratingUpToReceivedInvocations)
+		let receivedInvocations = enumerationObserverMock.didEnumerateReceivedInvocations as? [[FileProviderItem]]
+		XCTAssertEqual([items], receivedInvocations)
+		XCTAssertFalse(enumerationObserverMock.finishEnumeratingWithErrorCalled)
+	}
+
+	private func assertEnumerateItemsObserverFailed(with error: CloudProviderError) {
+		let receivedErrors = enumerationObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [CloudProviderError]
+		XCTAssertEqual([error], receivedErrors)
+		XCTAssertFalse(enumerationObserverMock.finishEnumeratingUpToCalled)
+		XCTAssertFalse(enumerationObserverMock.didEnumerateCalled)
+	}
+
+	private func assertErrorWrapped(_ error: FileProviderAdapterManagerError) {
+		let receivedErrors = enumerationObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
+		let expectedWrappedError = ErrorWrapper.wrapError(error, domain: domain)
+		XCTAssertEqual([expectedWrappedError], receivedErrors)
+		XCTAssertFalse(enumerationObserverMock.finishEnumeratingUpToCalled)
+		XCTAssertFalse(enumerationObserverMock.didEnumerateCalled)
+	}
+
+	private func assertWorkingSetInvalidated() {
+		let receivedErrors = enumerationObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
+		XCTAssertEqual(1, notificatorMock.invalidatedWorkingSetCallsCount)
+		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
+		XCTAssertFalse(enumerationObserverMock.finishEnumeratingUpToCalled)
+		XCTAssertFalse(enumerationObserverMock.didEnumerateCalled)
+	}
+
+	private func createSyncAnchor(from date: Date) throws -> NSFileProviderSyncAnchor {
+		return NSFileProviderSyncAnchor(try JSONEncoder().encode(date))
+	}
+
+	private func assertChangeObserverUpdated(deletedItems: [NSFileProviderItemIdentifier], updatedItems: [FileProviderItem], currentSyncAnchor: NSFileProviderSyncAnchor) {
+		XCTAssertEqual([deletedItems], changeObserverMock.didDeleteItemsWithIdentifiersReceivedInvocations)
+		let receivedUpdatedItems = changeObserverMock.didUpdateReceivedInvocations as? [[FileProviderItem]]
+		XCTAssertEqual([updatedItems], receivedUpdatedItems)
+		XCTAssertFalse(changeObserverMock.finishEnumeratingWithErrorCalled)
+	}
+
+	private func assertWorkingSetInvalidatedForEnumerateChanges() {
+		let receivedErrors = changeObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
+		XCTAssertEqual(1, notificatorMock.invalidatedWorkingSetCallsCount)
+		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
+		XCTAssertFalse(changeObserverMock.finishEnumeratingChangesUpToMoreComingCalled)
+		XCTAssertFalse(changeObserverMock.didUpdateCalled)
+	}
+}

--- a/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
@@ -1,0 +1,131 @@
+//
+//  FileProviderNotificatorTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 25.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import XCTest
+@testable import CryptomatorFileProvider
+
+@available(iOS 14.0, *)
+class FileProviderNotificatorTests: XCTestCase {
+	var notificator: FileProviderNotificator!
+	var enumerationSignalingMock: EnumerationSignalingMock!
+	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
+	let updatedMetadataIDs: [Int64] = [2, 3, 4]
+	lazy var updatedItemIdentifiers = updatedMetadataIDs.map { NSFileProviderItemIdentifier("\($0)") }
+	lazy var updatedItems: [FileProviderItem] = updatedMetadataIDs.map {
+		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false))
+	}
+
+	override func setUpWithError() throws {
+		enumerationSignalingMock = EnumerationSignalingMock()
+		notificator = FileProviderNotificator(manager: enumerationSignalingMock)
+	}
+
+	// MARK: Working Set
+
+	func testGetItemIdentifiersToDeleteFromWorkingSet() throws {
+		notificator.removeItemsFromWorkingSet(with: deleteItemIdentifiers)
+		XCTAssertEqual(deleteItemIdentifiers, getSortedItemIdentifiersToDeleteFromWorkingSet())
+		// Check getter does not clear the identifiers
+		XCTAssertEqual(deleteItemIdentifiers, getSortedItemIdentifiersToDeleteFromWorkingSet())
+		XCTAssertFalse(enumerationSignalingMock.signalEnumeratorForCompletionHandlerCalled)
+	}
+
+	func testPopUpdateWorkingSetItems() throws {
+		notificator.updateWorkingSetItems(updatedItems)
+		assertUpdateWorkingSetHasUpdatedItems()
+		// Check actually removed items
+		XCTAssert(notificator.popUpdateWorkingSetItems().isEmpty)
+		XCTAssertFalse(enumerationSignalingMock.signalEnumeratorForCompletionHandlerCalled)
+	}
+
+	func testUpdateWorkingSetItemRemovesFromDeleteSet() {
+		notificator.removeItemsFromWorkingSet(with: deleteItemIdentifiers)
+		notificator.updateWorkingSetItems(updatedItems)
+
+		XCTAssertEqual([NSFileProviderItemIdentifier("1")], getSortedItemIdentifiersToDeleteFromWorkingSet())
+		assertUpdateWorkingSetHasUpdatedItems()
+		XCTAssertFalse(enumerationSignalingMock.signalEnumeratorForCompletionHandlerCalled)
+	}
+
+	func testInvalidatedWorkingSet() {
+		notificator.updateWorkingSetItems(updatedItems)
+		notificator.removeItemsFromWorkingSet(with: deleteItemIdentifiers)
+		notificator.invalidatedWorkingSet()
+		XCTAssert(notificator.getItemIdentifiersToDeleteFromWorkingSet().isEmpty)
+		XCTAssert(notificator.popUpdateWorkingSetItems().isEmpty)
+		XCTAssertFalse(enumerationSignalingMock.signalEnumeratorForCompletionHandlerCalled)
+	}
+
+	func testRefreshWorkingSet() throws {
+		let expectation = XCTestExpectation()
+		let currentSyncAnchor = try getCurrentSyncAnchorAsDate()
+		enumerationSignalingMock.signalEnumeratorForCompletionHandlerClosure = { _, _ in
+			expectation.fulfill()
+		}
+		notificator.refreshWorkingSet()
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, enumerationSignalingMock.signalEnumeratorForCompletionHandlerCallsCount)
+		XCTAssertEqual(.workingSet, enumerationSignalingMock.signalEnumeratorForCompletionHandlerReceivedArguments?.containerItemIdentifier)
+		try assertSyncAnchorHasBeenUpdated(oldSyncAnchor: currentSyncAnchor)
+	}
+
+	// MARK: Normal Container
+
+	func testSignalUpdate() throws {
+		let expectation = XCTestExpectation()
+		let currentSyncAnchor = try getCurrentSyncAnchorAsDate()
+		enumerationSignalingMock.signalEnumeratorForCompletionHandlerClosure = { _, _ in
+			expectation.fulfill()
+		}
+		let updatedItem = updatedItems[0]
+		notificator.signalUpdate(for: updatedItem)
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(2, enumerationSignalingMock.signalEnumeratorForCompletionHandlerCallsCount)
+		XCTAssertEqual([updatedItem.parentItemIdentifier, updatedItem.itemIdentifier], enumerationSignalingMock.signalEnumeratorForCompletionHandlerReceivedInvocations.map {
+			$0.containerItemIdentifier
+		})
+
+		let actualItems = notificator.popUpdateContainerItems() as? [FileProviderItem]
+		XCTAssertEqual([updatedItem], actualItems?.sorted())
+		XCTAssert(notificator.popUpdateWorkingSetItems().isEmpty)
+		XCTAssert(notificator.getItemIdentifiersToDeleteFromWorkingSet().isEmpty)
+
+		try assertSyncAnchorHasBeenUpdated(oldSyncAnchor: currentSyncAnchor)
+	}
+
+	private func getSortedItemIdentifiersToDeleteFromWorkingSet() -> [NSFileProviderItemIdentifier] {
+		return notificator.getItemIdentifiersToDeleteFromWorkingSet().sorted()
+	}
+
+	private func assertUpdateWorkingSetHasUpdatedItems() {
+		let actualItems = notificator.popUpdateWorkingSetItems() as? [FileProviderItem]
+		XCTAssertEqual(updatedItems.sorted(), actualItems?.sorted())
+	}
+
+	private func getCurrentSyncAnchorAsDate() throws -> Date {
+		return try JSONDecoder().decode(Date.self, from: notificator.currentSyncAnchor)
+	}
+
+	private func assertSyncAnchorHasBeenUpdated(oldSyncAnchor: Date) throws {
+		let newSyncAnchor = try getCurrentSyncAnchorAsDate()
+		XCTAssert(oldSyncAnchor < newSyncAnchor)
+	}
+}
+
+extension FileProviderItem: Comparable {
+	public static func < (lhs: FileProviderItem, rhs: FileProviderItem) -> Bool {
+		return lhs.itemIdentifier < rhs.itemIdentifier
+	}
+}
+
+extension NSFileProviderItemIdentifier: Comparable {
+	public static func < (lhs: NSFileProviderItemIdentifier, rhs: NSFileProviderItemIdentifier) -> Bool {
+		return lhs.rawValue < rhs.rawValue
+	}
+}

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
@@ -45,11 +45,16 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		var cachedMetadata = [Int64: ItemMetadata]()
 		var removedMetadataID = [Int64]()
 		var updatedMetadata = [ItemMetadata]()
+		var workingSetMetadata = [ItemMetadata]()
+		var setTagData = [Int64: Data?]()
+		var setFavoriteRank = [Int64: Int64?]()
 
 		func cacheMetadata(_ metadata: ItemMetadata) throws {
 			if let cachedItemMetadata = try getCachedMetadata(for: metadata.cloudPath) {
 				metadata.id = cachedItemMetadata.id
 				metadata.statusCode = cachedItemMetadata.statusCode
+				metadata.tagData = cachedItemMetadata.tagData
+				metadata.favoriteRank = cachedItemMetadata.favoriteRank
 				cachedMetadata[cachedItemMetadata.id!] = metadata
 				return
 			}
@@ -138,6 +143,24 @@ class CloudTaskExecutorTestCase: XCTestCase {
 				}
 			}
 			return result
+		}
+
+		func getAllCachedMetadataInsideWorkingSet() throws -> [ItemMetadata] {
+			return workingSetMetadata
+		}
+
+		func setTagData(to tagData: Data?, forItemWithID id: Int64) throws {
+			let metadata = cachedMetadata[id]
+			metadata?.tagData = tagData
+			cachedMetadata[id] = metadata
+			setTagData[id] = tagData
+		}
+
+		func setFavoriteRank(to favoriteRank: Int64?, forItemWithID id: Int64) throws {
+			let metadata = cachedMetadata[id]
+			metadata?.favoriteRank = favoriteRank
+			cachedMetadata[id] = metadata
+			setFavoriteRank[id] = favoriteRank
 		}
 	}
 

--- a/CryptomatorFileProviderTests/Mocks/EnumerationSignalingMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/EnumerationSignalingMock.swift
@@ -1,0 +1,34 @@
+//
+//  EnumerationSignalingMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 25.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorFileProvider
+import FileProvider
+import Foundation
+
+// swiftlint:disable all
+final class EnumerationSignalingMock: EnumerationSignaling {
+	// MARK: - signalEnumerator
+
+	var signalEnumeratorForCompletionHandlerCallsCount = 0
+	var signalEnumeratorForCompletionHandlerCalled: Bool {
+		signalEnumeratorForCompletionHandlerCallsCount > 0
+	}
+
+	var signalEnumeratorForCompletionHandlerReceivedArguments: (containerItemIdentifier: NSFileProviderItemIdentifier, completion: (Error?) -> Void)?
+	var signalEnumeratorForCompletionHandlerReceivedInvocations: [(containerItemIdentifier: NSFileProviderItemIdentifier, completion: (Error?) -> Void)] = []
+	var signalEnumeratorForCompletionHandlerClosure: ((NSFileProviderItemIdentifier, @escaping (Error?) -> Void) -> Void)?
+
+	func signalEnumerator(for containerItemIdentifier: NSFileProviderItemIdentifier, completionHandler completion: @escaping (Error?) -> Void) {
+		signalEnumeratorForCompletionHandlerCallsCount += 1
+		signalEnumeratorForCompletionHandlerReceivedArguments = (containerItemIdentifier: containerItemIdentifier, completion: completion)
+		signalEnumeratorForCompletionHandlerReceivedInvocations.append((containerItemIdentifier: containerItemIdentifier, completion: completion))
+		signalEnumeratorForCompletionHandlerClosure?(containerItemIdentifier, completion)
+	}
+}
+
+// swiftlint:enable all

--- a/CryptomatorFileProviderTests/Mocks/FileProviderAdapterProvidingMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderAdapterProvidingMock.swift
@@ -1,0 +1,52 @@
+//
+//  FileProviderAdapterProvidingMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@testable import CryptomatorFileProvider
+
+// swiftlint:disable all
+final class FileProviderAdapterProvidingMock: FileProviderAdapterProviding {
+	// MARK: - semaphore
+
+	var semaphoreGetterCallsCount = 0
+	var semaphore: BiometricalUnlockSemaphore {
+		get {
+			semaphoreGetterCallsCount += 1
+			return underlyingSemaphore
+		}
+		set(value) { underlyingSemaphore = value }
+	}
+
+	private var underlyingSemaphore: BiometricalUnlockSemaphore!
+
+	// MARK: - getAdapter
+
+	var getAdapterForDomainDbPathDelegateNotificatorThrowableError: Error?
+	var getAdapterForDomainDbPathDelegateNotificatorCallsCount = 0
+	var getAdapterForDomainDbPathDelegateNotificatorCalled: Bool {
+		getAdapterForDomainDbPathDelegateNotificatorCallsCount > 0
+	}
+
+	var getAdapterForDomainDbPathDelegateNotificatorReceivedArguments: (domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType)?
+	var getAdapterForDomainDbPathDelegateNotificatorReceivedInvocations: [(domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType)] = []
+	var getAdapterForDomainDbPathDelegateNotificatorReturnValue: FileProviderAdapterType!
+	var getAdapterForDomainDbPathDelegateNotificatorClosure: ((NSFileProviderDomain, URL, LocalURLProvider?, FileProviderNotificatorType) throws -> FileProviderAdapterType)?
+
+	func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType {
+		if let error = getAdapterForDomainDbPathDelegateNotificatorThrowableError {
+			throw error
+		}
+		getAdapterForDomainDbPathDelegateNotificatorCallsCount += 1
+		getAdapterForDomainDbPathDelegateNotificatorReceivedArguments = (domain: domain, dbPath: dbPath, delegate: delegate, notificator: notificator)
+		getAdapterForDomainDbPathDelegateNotificatorReceivedInvocations.append((domain: domain, dbPath: dbPath, delegate: delegate, notificator: notificator))
+		return try getAdapterForDomainDbPathDelegateNotificatorClosure.map({ try $0(domain, dbPath, delegate, notificator) }) ?? getAdapterForDomainDbPathDelegateNotificatorReturnValue
+	}
+}
+
+// swiftlint:enable all

--- a/CryptomatorFileProviderTests/Mocks/FileProviderAdapterTypeMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderAdapterTypeMock.swift
@@ -14,6 +14,15 @@ import Promises
 // swiftlint:disable all
 
 final class FileProviderAdapterTypeMock: FileProviderAdapterType {
+	// MARK: - lastUnlockedDate
+
+	var lastUnlockedDate: Date {
+		get { underlyingLastUnlockedDate }
+		set(value) { underlyingLastUnlockedDate = value }
+	}
+
+	private var underlyingLastUnlockedDate: Date!
+
 	// MARK: - persistentIdentifierForItem
 
 	var persistentIdentifierForItemAtCallsCount = 0
@@ -58,7 +67,6 @@ final class FileProviderAdapterTypeMock: FileProviderAdapterType {
 
 	// MARK: - enumerateItems
 
-	var enumerateItemsForWithPageTokenThrowableError: Error?
 	var enumerateItemsForWithPageTokenCallsCount = 0
 	var enumerateItemsForWithPageTokenCalled: Bool {
 		enumerateItemsForWithPageTokenCallsCount > 0
@@ -70,9 +78,6 @@ final class FileProviderAdapterTypeMock: FileProviderAdapterType {
 	var enumerateItemsForWithPageTokenClosure: ((NSFileProviderItemIdentifier, String?) -> Promise<FileProviderItemList>)?
 
 	func enumerateItems(for identifier: NSFileProviderItemIdentifier, withPageToken pageToken: String?) -> Promise<FileProviderItemList> {
-		if let error = enumerateItemsForWithPageTokenThrowableError {
-			return Promise(error)
-		}
 		enumerateItemsForWithPageTokenCallsCount += 1
 		enumerateItemsForWithPageTokenReceivedArguments = (identifier: identifier, pageToken: pageToken)
 		enumerateItemsForWithPageTokenReceivedInvocations.append((identifier: identifier, pageToken: pageToken))
@@ -221,6 +226,42 @@ final class FileProviderAdapterTypeMock: FileProviderAdapterType {
 		startProvidingItemAtCompletionHandlerReceivedArguments = (url: url, completionHandler: completionHandler)
 		startProvidingItemAtCompletionHandlerReceivedInvocations.append((url: url, completionHandler: completionHandler))
 		startProvidingItemAtCompletionHandlerClosure?(url, completionHandler)
+	}
+
+	// MARK: - setFavoriteRank
+
+	var setFavoriteRankForItemIdentifierCompletionHandlerCallsCount = 0
+	var setFavoriteRankForItemIdentifierCompletionHandlerCalled: Bool {
+		setFavoriteRankForItemIdentifierCompletionHandlerCallsCount > 0
+	}
+
+	var setFavoriteRankForItemIdentifierCompletionHandlerReceivedArguments: (favoriteRank: NSNumber?, itemIdentifier: NSFileProviderItemIdentifier, completionHandler: (NSFileProviderItem?, Error?) -> Void)?
+	var setFavoriteRankForItemIdentifierCompletionHandlerReceivedInvocations: [(favoriteRank: NSNumber?, itemIdentifier: NSFileProviderItemIdentifier, completionHandler: (NSFileProviderItem?, Error?) -> Void)] = []
+	var setFavoriteRankForItemIdentifierCompletionHandlerClosure: ((NSNumber?, NSFileProviderItemIdentifier, @escaping (NSFileProviderItem?, Error?) -> Void) -> Void)?
+
+	func setFavoriteRank(_ favoriteRank: NSNumber?, forItemIdentifier itemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
+		setFavoriteRankForItemIdentifierCompletionHandlerCallsCount += 1
+		setFavoriteRankForItemIdentifierCompletionHandlerReceivedArguments = (favoriteRank: favoriteRank, itemIdentifier: itemIdentifier, completionHandler: completionHandler)
+		setFavoriteRankForItemIdentifierCompletionHandlerReceivedInvocations.append((favoriteRank: favoriteRank, itemIdentifier: itemIdentifier, completionHandler: completionHandler))
+		setFavoriteRankForItemIdentifierCompletionHandlerClosure?(favoriteRank, itemIdentifier, completionHandler)
+	}
+
+	// MARK: - setTagData
+
+	var setTagDataForItemIdentifierCompletionHandlerCallsCount = 0
+	var setTagDataForItemIdentifierCompletionHandlerCalled: Bool {
+		setTagDataForItemIdentifierCompletionHandlerCallsCount > 0
+	}
+
+	var setTagDataForItemIdentifierCompletionHandlerReceivedArguments: (tagData: Data?, itemIdentifier: NSFileProviderItemIdentifier, completionHandler: (NSFileProviderItem?, Error?) -> Void)?
+	var setTagDataForItemIdentifierCompletionHandlerReceivedInvocations: [(tagData: Data?, itemIdentifier: NSFileProviderItemIdentifier, completionHandler: (NSFileProviderItem?, Error?) -> Void)] = []
+	var setTagDataForItemIdentifierCompletionHandlerClosure: ((Data?, NSFileProviderItemIdentifier, @escaping (NSFileProviderItem?, Error?) -> Void) -> Void)?
+
+	func setTagData(_ tagData: Data?, forItemIdentifier itemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
+		setTagDataForItemIdentifierCompletionHandlerCallsCount += 1
+		setTagDataForItemIdentifierCompletionHandlerReceivedArguments = (tagData: tagData, itemIdentifier: itemIdentifier, completionHandler: completionHandler)
+		setTagDataForItemIdentifierCompletionHandlerReceivedInvocations.append((tagData: tagData, itemIdentifier: itemIdentifier, completionHandler: completionHandler))
+		setTagDataForItemIdentifierCompletionHandlerClosure?(tagData, itemIdentifier, completionHandler)
 	}
 }
 

--- a/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
@@ -11,24 +11,6 @@ import Foundation
 @testable import CryptomatorFileProvider
 
 final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
-	// MARK: - signalWorkingSetUpdate
-
-	var signalWorkingSetUpdateForCallsCount = 0
-	var signalWorkingSetUpdateForCalled: Bool {
-		signalWorkingSetUpdateForCallsCount > 0
-	}
-
-	var signalWorkingSetUpdateForReceivedItem: NSFileProviderItem?
-	var signalWorkingSetUpdateForReceivedInvocations: [NSFileProviderItem] = []
-	var signalWorkingSetUpdateForClosure: ((NSFileProviderItem) -> Void)?
-
-	func signalWorkingSetUpdate(for item: NSFileProviderItem) {
-		signalWorkingSetUpdateForCallsCount += 1
-		signalWorkingSetUpdateForReceivedItem = item
-		signalWorkingSetUpdateForReceivedInvocations.append(item)
-		signalWorkingSetUpdateForClosure?(item)
-	}
-
 	// MARK: - signalUpdate
 
 	var signalUpdateForCallsCount = 0
@@ -97,21 +79,21 @@ final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
 		refreshWorkingSetClosure?()
 	}
 
-	// MARK: - updateWorkingSetItem
+	// MARK: - updateWorkingSetItems
 
-	var updateWorkingSetItemCallsCount = 0
-	var updateWorkingSetItemCalled: Bool {
-		updateWorkingSetItemCallsCount > 0
+	var updateWorkingSetItemsCallsCount = 0
+	var updateWorkingSetItemsCalled: Bool {
+		updateWorkingSetItemsCallsCount > 0
 	}
 
-	var updateWorkingSetItemReceivedItem: NSFileProviderItem?
-	var updateWorkingSetItemReceivedInvocations: [NSFileProviderItem] = []
-	var updateWorkingSetItemClosure: ((NSFileProviderItem) -> Void)?
+	var updateWorkingSetItemsReceivedItems: [NSFileProviderItem]?
+	var updateWorkingSetItemsReceivedInvocations: [[NSFileProviderItem]] = []
+	var updateWorkingSetItemsClosure: (([NSFileProviderItem]) -> Void)?
 
-	func updateWorkingSetItem(_ item: NSFileProviderItem) {
-		updateWorkingSetItemCallsCount += 1
-		updateWorkingSetItemReceivedItem = item
-		updateWorkingSetItemReceivedInvocations.append(item)
-		updateWorkingSetItemClosure?(item)
+	func updateWorkingSetItems(_ items: [NSFileProviderItem]) {
+		updateWorkingSetItemsCallsCount += 1
+		updateWorkingSetItemsReceivedItems = items
+		updateWorkingSetItemsReceivedInvocations.append(items)
+		updateWorkingSetItemsClosure?(items)
 	}
 }

--- a/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderItemUpdateDelegateMock.swift
@@ -11,6 +11,24 @@ import Foundation
 @testable import CryptomatorFileProvider
 
 final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
+	// MARK: - signalWorkingSetUpdate
+
+	var signalWorkingSetUpdateForCallsCount = 0
+	var signalWorkingSetUpdateForCalled: Bool {
+		signalWorkingSetUpdateForCallsCount > 0
+	}
+
+	var signalWorkingSetUpdateForReceivedItem: NSFileProviderItem?
+	var signalWorkingSetUpdateForReceivedInvocations: [NSFileProviderItem] = []
+	var signalWorkingSetUpdateForClosure: ((NSFileProviderItem) -> Void)?
+
+	func signalWorkingSetUpdate(for item: NSFileProviderItem) {
+		signalWorkingSetUpdateForCallsCount += 1
+		signalWorkingSetUpdateForReceivedItem = item
+		signalWorkingSetUpdateForReceivedInvocations.append(item)
+		signalWorkingSetUpdateForClosure?(item)
+	}
+
 	// MARK: - signalUpdate
 
 	var signalUpdateForCallsCount = 0
@@ -47,6 +65,24 @@ final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
 		removeItemFromWorkingSetWithClosure?(identifier)
 	}
 
+	// MARK: - removeItemsFromWorkingSet
+
+	var removeItemsFromWorkingSetWithCallsCount = 0
+	var removeItemsFromWorkingSetWithCalled: Bool {
+		removeItemsFromWorkingSetWithCallsCount > 0
+	}
+
+	var removeItemsFromWorkingSetWithReceivedIdentifiers: [NSFileProviderItemIdentifier]?
+	var removeItemsFromWorkingSetWithReceivedInvocations: [[NSFileProviderItemIdentifier]] = []
+	var removeItemsFromWorkingSetWithClosure: (([NSFileProviderItemIdentifier]) -> Void)?
+
+	func removeItemsFromWorkingSet(with identifiers: [NSFileProviderItemIdentifier]) {
+		removeItemsFromWorkingSetWithCallsCount += 1
+		removeItemsFromWorkingSetWithReceivedIdentifiers = identifiers
+		removeItemsFromWorkingSetWithReceivedInvocations.append(identifiers)
+		removeItemsFromWorkingSetWithClosure?(identifiers)
+	}
+
 	// MARK: - refreshWorkingSet
 
 	var refreshWorkingSetCallsCount = 0
@@ -59,5 +95,23 @@ final class FileProviderItemUpdateDelegateMock: FileProviderItemUpdateDelegate {
 	func refreshWorkingSet() {
 		refreshWorkingSetCallsCount += 1
 		refreshWorkingSetClosure?()
+	}
+
+	// MARK: - updateWorkingSetItem
+
+	var updateWorkingSetItemCallsCount = 0
+	var updateWorkingSetItemCalled: Bool {
+		updateWorkingSetItemCallsCount > 0
+	}
+
+	var updateWorkingSetItemReceivedItem: NSFileProviderItem?
+	var updateWorkingSetItemReceivedInvocations: [NSFileProviderItem] = []
+	var updateWorkingSetItemClosure: ((NSFileProviderItem) -> Void)?
+
+	func updateWorkingSetItem(_ item: NSFileProviderItem) {
+		updateWorkingSetItemCallsCount += 1
+		updateWorkingSetItemReceivedItem = item
+		updateWorkingSetItemReceivedInvocations.append(item)
+		updateWorkingSetItemClosure?(item)
 	}
 }

--- a/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderNotificatorMock.swift
@@ -20,7 +20,6 @@ final class FileProviderNotificatorTypeMock: FileProviderNotificatorType {
 	}
 
 	private var underlyingCurrentSyncAnchor: Data!
-	var lastUnlockedDate: Date?
 
 	// MARK: - invalidatedWorkingSet
 
@@ -96,24 +95,6 @@ final class FileProviderNotificatorTypeMock: FileProviderNotificatorType {
 		return popUpdateContainerItemsClosure.map({ $0() }) ?? popUpdateContainerItemsReturnValue
 	}
 
-	// MARK: - signalWorkingSetUpdate
-
-	var signalWorkingSetUpdateForCallsCount = 0
-	var signalWorkingSetUpdateForCalled: Bool {
-		signalWorkingSetUpdateForCallsCount > 0
-	}
-
-	var signalWorkingSetUpdateForReceivedItem: NSFileProviderItem?
-	var signalWorkingSetUpdateForReceivedInvocations: [NSFileProviderItem] = []
-	var signalWorkingSetUpdateForClosure: ((NSFileProviderItem) -> Void)?
-
-	func signalWorkingSetUpdate(for item: NSFileProviderItem) {
-		signalWorkingSetUpdateForCallsCount += 1
-		signalWorkingSetUpdateForReceivedItem = item
-		signalWorkingSetUpdateForReceivedInvocations.append(item)
-		signalWorkingSetUpdateForClosure?(item)
-	}
-
 	// MARK: - signalUpdate
 
 	var signalUpdateForCallsCount = 0
@@ -182,22 +163,22 @@ final class FileProviderNotificatorTypeMock: FileProviderNotificatorType {
 		refreshWorkingSetClosure?()
 	}
 
-	// MARK: - updateWorkingSetItem
+	// MARK: - updateWorkingSetItems
 
-	var updateWorkingSetItemCallsCount = 0
-	var updateWorkingSetItemCalled: Bool {
-		updateWorkingSetItemCallsCount > 0
+	var updateWorkingSetItemsCallsCount = 0
+	var updateWorkingSetItemsCalled: Bool {
+		updateWorkingSetItemsCallsCount > 0
 	}
 
-	var updateWorkingSetItemReceivedItem: NSFileProviderItem?
-	var updateWorkingSetItemReceivedInvocations: [NSFileProviderItem] = []
-	var updateWorkingSetItemClosure: ((NSFileProviderItem) -> Void)?
+	var updateWorkingSetItemsReceivedItems: [NSFileProviderItem]?
+	var updateWorkingSetItemsReceivedInvocations: [[NSFileProviderItem]] = []
+	var updateWorkingSetItemsClosure: (([NSFileProviderItem]) -> Void)?
 
-	func updateWorkingSetItem(_ item: NSFileProviderItem) {
-		updateWorkingSetItemCallsCount += 1
-		updateWorkingSetItemReceivedItem = item
-		updateWorkingSetItemReceivedInvocations.append(item)
-		updateWorkingSetItemClosure?(item)
+	func updateWorkingSetItems(_ items: [NSFileProviderItem]) {
+		updateWorkingSetItemsCallsCount += 1
+		updateWorkingSetItemsReceivedItems = items
+		updateWorkingSetItemsReceivedInvocations.append(items)
+		updateWorkingSetItemsClosure?(items)
 	}
 }
 

--- a/CryptomatorFileProviderTests/Mocks/NSFileProviderChangeObserverMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/NSFileProviderChangeObserverMock.swift
@@ -1,0 +1,87 @@
+//
+//  NSFileProviderChangeObserverMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+// swiftlint:disable all
+final class NSFileProviderChangeObserverMock: NSObject, NSFileProviderChangeObserver {
+	// MARK: - didUpdate
+
+	var didUpdateCallsCount = 0
+	var didUpdateCalled: Bool {
+		didUpdateCallsCount > 0
+	}
+
+	var didUpdateReceivedUpdatedItems: [NSFileProviderItemProtocol]?
+	var didUpdateReceivedInvocations: [[NSFileProviderItemProtocol]] = []
+	var didUpdateClosure: (([NSFileProviderItemProtocol]) -> Void)?
+
+	func didUpdate(_ updatedItems: [NSFileProviderItemProtocol]) {
+		didUpdateCallsCount += 1
+		didUpdateReceivedUpdatedItems = updatedItems
+		didUpdateReceivedInvocations.append(updatedItems)
+		didUpdateClosure?(updatedItems)
+	}
+
+	// MARK: - didDeleteItems
+
+	var didDeleteItemsWithIdentifiersCallsCount = 0
+	var didDeleteItemsWithIdentifiersCalled: Bool {
+		didDeleteItemsWithIdentifiersCallsCount > 0
+	}
+
+	var didDeleteItemsWithIdentifiersReceivedDeletedItemIdentifiers: [NSFileProviderItemIdentifier]?
+	var didDeleteItemsWithIdentifiersReceivedInvocations: [[NSFileProviderItemIdentifier]] = []
+	var didDeleteItemsWithIdentifiersClosure: (([NSFileProviderItemIdentifier]) -> Void)?
+
+	func didDeleteItems(withIdentifiers deletedItemIdentifiers: [NSFileProviderItemIdentifier]) {
+		didDeleteItemsWithIdentifiersCallsCount += 1
+		didDeleteItemsWithIdentifiersReceivedDeletedItemIdentifiers = deletedItemIdentifiers
+		didDeleteItemsWithIdentifiersReceivedInvocations.append(deletedItemIdentifiers)
+		didDeleteItemsWithIdentifiersClosure?(deletedItemIdentifiers)
+	}
+
+	// MARK: - finishEnumeratingChanges
+
+	var finishEnumeratingChangesUpToMoreComingCallsCount = 0
+	var finishEnumeratingChangesUpToMoreComingCalled: Bool {
+		finishEnumeratingChangesUpToMoreComingCallsCount > 0
+	}
+
+	var finishEnumeratingChangesUpToMoreComingReceivedArguments: (anchor: NSFileProviderSyncAnchor, moreComing: Bool)?
+	var finishEnumeratingChangesUpToMoreComingReceivedInvocations: [(anchor: NSFileProviderSyncAnchor, moreComing: Bool)] = []
+	var finishEnumeratingChangesUpToMoreComingClosure: ((NSFileProviderSyncAnchor, Bool) -> Void)?
+
+	func finishEnumeratingChanges(upTo anchor: NSFileProviderSyncAnchor, moreComing: Bool) {
+		finishEnumeratingChangesUpToMoreComingCallsCount += 1
+		finishEnumeratingChangesUpToMoreComingReceivedArguments = (anchor: anchor, moreComing: moreComing)
+		finishEnumeratingChangesUpToMoreComingReceivedInvocations.append((anchor: anchor, moreComing: moreComing))
+		finishEnumeratingChangesUpToMoreComingClosure?(anchor, moreComing)
+	}
+
+	// MARK: - finishEnumeratingWithError
+
+	var finishEnumeratingWithErrorCallsCount = 0
+	var finishEnumeratingWithErrorCalled: Bool {
+		finishEnumeratingWithErrorCallsCount > 0
+	}
+
+	var finishEnumeratingWithErrorReceivedError: Error?
+	var finishEnumeratingWithErrorReceivedInvocations: [Error] = []
+	var finishEnumeratingWithErrorClosure: ((Error) -> Void)?
+
+	func finishEnumeratingWithError(_ error: Error) {
+		finishEnumeratingWithErrorCallsCount += 1
+		finishEnumeratingWithErrorReceivedError = error
+		finishEnumeratingWithErrorReceivedInvocations.append(error)
+		finishEnumeratingWithErrorClosure?(error)
+	}
+}
+
+// swiftlint:enable all

--- a/CryptomatorFileProviderTests/Mocks/NSFileProviderEnumerationObserverMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/NSFileProviderEnumerationObserverMock.swift
@@ -1,0 +1,66 @@
+//
+//  NSFileProviderEnumerationObserverMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+final class NSFileProviderEnumerationObserverMock: NSObject, NSFileProviderEnumerationObserver {
+	// MARK: - didEnumerate
+
+	var didEnumerateCallsCount = 0
+	var didEnumerateCalled: Bool {
+		didEnumerateCallsCount > 0
+	}
+
+	var didEnumerateReceivedUpdatedItems: [NSFileProviderItemProtocol]?
+	var didEnumerateReceivedInvocations: [[NSFileProviderItemProtocol]] = []
+	var didEnumerateClosure: (([NSFileProviderItemProtocol]) -> Void)?
+
+	func didEnumerate(_ updatedItems: [NSFileProviderItemProtocol]) {
+		didEnumerateCallsCount += 1
+		didEnumerateReceivedUpdatedItems = updatedItems
+		didEnumerateReceivedInvocations.append(updatedItems)
+		didEnumerateClosure?(updatedItems)
+	}
+
+	// MARK: - finishEnumerating
+
+	var finishEnumeratingUpToCallsCount = 0
+	var finishEnumeratingUpToCalled: Bool {
+		finishEnumeratingUpToCallsCount > 0
+	}
+
+	var finishEnumeratingUpToReceivedNextPage: NSFileProviderPage?
+	var finishEnumeratingUpToReceivedInvocations: [NSFileProviderPage?] = []
+	var finishEnumeratingUpToClosure: ((NSFileProviderPage?) -> Void)?
+
+	func finishEnumerating(upTo nextPage: NSFileProviderPage?) {
+		finishEnumeratingUpToCallsCount += 1
+		finishEnumeratingUpToReceivedNextPage = nextPage
+		finishEnumeratingUpToReceivedInvocations.append(nextPage)
+		finishEnumeratingUpToClosure?(nextPage)
+	}
+
+	// MARK: - finishEnumeratingWithError
+
+	var finishEnumeratingWithErrorCallsCount = 0
+	var finishEnumeratingWithErrorCalled: Bool {
+		finishEnumeratingWithErrorCallsCount > 0
+	}
+
+	var finishEnumeratingWithErrorReceivedError: Error?
+	var finishEnumeratingWithErrorReceivedInvocations: [Error] = []
+	var finishEnumeratingWithErrorClosure: ((Error) -> Void)?
+
+	func finishEnumeratingWithError(_ error: Error) {
+		finishEnumeratingWithErrorCallsCount += 1
+		finishEnumeratingWithErrorReceivedError = error
+		finishEnumeratingWithErrorReceivedInvocations.append(error)
+		finishEnumeratingWithErrorClosure?(error)
+	}
+}

--- a/CryptomatorFileProviderTests/Mocks/WorkingSetObservingMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/WorkingSetObservingMock.swift
@@ -1,0 +1,26 @@
+//
+//  WorkingSetObservingMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+@testable import CryptomatorFileProvider
+
+final class WorkingSetObservingMock: WorkingSetObserving {
+	// MARK: - startObservation
+
+	var startObservationCallsCount = 0
+	var startObservationCalled: Bool {
+		startObservationCallsCount > 0
+	}
+
+	var startObservationClosure: (() -> Void)?
+
+	func startObservation() {
+		startObservationCallsCount += 1
+		startObservationClosure?()
+	}
+}

--- a/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
+++ b/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
@@ -1,0 +1,54 @@
+//
+//  WorkingSetObserverTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 25.01.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import GRDB
+import XCTest
+@testable import CryptomatorFileProvider
+
+class WorkingSetObserverTests: XCTestCase {
+	var observer: WorkingSetObserver!
+	var notificatorMock: FileProviderNotificatorTypeMock!
+	let updatedMetadataIDs: [Int64] = [1, 2, 3]
+	lazy var updatedItems: [FileProviderItem] = updatedMetadataIDs.map {
+		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false))
+	}
+
+	override func setUpWithError() throws {
+		notificatorMock = FileProviderNotificatorTypeMock()
+		observer = WorkingSetObserver(database: DatabaseQueue(), notificator: notificatorMock, uploadTaskManager: CloudTaskExecutorTestCase.UploadTaskManagerMock(), cachedFileManager: CloudTaskExecutorTestCase.CachedFileManagerMock())
+	}
+
+	func testHandleNewWorkingSetUpdate() throws {
+		observer.handleWorkingSetUpdate(items: updatedItems)
+		XCTAssertFalse(notificatorMock.removeItemsFromWorkingSetWithCalled)
+		XCTAssertFalse(notificatorMock.removeItemFromWorkingSetWithCalled)
+
+		XCTAssertEqual(1, notificatorMock.updateWorkingSetItemsCallsCount)
+		let actualUpdatedItems = notificatorMock.updateWorkingSetItemsReceivedItems as? [FileProviderItem]
+		XCTAssertEqual(updatedItems.sorted(), actualUpdatedItems?.sorted())
+		XCTAssertEqual(1, notificatorMock.refreshWorkingSetCallsCount)
+	}
+
+	func testHandleWorkingSetUpdateRemoveItems() throws {
+		observer.handleWorkingSetUpdate(items: updatedItems)
+		observer.handleWorkingSetUpdate(items: [])
+		let actualRemovedItems = notificatorMock.removeItemsFromWorkingSetWithReceivedIdentifiers
+		XCTAssertEqual(updatedItems.map { $0.itemIdentifier }.sorted(), actualRemovedItems?.sorted())
+		XCTAssertEqual(2, notificatorMock.refreshWorkingSetCallsCount)
+	}
+
+	func testHandleWorkingSetUpdatePartiallyRemoveItems() throws {
+		observer.handleWorkingSetUpdate(items: updatedItems)
+		let removedItem = updatedItems.removeLast()
+		observer.handleWorkingSetUpdate(items: updatedItems)
+		let actualRemovedItems = notificatorMock.removeItemsFromWorkingSetWithReceivedIdentifiers
+		XCTAssertEqual([removedItem.itemIdentifier].sorted(), actualRemovedItems?.sorted())
+		XCTAssertEqual(2, notificatorMock.refreshWorkingSetCallsCount)
+	}
+}

--- a/FileProviderExtension/FileProvider+Actions.swift
+++ b/FileProviderExtension/FileProvider+Actions.swift
@@ -66,4 +66,26 @@ extension FileProviderExtension {
 		}
 		adapter.deleteItem(withIdentifier: itemIdentifier, completionHandler: completionHandler)
 	}
+
+	override func setFavoriteRank(_ favoriteRank: NSNumber?, forItemIdentifier itemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
+		DDLogDebug("FPExt: setFavoriteRank(_: \(String(describing: favoriteRank)), forItemIdentifier: \(itemIdentifier.rawValue)) called")
+		let adapter: FileProviderAdapterType
+		do {
+			adapter = try getAdapterWithWrappedError()
+		} catch {
+			return completionHandler(nil, error)
+		}
+		adapter.setFavoriteRank(favoriteRank, forItemIdentifier: itemIdentifier, completionHandler: completionHandler)
+	}
+
+	override func setTagData(_ tagData: Data?, forItemIdentifier itemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
+		DDLogDebug("FPExt: setTagData(_: \(String(describing: tagData)), forItemIdentifier: \(itemIdentifier.rawValue)) called")
+		let adapter: FileProviderAdapterType
+		do {
+			adapter = try getAdapterWithWrappedError()
+		} catch {
+			return completionHandler(nil, error)
+		}
+		adapter.setTagData(tagData, forItemIdentifier: itemIdentifier, completionHandler: completionHandler)
+	}
 }

--- a/FileProviderExtension/VaultUnlockingServiceSource.swift
+++ b/FileProviderExtension/VaultUnlockingServiceSource.swift
@@ -51,13 +51,13 @@ class VaultUnlockingServiceSource: NSObject, NSFileProviderServiceSource, VaultU
 
 	func unlockVault(kek: [UInt8], reply: @escaping (Error?) -> Void) {
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-			guard let domain = self.fileprovider.domain else {
+			guard let domain = self.fileprovider.domain, let notificator = self.fileprovider.notificator else {
 				DDLogError("Unlocking vault failed, unable to find FileProviderDomain")
 				reply(VaultManagerError.fileProviderDomainNotFound)
 				return
 			}
 			do {
-				try FileProviderAdapterManager.shared.unlockVault(with: domain.identifier, kek: kek, dbPath: self.fileprovider.dbPath, delegate: self.fileprovider, notificator: self.fileprovider.notificator)
+				try FileProviderAdapterManager.shared.unlockVault(with: domain.identifier, kek: kek, dbPath: self.fileprovider.dbPath, delegate: self.fileprovider, notificator: notificator)
 				DDLogInfo("Unlocked vault \"\(domain.displayName)\" (\(domain.identifier.rawValue))")
 				reply(nil)
 			} catch {


### PR DESCRIPTION
This PR adds support for favoriting folders and tagging items in the Files app and thus fixes #79.
For this the database associated to the respective FileProviderDomain has to be migrated for the first time, because now the two optional entries `favoriteRank` and `tagData` are added to the `itemMetadata` table.

The correct support of favorites and tag data requires that these items are also in the working set.
Therefore it can happen that these items appear in the Siri search if the vault is unlocked.
If the vault is locked (manually or automatically), the working set will still be completely invalidated, so that even the favorited or tagged items will not be displayed.

For a consistent display of the working set in unlocked state, the WorkingSetObserver has been introduced, which monitors the `itemMetadata` table for changes affecting the working set and updates the working set accordingly.

Since it is not possible to write unit tests for an App Extension Target, the `FileProviderEnumerator` class has been moved from the App Extension Target `FileProviderExtension` to our framework `CryptomatorFileProvider`.