### PR TITLE
Bugfix: disallow certain special characters in item names

### DIFF
--- a/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewModel.swift
+++ b/Cryptomator/AddVault/CreateNewVault/SetVaultNameViewModel.swift
@@ -33,21 +33,15 @@ class SetVaultNameViewModel: SingleSectionTableViewModel, SetVaultNameViewModelP
 		return vaultNameCellViewModel.input.value.trimmingCharacters(in: .whitespacesAndNewlines)
 	}
 
-	// disallowed characters \ / : * ? " < > |
-	// cannot end with .
-	// swiftlint:disable:next force_try
-	private let regex = try! NSRegularExpression(pattern: "[\\\\/:\\*\\?\"<>\\|]|\\.$")
-
 	private lazy var subscribers = Set<AnyCancellable>()
 
+	// disallowed characters \ / : * ? " < > |
+	// cannot end with .
 	func getValidatedVaultName() throws -> String {
 		guard !trimmedVaultName.isEmpty else {
 			throw SetVaultNameViewModelError.emptyVaultName
 		}
-		let range = NSRange(location: 0, length: trimmedVaultName.utf16.count)
-		guard regex.firstMatch(in: trimmedVaultName, options: [], range: range) == nil else {
-			throw SetVaultNameViewModelError.invalidInput
-		}
+		try ItemNameValidator.validateName(trimmedVaultName)
 		return trimmedVaultName
 	}
 
