### PR TITLE
Feature: subscription & offer codes

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		4A13612D276768000077EB7F /* SnapshotHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A13612C276768000077EB7F /* SnapshotHelper.swift */; };
 		4A13612F27676F5C0077EB7F /* SnapshotCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A13612E27676F5C0077EB7F /* SnapshotCoordinator.swift */; };
 		4A136132276770BB0077EB7F /* SnapshotVaultListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A136131276770BB0077EB7F /* SnapshotVaultListViewModel.swift */; };
+		4A1521E427C55EA2006C96B2 /* TPInAppReceipt in Frameworks */ = {isa = PBXBuildFile; productRef = 4A1521E327C55EA2006C96B2 /* TPInAppReceipt */; };
 		4A1673E1270C43AF0075C724 /* LoadingWithLabelCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E0270C43AF0075C724 /* LoadingWithLabelCell.swift */; };
 		4A1673E3270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E2270C4DD90075C724 /* LoadingWithLabelCellViewModel.swift */; };
 		4A1673E6270C652A0075C724 /* FileProviderCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A1673E4270C5E6C0075C724 /* FileProviderCacheManager.swift */; };
@@ -240,6 +241,8 @@
 		4AB8539E26BA8B4C00555F00 /* VaultDetailUnlockCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB8539D26BA8B4C00555F00 /* VaultDetailUnlockCoordinator.swift */; };
 		4ABC08D7250D1EB600E3CEDC /* DeletionTaskManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABC08D6250D1EB600E3CEDC /* DeletionTaskManagerTests.swift */; };
 		4ABCF3522726D24800A7FBB7 /* MoveVaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ABCF3512726D24800A7FBB7 /* MoveVaultViewModelTests.swift */; };
+		4AC005F127C3D80B006FFE87 /* PremiumManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC005F027C3D80B006FFE87 /* PremiumManager.swift */; };
+		4AC005F327C3D932006FFE87 /* PremiumManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC005F227C3D932006FFE87 /* PremiumManagerMock.swift */; };
 		4AC86270273598CC00E15BA5 /* UIViewController+ProgressHUDError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC8626F273598CC00E15BA5 /* UIViewController+ProgressHUDError.swift */; };
 		4AD0F61C24AF203F0026B765 /* FileProvider+Actions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AD0F61B24AF203F0026B765 /* FileProvider+Actions.swift */; };
 		4ADBD35827284BAB00B19B5C /* MoveVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ADBD35727284BAB00B19B5C /* MoveVaultViewController.swift */; };
@@ -698,6 +701,8 @@
 		4AB8539D26BA8B4C00555F00 /* VaultDetailUnlockCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetailUnlockCoordinator.swift; sourceTree = "<group>"; };
 		4ABC08D6250D1EB600E3CEDC /* DeletionTaskManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeletionTaskManagerTests.swift; sourceTree = "<group>"; };
 		4ABCF3512726D24800A7FBB7 /* MoveVaultViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveVaultViewModelTests.swift; sourceTree = "<group>"; };
+		4AC005F027C3D80B006FFE87 /* PremiumManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumManager.swift; sourceTree = "<group>"; };
+		4AC005F227C3D932006FFE87 /* PremiumManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PremiumManagerMock.swift; sourceTree = "<group>"; };
 		4AC8626F273598CC00E15BA5 /* UIViewController+ProgressHUDError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+ProgressHUDError.swift"; sourceTree = "<group>"; };
 		4AD0F61B24AF203F0026B765 /* FileProvider+Actions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileProvider+Actions.swift"; sourceTree = "<group>"; };
 		4ADBD35727284BAB00B19B5C /* MoveVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveVaultViewController.swift; sourceTree = "<group>"; };
@@ -883,6 +888,7 @@
 			files = (
 				4A9172822619F17C003C4043 /* CryptomatorCommon in Frameworks */,
 				4A1673ED270DE4600075C724 /* libCryptomatorFileProvider.a in Frameworks */,
+				4A1521E427C55EA2006C96B2 /* TPInAppReceipt in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1455,6 +1461,7 @@
 				4A1C6D632750EED900B41FFF /* IAPManagerMock.swift */,
 				4A1DB290275FA4AE00A5F27B /* IAPStoreMock.swift */,
 				4A3C5DD3272AF98700EB7C7A /* MaintenanceManagerMock.swift */,
