### PR TITLE
Added `shouldAutoLockVault` check into vault lock status update

### DIFF
--- a/CryptomatorFileProvider/FileProviderAdapterManager.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterManager.swift
@@ -93,10 +93,13 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 	}
 
 	public func vaultIsUnlocked(domainIdentifier: NSFileProviderDomainIdentifier) -> Bool {
+		updateLockStatus(domainIdentifier: domainIdentifier)
 		return adapterCache.getItem(identifier: domainIdentifier) != nil
 	}
 
 	public func getDomainIdentifiersOfUnlockedVaults() -> [NSFileProviderDomainIdentifier] {
+		let cachedIdentifiers = adapterCache.getAllCachedIdentifiers()
+		cachedIdentifiers.forEach { updateLockStatus(domainIdentifier: $0) }
 		return adapterCache.getAllCachedIdentifiers()
 	}
 
@@ -166,6 +169,16 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		try masterkeyCacheManager.removeCachedMasterkey(forVaultUID: domainIdentifier.rawValue)
 		let notificator = try notificatorManager.getFileProviderNotificator(for: NSFileProviderDomain(identifier: domainIdentifier, displayName: "", pathRelativeToDocumentStorage: ""))
 		notificator.refreshWorkingSet()
+	}
+
+	private func updateLockStatus(domainIdentifier: NSFileProviderDomainIdentifier) {
+		if vaultKeepUnlockedHelper.shouldAutoLockVault(withVaultUID: domainIdentifier.rawValue) {
+			do {
+				try gracefulLockVault(with: domainIdentifier)
+			} catch {
+				DDLogDebug("Graceful locking vault (\(domainIdentifier.rawValue)) failed with error: \(error)")
+			}
+		}
 	}
 }
 

--- a/CryptomatorFileProviderTests/FileProviderAdapterManagerTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapterManagerTests.swift
@@ -184,4 +184,69 @@ class FileProviderAdapterManagerTests: XCTestCase {
 
 		try assertLastUsedDateSet()
 	}
+
+	// MARK: Vault Lock Status
+
+	func testVaultIsUnlockedAdapterNotCached() throws {
+		adapterCacheMock.getItemIdentifierReturnValue = nil
+		vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReturnValue = false
+		XCTAssertFalse(fileProviderAdapterManager.vaultIsUnlocked(domainIdentifier: domain.identifier))
+		XCTAssertEqual([domain.identifier], adapterCacheMock.getItemIdentifierReceivedInvocations)
+		XCTAssertEqual([vaultUID], vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReceivedInvocations)
+	}
+
+	func testVaultIsUnlockedAdapterCached() throws {
+		let adapterCacheItem = AdapterCacheItem(adapter: FileProviderAdapterTypeMock(), maintenanceManager: MaintenanceManagerMock(), workingSetObserver: workingSetObservationMock)
+		adapterCacheMock.getItemIdentifierReturnValue = adapterCacheItem
+		vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReturnValue = false
+		XCTAssert(fileProviderAdapterManager.vaultIsUnlocked(domainIdentifier: domain.identifier))
+		XCTAssertEqual([domain.identifier], adapterCacheMock.getItemIdentifierReceivedInvocations)
+		XCTAssertEqual([vaultUID], vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReceivedInvocations)
+	}
+
+	func testVaultIsUnlockedAutoLocks() throws {
+		notificatorManagerMock.getFileProviderNotificatorForReturnValue = fileProviderNotificatorMock
+		let maintenanceManagerMock = MaintenanceManagerMock()
+		let adapterCacheItem = AdapterCacheItem(adapter: FileProviderAdapterTypeMock(), maintenanceManager: maintenanceManagerMock, workingSetObserver: workingSetObservationMock)
+		var cache = [NSFileProviderDomainIdentifier: AdapterCacheItem]()
+		cache[domain.identifier] = adapterCacheItem
+		adapterCacheMock.getItemIdentifierClosure = { return cache[$0] }
+		adapterCacheMock.removeItemIdentifierClosure = { cache[$0] = nil }
+		vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReturnValue = true
+		XCTAssertFalse(fileProviderAdapterManager.vaultIsUnlocked(domainIdentifier: domain.identifier))
+		XCTAssertEqual([vaultUID], vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDReceivedInvocations)
+		XCTAssertEqual(1, maintenanceManagerMock.enableMaintenanceModeCallsCount)
+		XCTAssertEqual(1, maintenanceManagerMock.disableMaintenanceModeCallsCount)
+		XCTAssert(cache.isEmpty)
+	}
+
+	func testGetDomainIdentifiersOfUnlockedVaults() throws {
+		let unlockedDomainIdentifier = NSFileProviderDomainIdentifier(rawValue: "1")
+		let lockedDomainIdentifier = NSFileProviderDomainIdentifier(rawValue: "2")
+		notificatorManagerMock.getFileProviderNotificatorForReturnValue = fileProviderNotificatorMock
+		let unlockedVaultMaintenanceManagerMock = MaintenanceManagerMock()
+		let lockedVaultMaintenanceManagerMock = MaintenanceManagerMock()
+		let unlockedVaultAdapterCacheItem = AdapterCacheItem(adapter: FileProviderAdapterTypeMock(), maintenanceManager: unlockedVaultMaintenanceManagerMock, workingSetObserver: workingSetObservationMock)
+		let lockedVaultAdapterCacheItem = AdapterCacheItem(adapter: FileProviderAdapterTypeMock(), maintenanceManager: lockedVaultMaintenanceManagerMock, workingSetObserver: workingSetObservationMock)
+
+		var cache = [NSFileProviderDomainIdentifier: AdapterCacheItem]()
+		cache[unlockedDomainIdentifier] = unlockedVaultAdapterCacheItem
+		cache[lockedDomainIdentifier] = lockedVaultAdapterCacheItem
+		adapterCacheMock.getItemIdentifierClosure = { return cache[$0] }
+		adapterCacheMock.getAllCachedIdentifiersClosure = { cache.map { $0.key }}
+		adapterCacheMock.removeItemIdentifierClosure = {
+			cache[$0] = nil
+		}
+		vaultKeepUnlockedHelperMock.shouldAutoLockVaultWithVaultUIDClosure = { $0 != unlockedDomainIdentifier.rawValue }
+
+		XCTAssertEqual([unlockedDomainIdentifier], fileProviderAdapterManager.getDomainIdentifiersOfUnlockedVaults())
+
+		XCTAssertFalse(unlockedVaultMaintenanceManagerMock.enableMaintenanceModeCalled)
+		XCTAssertFalse(unlockedVaultMaintenanceManagerMock.disableMaintenanceModeCalled)
+		XCTAssertEqual(1, lockedVaultMaintenanceManagerMock.enableMaintenanceModeCallsCount)
+		XCTAssertEqual(1, lockedVaultMaintenanceManagerMock.disableMaintenanceModeCallsCount)
+
+		XCTAssertEqual(1, cache.count)
+		XCTAssertNotNil(cache[unlockedDomainIdentifier])
+	}
 }


### PR DESCRIPTION
Due to the introduction of the Keep Unlocked feature, it could happen that a vault is displayed as unlocked to the user in the main app, although it is automatically locked the next time it is used in the Files app. This can lead to confusion for users.
Therefore, every time the main app requests the lock status of the vault, a check is now performed to determine whether the respective vault must be locked automatically. 