@@ -61,14 +55,11 @@ class SetVaultNameViewModel: SingleSectionTableViewModel, SetVaultNameViewModelP
 
 enum SetVaultNameViewModelError: LocalizedError {
 	case emptyVaultName
-	case invalidInput
 
 	var errorDescription: String? {
 		switch self {
 		case .emptyVaultName:
 			return LocalizedString.getValue("addVault.createNewVault.setVaultName.error.emptyVaultName")
-		case .invalidInput:
-			return LocalizedString.getValue("addVault.createNewVault.setVaultName.error.invalidInput")
 		}
 	}
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/ItemNameValidator.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/ItemNameValidator.swift
@@ -1,0 +1,52 @@
+//
+//  ItemNameValidator.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+
+public enum ItemNameValidatorError: Error, Equatable {
+	case nameEndsWithPeriod
+	case nameEndsWithSpace
+	case nameContainsIllegalCharacter(String)
+}
+
+extension ItemNameValidatorError: LocalizedError {
+	public var errorDescription: String? {
+		switch self {
+		case .nameEndsWithPeriod:
+			return LocalizedString.getValue("nameValidation.error.endsWithPeriod")
+		case .nameEndsWithSpace:
+			return LocalizedString.getValue("nameValidation.error.endsWithSpace")
+		case let .nameContainsIllegalCharacter(illegalCharacter):
+			return String(format: LocalizedString.getValue("nameValidation.error.containsIllegalCharacter"), illegalCharacter)
+		}
+	}
+}
+
+public enum ItemNameValidator {
+	/**
+	 Validates the item name.
+
+	 Disallowed characters are: `\ / : * ? " < > |`
+	 Furthermore, the item name cannot end with a period or space.
+	 */
+	public static func validateName(_ name: String) throws {
+		if name.hasSuffix(".") {
+			throw ItemNameValidatorError.nameEndsWithPeriod
+		}
+		if name.hasSuffix(" ") {
+			throw ItemNameValidatorError.nameEndsWithSpace
+		}
+
+		let regex = try NSRegularExpression(pattern: "[\\\\/:\\*\\?\"<>\\|]")
+		let range = NSRange(location: 0, length: name.utf16.count)
+		if let match = regex.firstMatch(in: name, options: [], range: range) {
+			let illegalCharacter = String(name[Range(match.range, in: name)!])
+			throw ItemNameValidatorError.nameContainsIllegalCharacter(illegalCharacter)
+		}
+	}
+}

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/ItemNameValidatorTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/ItemNameValidatorTests.swift
@@ -1,0 +1,57 @@
+//
+//  ItemNameValidatorTests.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 24.01.22.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import XCTest
+
+class ItemNameValidatorTests: XCTestCase {
+	func testValidateItemName() throws {
+		try ItemNameValidator.validateName("foo..pages")
+		assertThrowsItemNameValidatorError(try ItemNameValidator.validateName("foo."), expectedError: .nameEndsWithPeriod)
+		assertThrowsItemNameValidatorError(try ItemNameValidator.validateName("foo "), expectedError: .nameEndsWithSpace)
+	}
+
+	func testValidateItemNameIllegalCharacter() throws {
+		// \ inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo\\o", illegalCharacter: "\\")
+
+		// / inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo/o", illegalCharacter: "/")
+
+		// : inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo:o", illegalCharacter: ":")
+
+		// * inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo*o", illegalCharacter: "*")
+
+		// ? inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo?o", illegalCharacter: "?")
+
+		// " inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo\"o", illegalCharacter: "\"")
+
+		// < inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo<o", illegalCharacter: "<")
+
+		// > inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo>o", illegalCharacter: ">")
+
+		// | inside name
+		assertThrowsIllegalCharacterErrorWhenValidating("fo|o", illegalCharacter: "|")
+	}
+
+	private func assertThrowsIllegalCharacterErrorWhenValidating(_ name: String, illegalCharacter: String) {
+		assertThrowsItemNameValidatorError(try ItemNameValidator.validateName(name), expectedError: .nameContainsIllegalCharacter(illegalCharacter))
+	}
+
+	private func assertThrowsItemNameValidatorError(_ expression: @autoclosure () throws -> Void, expectedError: ItemNameValidatorError) {
+		XCTAssertThrowsError(try expression()) { error in
+			XCTAssertEqual(expectedError, error as? ItemNameValidatorError)
+		}
+	}
+}

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -381,24 +381,11 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	}
 
 	func validateItemName(_ name: String) throws {
-		if name.hasSuffix(".") {
-			throw createInvalidNameError(localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithPeriod"))
+		do {
+			try ItemNameValidator.validateName(name)
+		} catch let error as ItemNameValidatorError {
+			throw CocoaError(.fileWriteInvalidFileName, userInfo: [NSLocalizedDescriptionKey: error.localizedDescription, NSLocalizedFailureReasonErrorKey: ""])
 		}
-		if name.hasSuffix(" ") {
-			throw createInvalidNameError(localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithSpace"))
-		}
-
-		let regex = try NSRegularExpression(pattern: "[\\\\/:\\*\\?\"<>\\|]")
-		let range = NSRange(location: 0, length: name.utf16.count)
-		if let match = regex.firstMatch(in: name, options: [], range: range) {
-			let illegalCharacter = String(name[Range(match.range, in: name)!])
-			let localizedDescription = String(format: LocalizedString.getValue("fileProvider.rename.error.containsIllegalCharacter"), illegalCharacter)
-			throw createInvalidNameError(localizedDescription: localizedDescription)
-		}
-	}
-
-	private func createInvalidNameError(localizedDescription: String) -> CocoaError {
-		return CocoaError(.fileWriteInvalidFileName, userInfo: [NSLocalizedDescriptionKey: localizedDescription, NSLocalizedFailureReasonErrorKey: ""])
 	}
 
 	// MARK: Delete Item

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
@@ -232,31 +232,20 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		try adapter.validateItemName("Foo Bar.pages")
 		try adapter.validateItemName("Foo")
 		try adapter.validateItemName(".foo")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo."), localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithPeriod"))
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo "), localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithSpace"))
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\\o"), illegalCharacter: "\\")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo/o"), illegalCharacter: "/")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo:o"), illegalCharacter: ":")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo*o"), illegalCharacter: "*")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo?o"), illegalCharacter: "?")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\"o"), illegalCharacter: "\"")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo<o"), illegalCharacter: "<")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo>o"), illegalCharacter: ">")
-		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo|o"), illegalCharacter: "|")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo."), localizedDescription: ItemNameValidatorError.nameEndsWithPeriod.localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo "), localizedDescription: ItemNameValidatorError.nameEndsWithSpace.localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\\o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("\\").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo/o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("/").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo:o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter(":").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo*o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("*").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo?o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("?").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\"o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("\"").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo<o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("<").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo>o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter(">").localizedDescription)
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo|o"), localizedDescription: ItemNameValidatorError.nameContainsIllegalCharacter("|").localizedDescription)
 	}
 
 	private func assertThrowsInvalidNameCocoaError(_ expression: @autoclosure () throws -> Void, localizedDescription: String) {
-		let expectedError = CocoaError(.fileWriteInvalidFileName, userInfo: [
-			NSLocalizedDescriptionKey: localizedDescription,
-			NSLocalizedFailureReasonErrorKey: ""
-		])
-		XCTAssertThrowsError(try expression()) { error in
-			XCTAssertEqual(expectedError, error as? CocoaError)
-		}
-	}
-
-	private func assertThrowsInvalidNameCocoaError(_ expression: @autoclosure () throws -> Void, illegalCharacter: String) {
-		let localizedDescription = String(format: LocalizedString.getValue("fileProvider.rename.error.containsIllegalCharacter"), illegalCharacter)
 		let expectedError = CocoaError(.fileWriteInvalidFileName, userInfo: [
 			NSLocalizedDescriptionKey: localizedDescription,
 			NSLocalizedFailureReasonErrorKey: ""

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
@@ -7,6 +7,7 @@
 //
 
 import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
 import Foundation
 import Promises
 import XCTest
@@ -223,5 +224,45 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+	}
+
+	func testValidateItemName() throws {
+		try adapter.validateItemName("Foo.pages")
+		try adapter.validateItemName("Foo..pages")
+		try adapter.validateItemName("Foo Bar.pages")
+		try adapter.validateItemName("Foo")
+		try adapter.validateItemName(".foo")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo."), localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithPeriod"))
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Foo "), localizedDescription: LocalizedString.getValue("fileProvider.rename.error.endsWithSpace"))
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\\o"), illegalCharacter: "\\")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo/o"), illegalCharacter: "/")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo:o"), illegalCharacter: ":")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo*o"), illegalCharacter: "*")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo?o"), illegalCharacter: "?")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo\"o"), illegalCharacter: "\"")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo<o"), illegalCharacter: "<")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo>o"), illegalCharacter: ">")
+		assertThrowsInvalidNameCocoaError(try adapter.validateItemName("Fo|o"), illegalCharacter: "|")
+	}
+
+	private func assertThrowsInvalidNameCocoaError(_ expression: @autoclosure () throws -> Void, localizedDescription: String) {
+		let expectedError = CocoaError(.fileWriteInvalidFileName, userInfo: [
+			NSLocalizedDescriptionKey: localizedDescription,
+			NSLocalizedFailureReasonErrorKey: ""
+		])
+		XCTAssertThrowsError(try expression()) { error in
+			XCTAssertEqual(expectedError, error as? CocoaError)
+		}
+	}
+
+	private func assertThrowsInvalidNameCocoaError(_ expression: @autoclosure () throws -> Void, illegalCharacter: String) {
+		let localizedDescription = String(format: LocalizedString.getValue("fileProvider.rename.error.containsIllegalCharacter"), illegalCharacter)
+		let expectedError = CocoaError(.fileWriteInvalidFileName, userInfo: [
+			NSLocalizedDescriptionKey: localizedDescription,
+			NSLocalizedFailureReasonErrorKey: ""
+		])
+		XCTAssertThrowsError(try expression()) { error in
+			XCTAssertEqual(expectedError, error as? CocoaError)
+		}
 	}
 }