+				4AC005F227C3D932006FFE87 /* PremiumManagerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1699,6 +1706,7 @@
 		74F5DC1A26DCD2E300AFE989 /* Purchase */ = {
 			isa = PBXGroup;
 			children = (
+				4AC005F027C3D80B006FFE87 /* PremiumManager.swift */,
 				4A4246F1275640C9005BE82D /* IAPViewController.swift */,
 				4A5AC440275A5B3500342AA7 /* PurchaseAlert.swift */,
 				74C2BC5126E8FCD000BCAA03 /* PurchaseCoordinator.swift */,
@@ -1835,6 +1843,7 @@
 			name = Cryptomator;
 			packageProductDependencies = (
 				4A9172812619F17C003C4043 /* CryptomatorCommon */,
+				4A1521E327C55EA2006C96B2 /* TPInAppReceipt */,
 			);
 			productName = Cryptomator;
 			productReference = 4AE97DA824572E4900452814 /* Cryptomator.app */;
@@ -1952,6 +1961,7 @@
 			);
 			mainGroup = 4A5E5B202453119100BD6298;
 			packageReferences = (
+				4A1521E227C55EA2006C96B2 /* XCRemoteSwiftPackageReference "TPInAppReceipt" */,
 			);
 			productRefGroup = 4A5E5B2A2453119100BD6298 /* Products */;
 			projectDirPath = "";
@@ -2238,6 +2248,7 @@
 				4A4246F2275640C9005BE82D /* IAPViewController.swift in Sources */,
 				4A53CC17267CDBFF00853BB3 /* CreateNewVaultChooseFolderViewModel.swift in Sources */,
 				4A6A521D268B7C8F006F7368 /* BaseNavigationController.swift in Sources */,
+				4AC005F127C3D80B006FFE87 /* PremiumManager.swift in Sources */,
 				4ADD2342267383BE00374E4E /* AddVaultSuccessViewModel.swift in Sources */,
 				4A79E26926B16993008C9959 /* ActionButton.swift in Sources */,
 				4AF91CD925A722A600ACF01E /* VaultInfo.swift in Sources */,
@@ -2411,6 +2422,7 @@
 				4A644B49267B40C3008CBB9A /* SetVaultNameViewModelTests.swift in Sources */,
 				4AEFF7F627145F5A00D6CB99 /* FileProviderConnectorMock.swift in Sources */,
 				4AFCE56A25BAEE890069C4FC /* AccountListViewModelTests.swift in Sources */,
+				4AC005F327C3D932006FFE87 /* PremiumManagerMock.swift in Sources */,
 				4ABCF3522726D24800A7FBB7 /* MoveVaultViewModelTests.swift in Sources */,
 				4A644B59267CA3AD008CBB9A /* CreateNewFolderViewModelTests.swift in Sources */,
 				4A707804278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift in Sources */,
@@ -3093,7 +3105,23 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		4A1521E227C55EA2006C96B2 /* XCRemoteSwiftPackageReference "TPInAppReceipt" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/tikhop/TPInAppReceipt.git";
+			requirement = {
+				kind = upToNextMinorVersion;
+				minimumVersion = 3.3.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
+		4A1521E327C55EA2006C96B2 /* TPInAppReceipt */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 4A1521E227C55EA2006C96B2 /* XCRemoteSwiftPackageReference "TPInAppReceipt" */;
+			productName = TPInAppReceipt;
+		};
 		4A9172712619F16C003C4043 /* CryptomatorCommonCore */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = CryptomatorCommonCore;

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,6 +11,15 @@
         }
       },
       {
+        "package": "ASN1Swift",
+        "repositoryURL": "https://github.com/tikhop/ASN1Swift",
+        "state": {
+          "branch": null,
+          "revision": "b53bee03a942623db25afc5bfb80227b2cb3b425",
+          "version": "1.2.4"
+        }
+      },
+      {
         "package": "Base32",
         "repositoryURL": "https://github.com/norio-nomura/Base32.git",
         "state": {
@@ -143,6 +152,15 @@
           "branch": null,
           "revision": "5d66f7ba25daf4f94100e7022febf3c75e37a6c7",
           "version": "1.4.2"
+        }
+      },
+      {
+        "package": "TPInAppReceipt",
+        "repositoryURL": "https://github.com/tikhop/TPInAppReceipt.git",
+        "state": {
+          "branch": null,
+          "revision": "2b9946f8fe2dd74ed87dfcb5dbedc3be06c5ccab",
+          "version": "3.3.3"
         }
       }
     ]

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -106,6 +106,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		return false
 	}
 
+	func applicationDidBecomeActive(_ application: UIApplication) {
+		PremiumManager.shared.refreshStatus()
+	}
+
 	func applicationWillTerminate(_ application: UIApplication) {
 		SKPaymentQueue.default().remove(StoreObserver.shared)
 	}

