### PR TITLE
Fixed missing localURLProvider

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		4AB1C329265CED6600DC7A49 /* ReadingItemPathLockHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB1C328265CED6600DC7A49 /* ReadingItemPathLockHandler.swift */; };
 		4AB1C33A265E9D8600DC7A49 /* UploadTaskExecutorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB1C339265E9D8600DC7A49 /* UploadTaskExecutorTests.swift */; };
 		4AB1C33C265E9DBC00DC7A49 /* CloudTaskExecutorTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB1C33B265E9DBC00DC7A49 /* CloudTaskExecutorTestCase.swift */; };
+		4AB1D4EC27D0E027009060AB /* LocalURLProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB1D4EB27D0E027009060AB /* LocalURLProviderType.swift */; };
+		4AB1D4EE27D0E9EA009060AB /* LocalURLProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB1D4ED27D0E9EA009060AB /* LocalURLProviderMock.swift */; };
 		4AB2E7ED2791A97B00BDBB18 /* CheckMarkCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB2E7EC2791A97B00BDBB18 /* CheckMarkCell.swift */; };
 		4AB2E7EF2791B98A00BDBB18 /* KeepUnlockedSectionFooterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB2E7EE2791B98A00BDBB18 /* KeepUnlockedSectionFooterViewModel.swift */; };
 		4AB52338275F7AB0009B8D99 /* LoadingButtonCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AB52337275F7AB0009B8D99 /* LoadingButtonCellViewModel.swift */; };
@@ -701,6 +703,8 @@
 		4AB1C328265CED6600DC7A49 /* ReadingItemPathLockHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingItemPathLockHandler.swift; sourceTree = "<group>"; };
 		4AB1C339265E9D8600DC7A49 /* UploadTaskExecutorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTaskExecutorTests.swift; sourceTree = "<group>"; };
 		4AB1C33B265E9DBC00DC7A49 /* CloudTaskExecutorTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTaskExecutorTestCase.swift; sourceTree = "<group>"; };
+		4AB1D4EB27D0E027009060AB /* LocalURLProviderType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalURLProviderType.swift; sourceTree = "<group>"; };
+		4AB1D4ED27D0E9EA009060AB /* LocalURLProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalURLProviderMock.swift; sourceTree = "<group>"; };
 		4AB2E7EC2791A97B00BDBB18 /* CheckMarkCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CheckMarkCell.swift; sourceTree = "<group>"; };
 		4AB2E7EE2791B98A00BDBB18 /* KeepUnlockedSectionFooterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeepUnlockedSectionFooterViewModel.swift; sourceTree = "<group>"; };
 		4AB52337275F7AB0009B8D99 /* LoadingButtonCellViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingButtonCellViewModel.swift; sourceTree = "<group>"; };
@@ -1462,24 +1466,25 @@
 				4A797F9524AC9936007DDBE1 /* CloudProviderMock.swift */,
 				4A797F9724AC9A1B007DDBE1 /* CloudProviderMockTests.swift */,
 				4A123EA724BEF5F0001D1CF7 /* CloudProviderPaginationMock.swift */,
+				4A9C8E0027A0104E000063E4 /* EnumerationSignalingMock.swift */,
 				4AB6A893278F048D0016B01E /* FileProviderAdapterCacheTypeMock.swift */,
+				4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */,
 				4AB6A895278F07B20016B01E /* FileProviderAdapterTypeMock.swift */,
 				4A2060CA2798302600DA6C62 /* FileProviderItemUpdateDelegateMock.swift */,
 				4A2060D0279AB32700DA6C62 /* FileProviderNotificatorManagerMock.swift */,
 				4A2060D2279AB38A00DA6C62 /* FileProviderNotificatorMock.swift */,
 				4A5AC4382758EC9400342AA7 /* FullVersionCheckerMock.swift */,
