### PR TITLE
Removed the redeem code button from the purchase screen

### DIFF
--- a/Cryptomator/Purchase/PurchaseFooterView.swift
+++ b/Cryptomator/Purchase/PurchaseFooterView.swift
@@ -17,22 +17,8 @@ class PurchaseFooterView: UITableViewHeaderFooterView {
 		return button
 	}()
 
-	lazy var redeemCodeButton: UIButton = {
-		let button = UIButton(type: .system)
-		button.setTitle(LocalizedString.getValue("purchase.redeemCode.button"), for: .normal)
-		styleButton(button)
-		button.isHidden = !canRedeemCode()
-		return button
-	}()
-
-	private lazy var bulletPoint: UILabel = {
-		let label = createBulletPointLabel()
-		label.isHidden = !canRedeemCode()
-		return label
-	}()
-
 	private lazy var purchaseActionStack: UIStackView = {
-		let stack = UIStackView(arrangedSubviews: [restorePurchaseButton, bulletPoint, redeemCodeButton])
+		let stack = UIStackView(arrangedSubviews: [restorePurchaseButton])
 		stack.alignment = .center
 		return stack
 	}()
@@ -92,13 +78,11 @@ class PurchaseFooterView: UITableViewHeaderFooterView {
 	func configure(with traitCollection: UITraitCollection) {
 		let preferredContentSize = traitCollection.preferredContentSizeCategory
 		if preferredContentSize.isAccessibilityCategory {
-			bulletPoint.isHidden = true
 			configureAsVerticalStack(purchaseActionStack)
 
 			legalBulletPoint.isHidden = true
 			configureAsVerticalStack(legalInfoStack)
 		} else {
-			bulletPoint.isHidden = !canRedeemCode()
 			configureAsHorizontalStack(purchaseActionStack)
 
 			legalBulletPoint.isHidden = false
@@ -121,15 +105,6 @@ class PurchaseFooterView: UITableViewHeaderFooterView {
 		button.titleLabel?.adjustsFontSizeToFitWidth = true
 		button.titleLabel?.adjustsFontForContentSizeCategory = true
 		button.titleLabel?.minimumScaleFactor = 0.5
-	}
-
-	/// Offer codes are available on devices running iOS 14 or later
-	private func canRedeemCode() -> Bool {
-		if #available(iOS 14.0, *) {
-			return true
-		} else {
-			return false
-		}
 	}
 
 	private func createBulletPointLabel() -> UILabel {

--- a/Cryptomator/Purchase/PurchaseViewController.swift
+++ b/Cryptomator/Purchase/PurchaseViewController.swift
@@ -13,9 +13,6 @@ class PurchaseViewController: IAPViewController {
 	private lazy var footerView: PurchaseFooterView = {
 		let footerView = PurchaseFooterView()
 		footerView.restorePurchaseButton.addTarget(self, action: #selector(restorePurchase), for: .primaryActionTriggered)
-		if #available(iOS 14.0, *) {
-			footerView.redeemCodeButton.addTarget(self, action: #selector(redeemCode), for: .primaryActionTriggered)
-		}
 		return footerView
 	}()
 
@@ -28,7 +25,6 @@ class PurchaseViewController: IAPViewController {
 		super.viewDidLoad()
 		viewModel.hasRunningTransaction.receive(on: DispatchQueue.main).sink { [weak self] hasRunningTransaction in
 			self?.footerView.restorePurchaseButton.isEnabled = !hasRunningTransaction
-			self?.footerView.redeemCodeButton.isEnabled = !hasRunningTransaction
 		}.store(in: &subscribers)
 	}
 
@@ -62,10 +58,5 @@ class PurchaseViewController: IAPViewController {
 		}.catch { [weak self] error in
 			self?.handleError(error)
 		}
-	}
-
-	@available(iOS 14.0, *)
-	@objc private func redeemCode() {
-		viewModel.redeemCode()
 	}
 }

--- a/Cryptomator/Purchase/PurchaseViewModel.swift
+++ b/Cryptomator/Purchase/PurchaseViewModel.swift
@@ -39,16 +39,6 @@ class PurchaseViewModel: BaseIAPViewModel, ProductFetching {
 		addUpgradeOfferItem()
 	}
 
-	/**
-	 Presents the code redemption sheet.
-
-	 - Note: The code redemption sheet does not work on the simulator.
-	 */
-	@available(iOS 14.0, *)
-	func redeemCode() {
-		SKPaymentQueue.default().presentCodeRedemptionSheet()
-	}
-
 	private func addTrialItem() {
 		if let trialExpirationDate = cryptomatorSettings.trialExpirationDate {
 			cells.append(.trialCell(TrialCellViewModel(expirationDate: trialExpirationDate)))

--- a/Cryptomator/Settings/SettingsViewController.swift
+++ b/Cryptomator/Settings/SettingsViewController.swift
@@ -125,10 +125,6 @@ class SettingsViewController: StaticUITableViewController<SettingsSection> {
 			coordinator?.showUnlockFullVersion()
 		case .showManageSubscriptions:
 			coordinator?.showManageSubscriptions()
-		case .redeemCode:
-			if #available(iOS 14.0, *) {
-				viewModel.redeemCode()
-			}
 		case .restorePurchase:
 			viewModel.restorePurchase().then { [weak self] _ in
 				self?.refreshRows()

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -22,8 +22,6 @@ enum SettingsButtonAction: String {
 	case showRateApp
 	case showUnlockFullVersion
 	case showManageSubscriptions
-	@available(iOS 14.0, *)
-	case redeemCode
 	case restorePurchase
 }
 
@@ -73,9 +71,6 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 		var elements = [ButtonCellViewModel.createDisclosureButton(action: SettingsButtonAction.showAbout, title: LocalizedString.getValue("settings.aboutCryptomator"))]
 		if cryptomatorSettings.hasRunningSubscription {
 			elements.append(.init(action: .showManageSubscriptions, title: LocalizedString.getValue("settings.manageSubscriptions")))
-			if #available(iOS 14.0, *) {
-				elements.append(.init(action: .redeemCode, title: LocalizedString.getValue("purchase.redeemCode.button")))
-			}
 			elements.append(.init(action: .restorePurchase, title: LocalizedString.getValue("purchase.restorePurchase.button")))
 		} else if !cryptomatorSettings.fullVersionUnlocked {
 			elements.append(ButtonCellViewModel.createDisclosureButton(action: SettingsButtonAction.showUnlockFullVersion, title: LocalizedString.getValue("settings.unlockFullVersion")))
@@ -129,16 +124,6 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 
 	func restorePurchase() -> Promise<RestoreTransactionsResult> {
 		return StoreObserver.shared.restore()
-	}
-
-	/**
-	 Presents the code redemption sheet.
-
-	 - Note: The code redemption sheet does not work on the simulator.
-	 */
-	@available(iOS 14.0, *)
-	func redeemCode() {
-		SKPaymentQueue.default().presentCodeRedemptionSheet()
 	}
 
 	func enableDebugMode() {

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -142,7 +142,6 @@
 "purchase.product.yearlySubscription.duration" = "yearly";
 "purchase.readOnlyMode.alert.title" = "Read-Only Mode";
 "purchase.readOnlyMode.alert.message" = "You can unlock the full version of Cryptomator later in the settings and use it in read-only mode for now.";
-"purchase.redeemCode.button" = "Redeem Code";
 "purchase.restorePurchase.button" = "Restore Purchase";
 "purchase.restorePurchase.validTrialFound.alert.title" = "Trial Continued";
 "purchase.restorePurchase.validTrialFound.alert.message" = "You can now use the full version of Cryptomator for a limited time. Your trial expires on %@. After that, your vaults will still be accessible in read-only mode.";


### PR DESCRIPTION
Since the code redemption sheet does not reliably provide (internal) feedback about a successful redemption or cancellation of the process (as is the case with a normal purchase of an in-app product), we have decided to remove the Redeem Code button from the Purchase Screen. In our opinion, this offers a better user experience, as it is still possible to redeem offer codes via the app store or via direct URLs and they can be reliably recognized via the app store receipt.