--- a/Cryptomator/MainCoordinator.swift
+++ b/Cryptomator/MainCoordinator.swift
@@ -112,7 +112,7 @@ extension MainCoordinator: RemoveVaultDelegate {
 extension MainCoordinator: StoreObserverDelegate {
 	func purchaseDidSucceed(transaction: PurchaseTransaction) {
 		switch transaction {
-		case .fullVersion:
+		case .fullVersion, .yearlySubscription:
 			showFullVersionAlert()
 		case let .freeTrial(expiresOn):
 			showTrialAlert(expirationDate: expiresOn)

--- a/Cryptomator/Purchase/PremiumManager.swift
+++ b/Cryptomator/Purchase/PremiumManager.swift
@@ -1,0 +1,156 @@
+//
+//  PremiumManager.swift
+//  Cryptomator
+//
+//  Created by Philipp Schmid on 09.02.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import CryptomatorCommonCore
+import Foundation
+import Promises
+import StoreKit
+import TPInAppReceipt
+
+protocol PremiumManagerType {
+	/**
+	 Updates the premium status by reading the local app store receipt.
+
+	 The local app store receipt can only be read by the main app.
+	 */
+	func refreshStatus()
+	/**
+	 Returns the expiration date of the trial for a given purchase date by adding 30 days.
+
+	 - Note: To obtain the correct expiration date of a trial, the original purchase date should be passed. Otherwise, a restored transaction could extend the trial period.
+	 - Returns: The trial expiration date, or nil if a date could not be calculated with the given input
+	 */
+	func trialExpirationDate(for purchaseDate: Date) -> Date?
+}
+
+class PremiumManager: PremiumManagerType {
+	static let shared = PremiumManager(cryptomatorSettings: CryptomatorUserDefaults.shared)
+	private var cryptomatorSettings: CryptomatorSettings
+
+	init(cryptomatorSettings: CryptomatorSettings) {
+		self.cryptomatorSettings = cryptomatorSettings
+		refreshStatus()
+	}
+
+	func refreshStatus() {
+		reloadReceipt()
+	}
+
+	func trialExpirationDate(for purchaseDate: Date) -> Date? {
+		return Calendar.current.date(byAdding: .day, value: 30, to: purchaseDate)
+	}
+
+	private func reloadReceipt() {
+		let receipt: InAppReceipt
+		do {
+			receipt = try InAppReceipt.localReceipt()
+		} catch {
+			DDLogError("PremiumManager.reloadReceipt failed with error: \(error)")
+			return
+		}
+		let premiumHistory = createPremiumHistory(for: receipt)
+		savePremiumHistory(premiumHistory)
+	}
+
+	private func savePremiumHistory(_ premiumHistory: PremiumHistory) {
+		cryptomatorSettings.trialExpirationDate = premiumHistory.trialExpirationDate
+		cryptomatorSettings.fullVersionUnlocked = premiumHistory.lifetimePremiumEnabled
+		cryptomatorSettings.hasRunningSubscription = premiumHistory.hasRunningSubscription
+	}
+
+	private func createPremiumHistory(for receipt: InAppReceipt) -> PremiumHistory {
+		return PremiumHistory(trialExpirationDate: getTrialExpirationDate(for: receipt),
+		                      hasRunningSubscription: hasRunningSubscription(receipt: receipt),
+		                      lifetimePremiumEnabled: hasLifetimePremium(receipt: receipt))
+	}
+
+	private func getActiveAutoRenewableSubscriptionExpirationDate(receipt: InAppReceipt) -> Date? {
+		let activeAutoRenewableSubscription = receipt.activeAutoRenewableSubscriptionPurchases(ofProductIdentifier: .yearlySubscription, forDate: Date())
+		return activeAutoRenewableSubscription?.subscriptionExpirationDate
+	}
+
+	private func hasRunningSubscription(receipt: InAppReceipt) -> Bool {
+		return receipt.hasActiveAutoRenewableSubscription(ofProductIdentifier: .yearlySubscription, forDate: Date())
+	}
+
+	private func hasLifetimePremium(receipt: InAppReceipt) -> Bool {
+		let freeUpgradePurchases = receipt.validPurchases(ofProductIdentifier: .freeUpgrade)
+		let paidUpgradePurchases = receipt.validPurchases(ofProductIdentifier: .paidUpgrade)
+		let fullVersionPurchases = receipt.validPurchases(ofProductIdentifier: .fullVersion)
+
+		var premiumPurchases = [InAppPurchase]()
+		premiumPurchases.append(contentsOf: freeUpgradePurchases)
+		premiumPurchases.append(contentsOf: paidUpgradePurchases)
+		premiumPurchases.append(contentsOf: fullVersionPurchases)
+		return !premiumPurchases.isEmpty
+	}
+
+	private func hasRunningTrial(receipt: InAppReceipt) -> Bool {
+		let trialPurchases = receipt.validPurchases(ofProductIdentifier: .thirtyDayTrial)
+		for purchase in trialPurchases {
+			guard let trialExpirationDate = trialExpirationDate(for: purchase) else {
+				continue
+			}
+			if trialExpirationDate > Date() {
+				return true
+			}
+		}
+		return false
+	}
+
+	private func getTrialExpirationDate(for receipt: InAppReceipt) -> Date? {
+		let trialPurchases = receipt.validPurchases(ofProductIdentifier: .thirtyDayTrial)
+		let trialExpirationDates = trialPurchases.map { trialExpirationDate(for: $0) ?? .distantPast }
+		let descendingSortedTrialExpirationDates = trialExpirationDates.sorted(by: { $0 > $1 })
+		return descendingSortedTrialExpirationDates.first
+	}
+
+	private func trialExpirationDate(for purchase: InAppPurchase) -> Date? {
+		let purchaseDate: Date
+		if let originalPurchaseDate = purchase.originalPurchaseDate {
+			purchaseDate = originalPurchaseDate
+		} else {
+			purchaseDate = purchase.purchaseDate
+		}
+		return trialExpirationDate(for: purchaseDate)
+	}
+}
+
+private struct PremiumHistory: Codable {
+	let trialExpirationDate: Date?
+	let hasRunningSubscription: Bool
+	let lifetimePremiumEnabled: Bool
+}
+
+extension InAppReceipt {
+	/**
+	 Returns all valid purchases of a given product identifier by filtering out cancelled purchases.
+
+	 A cancellation date that is not nil means that the purchase has been refunded by Apple Support or the user has upgraded to a higher subscription plan.
+	 Subscriptions canceled by the user but possibly not yet expired will continue to be returned.
+	 */
+	func validPurchases(ofProductIdentifier productIdentifier: ProductIdentifier) -> [InAppPurchase] {
+		return purchases(ofProductIdentifier: productIdentifier).filter { $0.cancellationDate == nil }
+	}
+
+	// MARK: Convenience
+
+	func purchases(ofProductIdentifier productIdentifier: ProductIdentifier,
+	               sortedBy sort: ((InAppPurchase, InAppPurchase) -> Bool)? = nil) -> [InAppPurchase] {
+		return purchases(ofProductIdentifier: productIdentifier.rawValue, sortedBy: sort)
+	}
+
+	func hasActiveAutoRenewableSubscription(ofProductIdentifier productIdentifier: ProductIdentifier, forDate date: Date) -> Bool {
+		return hasActiveAutoRenewableSubscription(ofProductIdentifier: productIdentifier.rawValue, forDate: date)
+	}
+
+	func activeAutoRenewableSubscriptionPurchases(ofProductIdentifier productIdentifier: ProductIdentifier, forDate date: Date) -> InAppPurchase? {
+		return activeAutoRenewableSubscriptionPurchases(ofProductIdentifier: productIdentifier.rawValue, forDate: date)
+	}
+}

--- a/Cryptomator/Purchase/PurchaseViewController.swift
+++ b/Cryptomator/Purchase/PurchaseViewController.swift
@@ -56,6 +56,16 @@ class PurchaseViewController: IAPViewController<PurchaseSection, PurchaseButtonA
 			viewModel.replaceRetrySectionWithLoadingSection()
 			applySnapshot(sections: viewModel.sections)
 			fetchProducts()
+		case .redeemCode:
+			if #available(iOS 14.0, *) {
+				viewModel.redeemCode()
+			}
+		case .startSubscription:
+			viewModel.startSubscription().then { [weak self] in
+				self?.coordinator?.fullVersionPurchased()
+			}.catch { [weak self] error in
+				self?.handleError(error)
+			}
 		case .unknown, .none:
 			break
 		}

--- a/Cryptomator/Purchase/StoreManager.swift
+++ b/Cryptomator/Purchase/StoreManager.swift
@@ -16,6 +16,7 @@ enum ProductIdentifier: String, CaseIterable {
 	case thirtyDayTrial = "org.cryptomator.ios.iap.30_day_trial"
 	case paidUpgrade = "org.cryptomator.ios.iap.paid_upgrade"
 	case freeUpgrade = "org.cryptomator.ios.iap.free_upgrade"
+	case yearlySubscription = "org.cryptomator.ios.iap.yearly_sub"
 }
 
 protocol IAPStore {

--- a/Cryptomator/Settings/SettingsCoordinator.swift
+++ b/Cryptomator/Settings/SettingsCoordinator.swift
@@ -9,6 +9,7 @@
 import CocoaLumberjackSwift
 import CryptomatorCommonCore
 import Foundation
+import StoreKit
 import UIKit
 
 class SettingsCoordinator: Coordinator {
@@ -72,6 +73,26 @@ class SettingsCoordinator: Coordinator {
 		let child = SettingsPurchaseCoordinator(navigationController: navigationController)
 		childCoordinators.append(child) // TODO: remove missing?
 		child.start()
+	}
+
+	func showManageSubscriptions() {
+		if #available(iOS 15.0, *), let scene = UIApplication.shared.connectedScenes.first as? UIWindowScene {
+			Task.init {
+				do {
+					try await AppStore.showManageSubscriptions(in: scene)
+				} catch {
+					handleError(error, for: navigationController)
+				}
+			}
+		} else {
+			showExternalManageSubscriptions()
+		}
+	}
+
+	private func showExternalManageSubscriptions() {
+		if let manageSubscriptionsURL = URL(string: "https://apps.apple.com/account/subscriptions") {
+			UIApplication.shared.open(manageSubscriptionsURL)
+		}
 	}
 
 	@objc func close() {

--- a/Cryptomator/Settings/SettingsViewController.swift
+++ b/Cryptomator/Settings/SettingsViewController.swift
@@ -39,7 +39,7 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 
 	override func viewWillAppear(_ animated: Bool) {
 		super.viewWillAppear(animated)
-		applySnapshot(sections: viewModel.sections, animatingDifferences: false)
+		refreshRows()
 	}
 
 	override func viewWillDisappear(_ animated: Bool) {
@@ -99,9 +99,13 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 
 	// MARK: - UITableViewDelegate
 
+	// swiftlint:disable:next cyclomatic_complexity
 	override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-		tableView.deselectRow(at: indexPath, animated: true)
-		switch viewModel.buttonAction(for: indexPath) {
+		let cellViewModel = dataSource?.itemIdentifier(for: indexPath) as? ButtonCellViewModel<SettingsButtonAction>
+		if cellViewModel?.accessoryType.value != .disclosureIndicator {
+			tableView.deselectRow(at: indexPath, animated: true)
+		}
+		switch cellViewModel?.action {
 		case .showAbout:
 			showAbout()
 		case .sendLogFile:
@@ -119,8 +123,23 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 			showRateApp()
 		case .showUnlockFullVersion:
 			coordinator?.showUnlockFullVersion()
-		case .unknown:
+		case .showManageSubscriptions:
+			coordinator?.showManageSubscriptions()
+		case .redeemCode:
+			if #available(iOS 14.0, *) {
+				viewModel.redeemCode()
+			}
+		case .restorePurchase:
+			viewModel.restorePurchase().then { [weak self] _ in
+				self?.refreshRows()
+			}
+		case .none:
 			break
 		}
+	}
+
+	private func refreshRows() {
+		PremiumManager.shared.refreshStatus()
+		applySnapshot(sections: viewModel.sections, animatingDifferences: false)
 	}
 }

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -11,6 +11,7 @@ import CryptomatorCommonCore
 import CryptomatorFileProvider
 import Foundation
 import Promises
+import StoreKit
 
 enum SettingsButtonAction: String {
 	case showAbout
@@ -20,7 +21,10 @@ enum SettingsButtonAction: String {
 	case showContact
 	case showRateApp
 	case showUnlockFullVersion
-	case unknown
+	case showManageSubscriptions
+	@available(iOS 14.0, *)
+	case redeemCode
+	case restorePurchase
 }
 
 enum SettingsSection: Int {
@@ -67,7 +71,13 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 
 	private var aboutSectionElements: [TableViewCellViewModel] {
 		var elements = [ButtonCellViewModel.createDisclosureButton(action: SettingsButtonAction.showAbout, title: LocalizedString.getValue("settings.aboutCryptomator"))]
-		if !cryptomatorSettings.fullVersionUnlocked {
+		if cryptomatorSettings.hasRunningSubscription {
+			elements.append(.init(action: .showManageSubscriptions, title: LocalizedString.getValue("settings.manageSubscriptions")))
+			if #available(iOS 14.0, *) {
+				elements.append(.init(action: .redeemCode, title: LocalizedString.getValue("purchase.redeemCode.button")))
+			}
+			elements.append(.init(action: .restorePurchase, title: LocalizedString.getValue("purchase.restorePurchase.button")))
+		} else if !cryptomatorSettings.fullVersionUnlocked {
 			elements.append(ButtonCellViewModel.createDisclosureButton(action: SettingsButtonAction.showUnlockFullVersion, title: LocalizedString.getValue("settings.unlockFullVersion")))
 		}
 		return elements
@@ -94,14 +104,6 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 		self.fileProviderConnector = fileProviderConnector
 	}
 
-	func buttonAction(for indexPath: IndexPath) -> SettingsButtonAction {
-		let section = sections[indexPath.section]
-		guard let cell = section.elements[indexPath.row] as? ButtonCellViewModel<SettingsButtonAction> else {
-			return .unknown
-		}
-		return cell.action
-	}
-
 	func refreshCacheSize() -> Promise<Void> {
 		var loading = true
 		DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
@@ -123,6 +125,20 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 		return cacheManager.clearCache().then {
 			self.refreshCacheSize()
 		}
+	}
+
+	func restorePurchase() -> Promise<RestoreTransactionsResult> {
+		return StoreObserver.shared.restore()
+	}
+
+	/**
+	 Presents the code redemption sheet.
+
+	 - Note: The code redemption sheet does not work on the simulator.
+	 */
+	@available(iOS 14.0, *)
+	func redeemCode() {
+		SKPaymentQueue.default().presentCodeRedemptionSheet()
 	}
 
 	func enableDebugMode() {

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
@@ -13,6 +13,7 @@ public protocol CryptomatorSettings {
 	var debugModeEnabled: Bool { get set }
 	var trialExpirationDate: Date? { get set }
 	var fullVersionUnlocked: Bool { get set }
+	var hasRunningSubscription: Bool { get set }
 }
 
 public class CryptomatorUserDefaults {
@@ -74,6 +75,11 @@ extension CryptomatorUserDefaults: CryptomatorSettings {
 
 	public var debugModeEnabled: Bool {
 		get { read() ?? CryptomatorUserDefaults.debugModeEnabledDefaultValue }
+		set { write(value: newValue) }
+	}
+
+	public var hasRunningSubscription: Bool {
+		get { read() ?? false }
 		set { write(value: newValue) }
 	}
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FullVersionChecker.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FullVersionChecker.swift
@@ -24,6 +24,9 @@ public class UserDefaultsFullVersionChecker: FullVersionChecker {
 		if cryptomatorSettings.fullVersionUnlocked {
 			return true
 		}
+		if cryptomatorSettings.hasRunningSubscription {
+			return true
+		}
 		if let trialExpirationDate = cryptomatorSettings.trialExpirationDate, trialExpirationDate > Date() {
 			return true
 		} else {

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Mocks/CryptomatorSettingsMock.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Mocks/CryptomatorSettingsMock.swift
@@ -13,5 +13,6 @@ class CryptomatorSettingsMock: CryptomatorSettings {
 	var trialExpirationDate: Date?
 	var debugModeEnabled: Bool = false
 	var fullVersionUnlocked: Bool = false
+	var hasRunningSubscription: Bool = false
 }
 #endif

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
@@ -1,0 +1,64 @@
+//
+//  FullVersionCheckerTests.swift
+//
+//
+//  Created by Philipp Schmid on 21.02.22.
+//
+
+import XCTest
+@testable import CryptomatorCommonCore
+
+class FullVersionCheckerTests: XCTestCase {
+	var settingsMock: CryptomatorSettingsMock!
+	var fullVersionChecker: FullVersionChecker!
+
+	override func setUpWithError() throws {
+		settingsMock = CryptomatorSettingsMock()
+		settingsMock.fullVersionUnlocked = false
+		settingsMock.hasRunningSubscription = false
+		settingsMock.trialExpirationDate = nil
+		fullVersionChecker = UserDefaultsFullVersionChecker(cryptomatorSettings: settingsMock)
+	}
+
+	// MARK: Is Full Version
+
+	func testIsFullVersionWithLifetime() {
+		settingsMock.fullVersionUnlocked = true
+		XCTAssert(fullVersionChecker.isFullVersion)
+	}
+
+	func testIsFullVersionWithRunningSubscription() {
+		settingsMock.fullVersionUnlocked = true
+		XCTAssert(fullVersionChecker.isFullVersion)
+	}
+
+	func testIsFullVersionWithTrialExpirationDateInTheFuture() {
+		settingsMock.trialExpirationDate = .distantFuture
+		XCTAssert(fullVersionChecker.isFullVersion)
+	}
+
+	func testIsNotFullVersionWithTrialExpirationDateInThePast() {
+		settingsMock.trialExpirationDate = .distantPast
+		XCTAssertFalse(fullVersionChecker.isFullVersion)
+	}
+
+	func testIsNotFullVersionWithNothingSet() {
+		XCTAssertFalse(fullVersionChecker.isFullVersion)
+	}
+
+	// MARK: Has Expired Trial
+
+	func testHasExpiredTrialWithTrialExpirationDateNotSet() {
+		XCTAssertFalse(fullVersionChecker.hasExpiredTrial)
+	}
+
+	func testHasExpiredTrialWithExpirationDateInTheFuture() {
+		settingsMock.trialExpirationDate = .distantFuture
+		XCTAssertFalse(fullVersionChecker.hasExpiredTrial)
+	}
+
+	func testHasExpiredTrialWithExpirationDateInThePast() {
+		settingsMock.trialExpirationDate = .distantPast
+		XCTAssert(fullVersionChecker.hasExpiredTrial)
+	}
+}

--- a/CryptomatorFileProviderTests/LogLevelUpdatingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/LogLevelUpdatingServiceSourceTests.swift
@@ -30,9 +30,3 @@ class LogLevelUpdatingServiceSourceTests: XCTestCase {
 		XCTAssertEqual(.debug, dynamicLogLevel)
 	}
 }
-
-private class CryptomatorSettingsMock: CryptomatorSettings {
-	var trialExpirationDate: Date?
-	var fullVersionUnlocked: Bool = false
-	var debugModeEnabled: Bool = false
-}

--- a/CryptomatorTests/Mocks/PremiumManagerMock.swift
+++ b/CryptomatorTests/Mocks/PremiumManagerMock.swift
@@ -1,0 +1,45 @@
+//
+//  PremiumManagerMock.swift
+//  CryptomatorTests
+//
+//  Created by Philipp Schmid on 21.02.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+@testable import Cryptomator
+
+final class PremiumManagerTypeMock: PremiumManagerType {
+	// MARK: - refreshStatus
+
+	var refreshStatusCallsCount = 0
+	var refreshStatusCalled: Bool {
+		refreshStatusCallsCount > 0
+	}
+
+	var refreshStatusClosure: (() -> Void)?
+
+	func refreshStatus() {
+		refreshStatusCallsCount += 1
+		refreshStatusClosure?()
+	}
+
+	// MARK: - trialExpirationDate
+
+	var trialExpirationDateForCallsCount = 0
+	var trialExpirationDateForCalled: Bool {
+		trialExpirationDateForCallsCount > 0
+	}
+
+	var trialExpirationDateForReceivedPurchaseDate: Date?
+	var trialExpirationDateForReceivedInvocations: [Date] = []
+	var trialExpirationDateForReturnValue: Date?
+	var trialExpirationDateForClosure: ((Date) -> Date?)?
+
+	func trialExpirationDate(for purchaseDate: Date) -> Date? {
+		trialExpirationDateForCallsCount += 1
+		trialExpirationDateForReceivedPurchaseDate = purchaseDate
+		trialExpirationDateForReceivedInvocations.append(purchaseDate)
+		return trialExpirationDateForClosure.map({ $0(purchaseDate) }) ?? trialExpirationDateForReturnValue
+	}
+}

--- a/CryptomatorTests/Purchase/PurchaseViewModelTests.swift
+++ b/CryptomatorTests/Purchase/PurchaseViewModelTests.swift
@@ -50,6 +50,7 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
 			Section(id: .trialSection, elements: [viewModel.freeTrialButtonCellViewModel]),
 			Section(id: .purchaseSection, elements: [viewModel.purchaseButtonCellViewModel]),
+			Section(id: .subscribeSection, elements: [viewModel.subscribeButtonCellViewModel, viewModel.redeemButtonCellViewModel]),
 			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
 			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
 		]
@@ -70,6 +71,7 @@ class PurchaseViewModelTests: IAPViewModelTestCase<PurchaseSection, PurchaseButt
 			Section(id: .emptySection, elements: []),
 			Section(id: .upgradeSection, elements: [viewModel.upgradeButtonCellViewModel]),
 			Section(id: .purchaseSection, elements: [viewModel.purchaseButtonCellViewModel]),
+			Section(id: .subscribeSection, elements: [viewModel.subscribeButtonCellViewModel, viewModel.redeemButtonCellViewModel]),
 			Section(id: .restoreSection, elements: [viewModel.restorePurchaseButtonCellViewModel]),
 			Section(id: .decideLaterSection, elements: [viewModel.decideLaterButtonCellViewModel])
 		]

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -136,6 +136,7 @@
 "purchase.beginFreeTrial.alert.message" = "You can now use the full version of Cryptomator for a limited time. Your trial expires on %@. After that, your vaults will still be accessible in read-only mode.";
 "purchase.purchaseFullVersion.button" = "Purchase Full Version for %@";
 "purchase.purchaseFullVersion.footer" = "Pay once and unlock write access to your vaults for the lifetime of Cryptomator.";
+"purchase.redeemCode.button" = "Redeem Code";
 "purchase.restorePurchase.button" = "Restore Purchase";
 "purchase.restorePurchase.footer" = "If you have already purchased the full version of Cryptomator, you can restore the purchase.";
 "purchase.restorePurchase.validTrialFound.alert.title" = "Trial Continued";
@@ -145,6 +146,7 @@
 "purchase.restorePurchase.fullVersionNotFound.alert.message" = "We were unable to find a previously purchased full version that could be restored. Please try another option.";
 "purchase.retry.button" = "Retry";
 "purchase.retry.footer" = "Could not load the available products.";
+"purchase.startSubscription.button" = "Subscribe for %@ per Year";
 "purchase.decideLater.button" = "Decide Later";
 "purchase.decideLater.footer" = "You can unlock the full version of Cryptomator later in the settings and use it in read-only mode for now.";
 "purchase.unlockedFullVersion.message" = "You can now use the full version of Cryptomator. Happy crypting!";
@@ -159,6 +161,7 @@
 "settings.contact" = "Contact";
 "settings.debugMode" = "Debug Mode";
 "settings.debugMode.alert.message" = "In this mode, sensitive data may be written to a log file on your device (e.g., filenames and paths). Passwords, cookies, etc. are explicitly excluded.\n\nRemember to disable debug mode as soon as possible.";
+"settings.manageSubscriptions" = "Manage Subscription";
 "settings.rateApp" = "Rate App";
 "settings.sendLogFile" = "Send Log File";
 "settings.unlockFullVersion" = "Unlock Full Version";

--- a/StoreKitTestConfiguration/Configuration.storekit
+++ b/StoreKitTestConfiguration/Configuration.storekit
@@ -83,30 +83,26 @@
 
           ],
           "displayPrice" : "5.99",
-          "familyShareable" : false,
+          "familyShareable" : true,
           "groupNumber" : 1,
           "internalID" : "93C382A2",
           "introductoryOffer" : null,
           "localizations" : [
             {
               "description" : "Grant write access to your vaults",
-              "displayName" : "Yearly Subscription",
+              "displayName" : "Full Version",
               "locale" : "en_US"
             }
           ],
           "productID" : "org.cryptomator.ios.iap.yearly_sub",
           "recurringSubscriptionPeriod" : "P1M",
-          "referenceName" : "Full Version - Yearly",
+          "referenceName" : "Yearly Subscription",
           "subscriptionGroupID" : "59D287B1",
           "type" : "RecurringSubscription"
         }
       ]
     }
   ],
-  "subscriptionOffersKeyPair" : {
-    "id" : "D5256327",
-    "privateKey" : "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgl7DhxSIWpw1nGlf93J94puapub1XH5YNdkBn8OmxSn2gCgYIKoZIzj0DAQehRANCAARf8Ga/+zK1MEWiqdcYCpOHUaiwBWV1lDskeEcgZ2cjnHnIXENCdJXAq3LURPjbW8q3yOe+rw95ZAqt2eC7RUK6"
-  },
   "version" : {
     "major" : 1,
     "minor" : 1

--- a/StoreKitTestConfiguration/Configuration.storekit
+++ b/StoreKitTestConfiguration/Configuration.storekit
@@ -66,11 +66,47 @@
     }
   ],
   "settings" : {
-    "_storefront" : "USA"
+    "_compatibilityTimeRate" : 6,
+    "_storefront" : "USA",
+    "_timeRate" : 15
   },
   "subscriptionGroups" : [
+    {
+      "id" : "59D287B1",
+      "localizations" : [
 
+      ],
+      "name" : "Full Version",
+      "subscriptions" : [
+        {
+          "adHocOffers" : [
+
+          ],
+          "displayPrice" : "5.99",
+          "familyShareable" : false,
+          "groupNumber" : 1,
+          "internalID" : "93C382A2",
+          "introductoryOffer" : null,
+          "localizations" : [
+            {
+              "description" : "Grant write access to your vaults",
+              "displayName" : "Yearly Subscription",
+              "locale" : "en_US"
+            }
+          ],
+          "productID" : "org.cryptomator.ios.iap.yearly_sub",
+          "recurringSubscriptionPeriod" : "P1M",
+          "referenceName" : "Full Version - Yearly",
+          "subscriptionGroupID" : "59D287B1",
+          "type" : "RecurringSubscription"
+        }
+      ]
+    }
   ],
+  "subscriptionOffersKeyPair" : {
+    "id" : "D5256327",
+    "privateKey" : "MIGTAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBHkwdwIBAQQgl7DhxSIWpw1nGlf93J94puapub1XH5YNdkBn8OmxSn2gCgYIKoZIzj0DAQehRANCAARf8Ga/+zK1MEWiqdcYCpOHUaiwBWV1lDskeEcgZ2cjnHnIXENCdJXAq3LURPjbW8q3yOe+rw95ZAqt2eC7RUK6"
+  },
   "version" : {
     "major" : 1,
     "minor" : 1


### PR DESCRIPTION
Adds the option to use an annual subscription instead of a one-time Lifetime Premium purchase. In particular, this allows the use (starting with iOS 14) of [Offer Codes](https://developer.apple.com/documentation/storekit/original_api_for_in-app_purchase/subscriptions_and_offers/implementing_offer_codes_in_your_app).

To support subscriptions, it is necessary to use or read the in-app purchase receipt.
This can be done in two ways:
1. by using your own server / 3rd party provider.
2. locally on the device

The advantage of option 1 is that we are notified when the user has cancelled the subscription.
However, option 1 has the disadvantage that we have to create additional infrastructure and it contradicts our general approach of "do everything on the local device".

Therefore, we decided to go with option 2.
However, option 2 has the disadvantage that we are more limited in terms of notifications about renewal / cancellation of the subscription. In particular, it is not possible to read the local receipt from an app extension - so we cannot update the status from the FileProviderExtension. In order not to inconvenience paying users (by forcing them to open the main app after one year has expired), unless we explicitly know that the user no longer has a current subscription at the current time, we assume that the subscription is active or has been renewed. This allows potential "attacks" on the premium model, but in our case (open source) these are negligible - for the same reason we already store the premium status in the `UserDefaults` and not in the keychain.

The settings screen now shows the following additional items when the subscription is running:
- Manage Subscription (since iOS 15 a sheet with the running subscriptions is presented directly in the main app)
- Redeem Code
- Restore Purchases

because it should be possible to restore Lifetime Premium (e.g. from family sharing) or redeem an offer code even with a running subscription.