+				4AB1D4ED27D0E9EA009060AB /* LocalURLProviderMock.swift */,
 				4AB6A898278F084E0016B01E /* MaintenanceManagerMock.swift */,
 				4AE791C9278F168E00525913 /* MasterkeyCacheManagerMock.swift */,
-				4AEECD3A279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift */,
 				4AEECD3E279EC48200C6E2B5 /* NSFileProviderChangeObserverMock.swift */,
+				4AEECD3A279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift */,
+				4ADC66C627A95E67002E6CC7 /* UnlockMonitorTaskExecutorMock.swift */,
 				4AE791CB278F16BD00525913 /* VaultKeepUnlockedHelperMock.swift */,
 				4AE791CD278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift */,
 				4AB6A891278EFC730016B01E /* VaultManagerMock.swift */,
-				4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */,
-				4AEECD3C279EB4B200C6E2B5 /* FileProviderAdapterProvidingMock.swift */,
-				4A9C8E0027A0104E000063E4 /* EnumerationSignalingMock.swift */,
-				4ADC66C627A95E67002E6CC7 /* UnlockMonitorTaskExecutorMock.swift */,
 				4ADC66C827A962C2002E6CC7 /* VaultPasswordManagerMock.swift */,
+				4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1609,6 +1614,7 @@
 				4A1673E9270C77CC0075C724 /* DocumentStorageURLProvider.swift */,
 				4AEECD36279EB15400C6E2B5 /* ErrorWrapper.swift */,
 				4A8F149D266A2A8200ADBCE4 /* FileProviderAdapter.swift */,
+				4AB1D4EB27D0E027009060AB /* LocalURLProviderType.swift */,
 				740375F12587AEB40023FF53 /* FileProviderAdapterError.swift */,
 				4A2482322670D6FB002D9F59 /* FileProviderAdapterManager.swift */,
 				4A1673E4270C5E6C0075C724 /* FileProviderCacheManager.swift */,
@@ -2213,6 +2219,7 @@
 				4A511D5326615439000A0E01 /* ReparentTaskExecutorTests.swift in Sources */,
 				4A248227266E27C5002D9F59 /* FolderCreationTaskExecutorTests.swift in Sources */,
 				4AE791CE278F172E00525913 /* VaultKeepUnlockedSettingsMock.swift in Sources */,
+				4AB1D4EE27D0E9EA009060AB /* LocalURLProviderMock.swift in Sources */,
 				4A9C8DFD27A007C2000063E4 /* FileProviderNotificatorTests.swift in Sources */,
 				4AB1C325265CE69700DC7A49 /* DownloadTaskExecutorTests.swift in Sources */,
 				4AEECD3B279EB24300C6E2B5 /* NSFileProviderEnumerationObserverMock.swift in Sources */,
@@ -2525,6 +2532,7 @@
 				4A511D5D26668E47000A0E01 /* ReparentTaskRecord.swift in Sources */,
 				747F2F272587BC250072FB30 /* ReparentTask.swift in Sources */,
 				747F2F282587BC250072FB30 /* ReparentTaskDBManager.swift in Sources */,
+				4AB1D4EC27D0E027009060AB /* LocalURLProviderType.swift in Sources */,
 				4A511D4E2660FF9E000A0E01 /* WorkflowScheduler.swift in Sources */,
 				4A2482352671110A002D9F59 /* DBManagerError.swift in Sources */,
 				4A2060D5279AF67C00DA6C62 /* WorkingSetObserver.swift in Sources */,

--- a/CryptomatorFileProvider/FileProviderAdapterManager.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterManager.swift
@@ -16,12 +16,12 @@ import Promises
 
 protocol FileProviderAdapterProviding {
 	var unlockMonitor: UnlockMonitorType { get }
-	func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType
+	func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProviderType, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType
 }
 
 public class FileProviderAdapterManager: FileProviderAdapterProviding {
 	public static let shared = FileProviderAdapterManager()
-	public typealias FileProviderAdapterDelegate = LocalURLProvider
+	public typealias FileProviderAdapterDelegate = LocalURLProviderType
 	let unlockMonitor: UnlockMonitorType
 
 	private let masterkeyCacheManager: MasterkeyCacheManager
@@ -46,7 +46,7 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		self.unlockMonitor = unlockMonitor
 	}
 