--- a/CryptomatorTests/SetVaultNameViewModelTests.swift
+++ b/CryptomatorTests/SetVaultNameViewModelTests.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import CryptomatorCommonCore
 import XCTest
 @testable import Cryptomator
 
@@ -36,49 +37,49 @@ class SetVaultNameViewModelTests: XCTestCase {
 
 	func testValidateInputForEmptyVaultName() throws {
 		XCTAssert(viewModel.vaultNameCellViewModel.input.value.isEmpty)
-		getValidatetVaultNameThrowsEmptyVaultNameError()
+		getValidatedVaultNameThrowsEmptyVaultNameError()
 	}
 
 	func testValidateInputForDisallowedCharacters() throws {
 		// \ inside name
 		setVaultName("fo\\o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("\\"))
 
 		// / inside name
 		setVaultName("fo/o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("/"))
 
 		// : inside name
 		setVaultName("fo:o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter(":"))
 
 		// * inside name
 		setVaultName("fo*o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("*"))
 
 		// ? inside name
 		setVaultName("fo?o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("?"))
 
 		// " inside name
 		setVaultName("fo\"o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("\""))
 
 		// < inside name
 		setVaultName("fo<o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("<"))
 
 		// > inside name
 		setVaultName("fo>o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter(">"))
 
 		// | inside name
 		setVaultName("fo|o")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameContainsIllegalCharacter("|"))
 
 		// Point at the end
 		setVaultName("foo.")
-		getValidatedVaultNameThrowsInvalidInputError()
+		getValidatedVaultNameThrowsError(ItemNameValidatorError.nameEndsWithPeriod)
 	}
 
 	func testReturnButtonSupport() {
@@ -97,16 +98,13 @@ class SetVaultNameViewModelTests: XCTestCase {
 		setVaultName(name, viewModel: viewModel)
 	}
 
-	private func getValidatedVaultNameThrowsInvalidInputError() {
+	private func getValidatedVaultNameThrowsError(_ expectedError: ItemNameValidatorError) {
 		XCTAssertThrowsError(try viewModel.getValidatedVaultName()) { error in
-			guard case SetVaultNameViewModelError.invalidInput = error else {
-				XCTFail("Throws the wrong error: \(error)")
-				return
-			}
+			XCTAssertEqual(expectedError, error as? ItemNameValidatorError)
 		}
 	}
 
-	private func getValidatetVaultNameThrowsEmptyVaultNameError() {
+	private func getValidatedVaultNameThrowsEmptyVaultNameError() {
 		XCTAssertThrowsError(try viewModel.getValidatedVaultName()) { error in
 			guard case SetVaultNameViewModelError.emptyVaultName = error else {
 				XCTFail("Throws the wrong error: \(error)")

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -39,7 +39,7 @@
 "addVault.createNewVault.setVaultName.header.title" = "Choose a name for the vault.";
 "addVault.createNewVault.setVaultName.cells.name" = "Vault Name";
 "addVault.createNewVault.setVaultName.error.emptyVaultName" = "Vault name cannot be empty.";
-"addVault.createNewVault.setVaultName.error.invalidInput" = "Vault name should not contain \\ / : * ? \" < > | or end with a period.";
+
 "addVault.createNewVault.chooseCloud.header" = "Where should Cryptomator store the encrypted files of your vault?";
 "addVault.createNewVault.chooseFolder.error.vaultNameCollision" = "\"%@\" already exists at this location. Choose a different vault name or location.";
 "addVault.createNewVault.detectedMasterkey.text" = "Cryptomator detected an existing vault at this location.\nIn order to create a new vault, please go back and choose a different folder.";
@@ -89,9 +89,6 @@
 "fileProvider.onboarding.title" = "Welcome";
 "fileProvider.onboarding.info" = "Thanks for choosing Cryptomator to protect your files. To get started, go to the main app and add a vault.";
 "fileProvider.onboarding.button.openCryptomator" = "Open Cryptomator";
-"fileProvider.rename.error.endsWithPeriod" = "You can't use a name that ends with a period. Please choose another name.";
-"fileProvider.rename.error.endsWithSpace" = "You can't use a name that ends with a space. Please choose another name.";
-"fileProvider.rename.error.containsIllegalCharacter" = "You can't use a name that contains \"%@\". Please choose another name.";
 
 "keepUnlocked.alert.title" = "Lock Vault?";
 "keepUnlocked.alert.message" = "This change requires your vault to be locked in order to take effect.";
@@ -112,6 +109,10 @@
 "localFileSystemAuthentication.info.footer" = "File providers that are grayed out don't support \"picking folders\". This is not a limitation of Cryptomator.";
 
 "maintenanceModeError.runningCloudTask" = "Operation cannot be performed because other background operations for this vault have to finish first. Please try again later.";
+
+"nameValidation.error.endsWithPeriod" = "You can't use a name that ends with a period. Please choose another name.";
+"nameValidation.error.endsWithSpace" = "You can't use a name that ends with a space. Please choose another name.";
+"nameValidation.error.containsIllegalCharacter" = "You can't use a name that contains \"%@\". Please choose another name.";
 
 "onboarding.title" = "Welcome";
 "onboarding.info" = "Thanks for choosing Cryptomator to protect your files.\n\nWith Cryptomator, the key to your data is in your hands. Cryptomator encrypts your data quickly and easily.\n\nThis app is fully integrated into the Files app. Make sure to enable Cryptomator in the Files app later to access your vaults.";

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -89,6 +89,9 @@
 "fileProvider.onboarding.title" = "Welcome";
 "fileProvider.onboarding.info" = "Thanks for choosing Cryptomator to protect your files. To get started, go to the main app and add a vault.";
 "fileProvider.onboarding.button.openCryptomator" = "Open Cryptomator";
+"fileProvider.rename.error.endsWithPeriod" = "You can't use a name that ends with a period. Please choose another name.";
+"fileProvider.rename.error.endsWithSpace" = "You can't use a name that ends with a space. Please choose another name.";
+"fileProvider.rename.error.containsIllegalCharacter" = "You can't use a name that contains \"%@\". Please choose another name.";
 
 "keepUnlocked.alert.title" = "Lock Vault?";
 "keepUnlocked.alert.message" = "This change requires your vault to be locked in order to take effect.";


### PR DESCRIPTION
Fixes  #152.
The validation of the vault name and a general FileProvider item has been unified.

Small background info on the error display in the Files app:
In the FileProviderExtension only errors with `NSFileProviderErrorDomain` or `CocoaErrorDomain` are displayed and (meaningfully) processed. In this case we can override the `localizedErrorDescription` of the `CocoaError.fileWriteInvalidFileName` to display our own error messages.
Additionally, we set the `localizedFailureReason` to an empty string to mimic the default alert message style from the Files app.