### PR TITLE
Workaround for a regression introduced with SQLite 3.37.0

### DIFF
--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
@@ -134,9 +134,12 @@ public class CryptomatorDatabase {
 		var coordinatorError: NSError?
 		var dbPool: DatabasePool?
 		var dbError: Error?
+		var configuration = Configuration()
+		// Workaround for a SQLite regression (see https://github.com/groue/GRDB.swift/issues/1171 for more details)
+		configuration.acceptsDoubleQuotedStringLiterals = true
 		coordinator.coordinate(writingItemAt: databaseURL, options: .forMerging, error: &coordinatorError, byAccessor: { _ in
 			do {
-				dbPool = try DatabasePool(path: databaseURL.path)
+				dbPool = try DatabasePool(path: databaseURL.path, configuration: configuration)
 			} catch {
 				dbError = error
 			}


### PR DESCRIPTION
Fixes #171 by bypassing the regression introduced by SQLite 3.37.0 by accepting double-quoted string literals.
Since iOS 15.4 uses a newer SQLite version (3.37.x instead of 3.36.x), this caused a crash on pending migration.
More details can be found in the related [issue](https://github.com/groue/GRDB.swift/issues/1171) at the GRDB repository.

The following scenarios have been successfully tested:

- fully migrated database
- clean installation, i.e. database is created from scratch
- database has not yet been migrated to v2
    - empty v1 database
    - with a cached vault (but here without reopening the Files app, because the database was copied between the simulators and therefore the matching FileProviderDomain is missing)
 