-	public func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: FileProviderAdapterDelegate?, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType {
+	public func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: FileProviderAdapterDelegate, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType {
 		try queue.sync {
 			let cachedAdapterItem = adapterCache.getItem(identifier: domain.identifier)
 			let vaultUID = domain.identifier.rawValue
@@ -73,7 +73,7 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		}
 	}
 
-	public func unlockVault(with domainIdentifier: NSFileProviderDomainIdentifier, kek: [UInt8], dbPath: URL?, delegate: FileProviderAdapterDelegate?, notificator: FileProviderNotificatorType) throws {
+	public func unlockVault(with domainIdentifier: NSFileProviderDomainIdentifier, kek: [UInt8], dbPath: URL?, delegate: FileProviderAdapterDelegate, notificator: FileProviderNotificatorType) throws {
 		guard let dbPath = dbPath else {
 			return
 		}
@@ -119,7 +119,7 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		try maintenanceManager.disableMaintenanceMode()
 	}
 
-	private func autoUnlockVault(withVaultUID vaultUID: String, dbPath: URL, delegate: FileProviderAdapterDelegate?, notificator: FileProviderNotificatorType) throws -> AdapterCacheItem {
+	private func autoUnlockVault(withVaultUID vaultUID: String, dbPath: URL, delegate: FileProviderAdapterDelegate, notificator: FileProviderNotificatorType) throws -> AdapterCacheItem {
 		guard vaultKeepUnlockedHelper.shouldAutoUnlockVault(withVaultUID: vaultUID) else {
 			try masterkeyCacheManager.removeCachedMasterkey(forVaultUID: vaultUID)
 			throw unlockMonitor.getUnlockError(forVaultUID: vaultUID)
@@ -133,7 +133,7 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		return adapterCacheItem
 	}
 
-	private func createAdapterCacheItem(cloudProvider: CloudProvider, dbPath: URL, delegate: FileProviderAdapterDelegate?, notificator: FileProviderNotificatorType) throws -> AdapterCacheItem {
+	private func createAdapterCacheItem(cloudProvider: CloudProvider, dbPath: URL, delegate: FileProviderAdapterDelegate, notificator: FileProviderNotificatorType) throws -> AdapterCacheItem {
 		let database = try DatabaseHelper.getMigratedDB(at: dbPath)
 		let itemMetadataManager = ItemMetadataDBManager(database: database)
 		let cachedFileManager = CachedFileDBManager(database: database)

--- a/CryptomatorFileProvider/FileProviderEnumerator.swift
+++ b/CryptomatorFileProvider/FileProviderEnumerator.swift
@@ -15,9 +15,9 @@ public class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 	private let domain: NSFileProviderDomain
 	private let dbPath: URL
 	private let adapterProvider: FileProviderAdapterProviding
-	private weak var localURLProvider: LocalURLProvider?
+	private let localURLProvider: LocalURLProviderType
 
-	public convenience init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificatorType, domain: NSFileProviderDomain, dbPath: URL, localURLProvider: LocalURLProvider?) {
+	public convenience init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificatorType, domain: NSFileProviderDomain, dbPath: URL, localURLProvider: LocalURLProviderType) {
 		self.init(enumeratedItemIdentifier: enumeratedItemIdentifier,
 		          notificator: notificator,
 		          domain: domain,
@@ -26,7 +26,7 @@ public class FileProviderEnumerator: NSObject, NSFileProviderEnumerator {
 		          adapterProvider: FileProviderAdapterManager.shared)
 	}
 
-	init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificatorType, domain: NSFileProviderDomain, dbPath: URL, localURLProvider: LocalURLProvider?, adapterProvider: FileProviderAdapterProviding) {
+	init(enumeratedItemIdentifier: NSFileProviderItemIdentifier, notificator: FileProviderNotificatorType, domain: NSFileProviderDomain, dbPath: URL, localURLProvider: LocalURLProviderType, adapterProvider: FileProviderAdapterProviding) {
 		self.enumeratedItemIdentifier = enumeratedItemIdentifier
 		self.notificator = notificator
 		self.domain = domain

--- a/CryptomatorFileProvider/LocalURLProviderType.swift
+++ b/CryptomatorFileProvider/LocalURLProviderType.swift
@@ -1,0 +1,82 @@
+//
+//  LocalURLProvider.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 03.03.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import FileProvider
+import Foundation
+
+public protocol LocalURLProviderType: AnyObject {
+	/**
+	 Returns the item identifier directory for a given item identifier.
+
+	 All paths are structured as `<base storage directory>/<item identifier>/`
+
+	 - Note: The path for the `NSFileProviderItemIdentifier.rootContainer` is `<base storage directory>`
+	 */
+	func itemIdentifierDirectoryURLForItem(withPersistentIdentifier identifier: NSFileProviderItemIdentifier) -> URL?
+}
+
+public extension LocalURLProviderType {
+	/**
+	 Resolves the given identifier to a file on disk.
+
+	 All paths are structured as `<base storage directory>/<item identifier>/<item file name>`
+
+	 - Note: The path for the `NSFileProviderItemIdentifier.rootContainer` is `<base storage directory>`
+	 */
+	func urlForItem(withPersistentIdentifier identifier: NSFileProviderItemIdentifier, itemName: String) -> URL? {
+		return itemIdentifierDirectoryURLForItem(withPersistentIdentifier: identifier)?.appendingPathComponent(itemName, isDirectory: false)
+	}
+
+	/**
+	 Resolve the given URL to a persistent identifier.
+
+	 This implementation exploits the fact that the path structure has been defined as
+	 `<base storage directory>/<item identifier>/<item file name>`.
+	 */
+	func persistentIdentifierForItem(at url: URL) -> NSFileProviderItemIdentifier? {
+		let pathComponents = url.pathComponents
+		assert(pathComponents.count > 2)
+		return NSFileProviderItemIdentifier(pathComponents[pathComponents.count - 2])
+	}
+}
+
+public class LocalURLProvider: LocalURLProviderType {
+	private let domain: NSFileProviderDomain
+
+	public init(domain: NSFileProviderDomain) {
+		self.domain = domain
+	}
+
+	public func itemIdentifierDirectoryURLForItem(withPersistentIdentifier identifier: NSFileProviderItemIdentifier) -> URL? {
+		if identifier == .rootContainer {
+			return getBaseStorageDirectory()
+		}
+		let baseStorageDirectoryURL = getBaseStorageDirectory()
+		return baseStorageDirectoryURL?.appendingPathComponent(identifier.rawValue, isDirectory: true)
+	}
+
+	private func getBaseStorageDirectory() -> URL? {
+		let domainDocumentStorage = domain.pathRelativeToDocumentStorage
+		let manager = NSFileProviderManager.default
+		do {
+			try excludeFileProviderDocumentStorageFromiCloudBackup()
+		} catch {
+			DDLogError("Exclude FileProviderDocumentStorage from iCloud backup failed with error: \(error)")
+			return nil
+		}
+		return manager.documentStorageURL.appendingPathComponent(domainDocumentStorage)
+	}
+
+	private func excludeFileProviderDocumentStorageFromiCloudBackup() throws {
+		var values = URLResourceValues()
+		values.isExcludedFromBackup = true
+		var documentStorageURL = NSFileProviderManager.default.documentStorageURL
+		try documentStorageURL.setResourceValues(values)
+	}
+}

--- a/CryptomatorFileProvider/VaultUnlockingServiceSource.swift
+++ b/CryptomatorFileProvider/VaultUnlockingServiceSource.swift
@@ -19,7 +19,7 @@ public class VaultUnlockingServiceSource: NSObject, NSFileProviderServiceSource,
 	private let domain: NSFileProviderDomain
 	private let notificator: FileProviderNotificatorType?
 	private let dbPath: URL?
-	private weak var delegate: LocalURLProvider?
+	private let localURLProvider: LocalURLProviderType
 	private lazy var listener: NSXPCListener = {
 		let listener = NSXPCListener.anonymous()
 		listener.delegate = self
@@ -31,11 +31,11 @@ public class VaultUnlockingServiceSource: NSObject, NSFileProviderServiceSource,
 		return domain.identifier.rawValue
 	}
 
-	public init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType?, dbPath: URL?, delegate: LocalURLProvider?) {
+	public init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType?, dbPath: URL?, delegate: LocalURLProviderType) {
 		self.domain = domain
 		self.notificator = notificator
 		self.dbPath = dbPath
-		self.delegate = delegate
+		self.localURLProvider = delegate
 	}
 
 	public func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
@@ -68,7 +68,7 @@ public class VaultUnlockingServiceSource: NSObject, NSFileProviderServiceSource,
 				return
 			}
 			do {
-				try FileProviderAdapterManager.shared.unlockVault(with: domain.identifier, kek: kek, dbPath: self.dbPath, delegate: self.delegate, notificator: notificator)
+				try FileProviderAdapterManager.shared.unlockVault(with: domain.identifier, kek: kek, dbPath: self.dbPath, delegate: self.localURLProvider, notificator: notificator)
 				FileProviderAdapterManager.shared.unlockMonitor.unlockSucceeded(forVaultUID: vaultUID)
 				DDLogInfo("Unlocked vault \"\(domain.displayName)\" (\(domain.identifier.rawValue))")
 				reply(nil)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterCreateDirectoryTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterCreateDirectoryTests.swift
@@ -15,7 +15,7 @@ class FileProviderAdapterCreateDirectoryTests: FileProviderAdapterTestCase {
 		let expectation = XCTestExpectation()
 		let rootItemMetadata = ItemMetadata(id: metadataManagerMock.getRootContainerID(), name: "Home", type: .folder, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(rootItemMetadata)
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
 		adapter.createDirectory(withName: "TestFolder", inParentItemIdentifier: .rootContainer) { item, error in
 			XCTAssertNil(error)
 			guard let fileProviderItem = item as? FileProviderItem else {
@@ -40,7 +40,7 @@ class FileProviderAdapterCreateDirectoryTests: FileProviderAdapterTestCase {
 
 	func testCreateDirectoryFailsIfParentDoesNotExist() throws {
 		let expectation = XCTestExpectation()
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: LocalURLProviderMock())
 		adapter.createDirectory(withName: "TestFolder", inParentItemIdentifier: NSFileProviderItemIdentifier("2")) { item, error in
 			XCTAssertNil(item)
 			guard let error = error else {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterDeleteItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterDeleteItemTests.swift
@@ -17,7 +17,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let cloudPath = CloudPath("/test.txt")
 		let itemMetadata = ItemMetadata(id: itemID, name: "test.txt", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(itemMetadata)
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = createFullyMockedAdapter()
 		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
 		adapter.deleteItem(withIdentifier: itemIdentifier) { error in
 			XCTAssertNil(error)
@@ -49,7 +49,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let localURLForItem = tmpDirectory.appendingPathComponent("/\(fileItemIdentifier)/test.txt")
 		try cachedFileManagerMock.cacheLocalFileInfo(for: fileItemID, localURL: localURLForItem, lastModifiedDate: Date(timeIntervalSinceReferenceDate: 0))
 
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = createFullyMockedAdapter()
 		adapter.deleteItem(withIdentifier: folderItemIdentifier) { error in
 			XCTAssertNil(error)
 
@@ -71,7 +71,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let cloudPath = CloudPath("/test.txt")
 		let itemMetadata = ItemMetadata(id: itemID, name: "test.txt", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(itemMetadata)
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = createFullyMockedAdapter()
 		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
 
 		let localURLForItem = tmpDirectory.appendingPathComponent("/\(itemIdentifier)/test.txt")
@@ -100,7 +100,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let itemID: Int64 = 2
 		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
 
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock)
+		let adapter = createFullyMockedAdapter()
 
 		adapter.deleteItem(withIdentifier: itemIdentifier) { error in
 			XCTAssertNil(error)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
@@ -76,13 +76,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 		// Create local folder for conflicting item
 		let conflictingItemDirectory = tmpDirectory.appendingPathComponent("3")
 		try FileManager.default.createDirectory(at: conflictingItemDirectory, withIntermediateDirectories: false)
-		localURLProviderMock.response = { identifier in
-			XCTAssertEqual(NSFileProviderItemIdentifier("3"), identifier)
-			guard let item = try? self.adapter.item(for: identifier) else {
-				return nil
-			}
-			return conflictingItemDirectory.appendingPathComponent(item.filename, isDirectory: false)
-		}
+		localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReturnValue = conflictingItemDirectory
 
 		try "Local changed file content".write(to: url, atomically: true, encoding: .utf8)
 
@@ -118,6 +112,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 		}
 		wait(for: [expectation], timeout: 1.0)
 		assertItemRemovedFromWorkingSet()
+		XCTAssertEqual([NSFileProviderItemIdentifier("3")], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
 	}
 
 	func testStartProvidingItemWithTagData() throws {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -37,17 +37,6 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		                              fullVersionChecker: fullVersionCheckerMock)
 	}
 
-	class LocalURLProviderMock: LocalURLProvider {
-		var response: ((NSFileProviderItemIdentifier) -> URL?)?
-
-		func urlForItem(withPersistentIdentifier identifier: NSFileProviderItemIdentifier) -> URL? {
-			guard let response = response else {
-				fatalError("urlForItem not mocked")
-			}
-			return response(identifier)
-		}
-	}
-
 	class WorkflowSchedulerMock: WorkflowScheduler {
 		init() {
 			super.init(maxParallelUploads: 1, maxParallelDownloads: 1)
@@ -56,6 +45,10 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		override func schedule<T>(_ workflow: Workflow<T>) -> Promise<T> {
 			return Promise(CloudTaskTestError.correctPassthrough)
 		}
+	}
+
+	func createFullyMockedAdapter() -> FileProviderAdapter {
+		return FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
 	}
 }
 

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -18,6 +18,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 	var notificatorMock: FileProviderNotificatorTypeMock!
 	var adapterProvidingMock: FileProviderAdapterProvidingMock!
 	var adapterMock: FileProviderAdapterTypeMock!
+	var localURLProviderMock: LocalURLProviderMock!
 	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
 	let dbPath = FileManager.default.temporaryDirectory
 	let items: [FileProviderItem] = [
@@ -34,6 +35,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 		adapterProvidingMock = FileProviderAdapterProvidingMock()
 		adapterMock = FileProviderAdapterTypeMock()
 		adapterProvidingMock.unlockMonitor = UnlockMonitor()
+		localURLProviderMock = LocalURLProviderMock()
 	}
 
 	// MARK: Enumerate Items
@@ -227,7 +229,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 	}
 
 	private func createEnumerator(for itemIdentifier: NSFileProviderItemIdentifier) -> FileProviderEnumerator {
-		return FileProviderEnumerator(enumeratedItemIdentifier: itemIdentifier, notificator: notificatorMock, domain: domain, dbPath: dbPath, localURLProvider: nil, adapterProvider: adapterProvidingMock)
+		return FileProviderEnumerator(enumeratedItemIdentifier: itemIdentifier, notificator: notificatorMock, domain: domain, dbPath: dbPath, localURLProvider: localURLProviderMock, adapterProvider: adapterProvidingMock)
 	}
 
 	private func assertWaitForSemaphoreCalled() {

--- a/CryptomatorFileProviderTests/Mocks/FileProviderAdapterProvidingMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderAdapterProvidingMock.swift
@@ -34,12 +34,12 @@ final class FileProviderAdapterProvidingMock: FileProviderAdapterProviding {
 		getAdapterForDomainDbPathDelegateNotificatorCallsCount > 0
 	}
 
-	var getAdapterForDomainDbPathDelegateNotificatorReceivedArguments: (domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType)?
-	var getAdapterForDomainDbPathDelegateNotificatorReceivedInvocations: [(domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType)] = []
+	var getAdapterForDomainDbPathDelegateNotificatorReceivedArguments: (domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProviderType, notificator: FileProviderNotificatorType)?
+	var getAdapterForDomainDbPathDelegateNotificatorReceivedInvocations: [(domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProviderType?, notificator: FileProviderNotificatorType)] = []
 	var getAdapterForDomainDbPathDelegateNotificatorReturnValue: FileProviderAdapterType!
-	var getAdapterForDomainDbPathDelegateNotificatorClosure: ((NSFileProviderDomain, URL, LocalURLProvider?, FileProviderNotificatorType) throws -> FileProviderAdapterType)?
+	var getAdapterForDomainDbPathDelegateNotificatorClosure: ((NSFileProviderDomain, URL, LocalURLProviderType, FileProviderNotificatorType) throws -> FileProviderAdapterType)?
 
-	func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProvider?, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType {
+	func getAdapter(forDomain domain: NSFileProviderDomain, dbPath: URL, delegate: LocalURLProviderType, notificator: FileProviderNotificatorType) throws -> FileProviderAdapterType {
 		if let error = getAdapterForDomainDbPathDelegateNotificatorThrowableError {
 			throw error
 		}

--- a/CryptomatorFileProviderTests/Mocks/LocalURLProviderMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/LocalURLProviderMock.swift
@@ -1,0 +1,35 @@
+//
+//  LocalURLProviderMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 03.03.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorFileProvider
+import FileProvider
+import Foundation
+
+// swiftlint:disable all
+final class LocalURLProviderMock: LocalURLProviderType {
+	// MARK: - itemIdentifierDirectoryURLForItem
+
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierCallsCount = 0
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierCalled: Bool {
+		itemIdentifierDirectoryURLForItemWithPersistentIdentifierCallsCount > 0
+	}
+
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedIdentifier: NSFileProviderItemIdentifier?
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations: [NSFileProviderItemIdentifier] = []
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierReturnValue: URL?
+	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierClosure: ((NSFileProviderItemIdentifier) -> URL?)?
+
+	func itemIdentifierDirectoryURLForItem(withPersistentIdentifier identifier: NSFileProviderItemIdentifier) -> URL? {
+		itemIdentifierDirectoryURLForItemWithPersistentIdentifierCallsCount += 1
+		itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedIdentifier = identifier
+		itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations.append(identifier)
+		return itemIdentifierDirectoryURLForItemWithPersistentIdentifierClosure.map({ $0(identifier) }) ?? itemIdentifierDirectoryURLForItemWithPersistentIdentifierReturnValue
+	}
+}
+
+// swiftlint:enable all


### PR DESCRIPTION
Since the bug with the strong reference to the FileProviderExtension was fixed in https://github.com/cryptomator/ios/commit/f77da62827eec74929d4f9dce50a3be34d047b41, the FileProviderExtension now actually deinitializes itself. Since we had only a weak reference in the FileProviderAdapter on the FileProviderExtension object, we received thereby after some time no more local URLs. This caused all actions that call `importDocument` to fail.

Therefore, this should fix #181 , #179 and maybe even #173.