### PR TITLE
Bugfix: Limit the background activity of the FileProviderExtension

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		4A03258125A36B7D00E63D7A /* UIViewController+Preview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A03258025A36B7D00E63D7A /* UIViewController+Preview.swift */; };
 		4A0337CA2726FF46001753B7 /* MoveVaultCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A0337C92726FF46001753B7 /* MoveVaultCoordinator.swift */; };
 		4A03BD6527DF4AEE00B96FA7 /* WorkflowFactoryLocking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A03BD6427DF4AEE00B96FA7 /* WorkflowFactoryLocking.swift */; };
+		4A079FB928084134009AD932 /* WorkingSetEnumerationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A079FB828084134009AD932 /* WorkingSetEnumerationTests.swift */; };
 		4A09BFC62684D599000E40AB /* VaultDetailItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A09BFC52684D599000E40AB /* VaultDetailItem.swift */; };
 		4A09E54C27071F3C0056D32A /* ErrorMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A09E54B27071F3C0056D32A /* ErrorMapperTests.swift */; };
 		4A09E54E27071F4F0056D32A /* ErrorMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A09E54D27071F4F0056D32A /* ErrorMapper.swift */; };
@@ -486,6 +487,7 @@
 		4A0337C92726FF46001753B7 /* MoveVaultCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoveVaultCoordinator.swift; sourceTree = "<group>"; };
 		4A03BD6427DF4AEE00B96FA7 /* WorkflowFactoryLocking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowFactoryLocking.swift; sourceTree = "<group>"; };
 		4A0698692619EF9C00A67F30 /* CryptomatorCommon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = CryptomatorCommon; sourceTree = "<group>"; };
+		4A079FB828084134009AD932 /* WorkingSetEnumerationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetEnumerationTests.swift; sourceTree = "<group>"; };
 		4A09BFC52684D599000E40AB /* VaultDetailItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultDetailItem.swift; sourceTree = "<group>"; };
 		4A09E54B27071F3C0056D32A /* ErrorMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMapperTests.swift; sourceTree = "<group>"; };
 		4A09E54D27071F4F0056D32A /* ErrorMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMapper.swift; sourceTree = "<group>"; };
@@ -1041,6 +1043,7 @@
 				4A4F47F224B875070033328B /* URL+NameCollisionExtensionTests.swift */,
 				4AE5196427F48D6600BA6E4A /* WorkflowDependencyFactoryTests.swift */,
 				4AE5196627F495BF00BA6E4A /* WorkflowDependencyTasksCollectionMock.swift */,
+				4A079FB828084134009AD932 /* WorkingSetEnumerationTests.swift */,
 				4A9C8E0227A016CF000063E4 /* WorkingSetObserverTests.swift */,
 				4ADC66BE27A44557002E6CC7 /* XCTestCase+Promises.swift */,
 				4AF69E2924ACCED000A7174C /* DB */,
@@ -2211,6 +2214,7 @@
 				4ADC66C727A95E67002E6CC7 /* UnlockMonitorTaskExecutorMock.swift in Sources */,
 				4A797F9824AC9A1B007DDBE1 /* CustomCloudProviderMockTests.swift in Sources */,
 				4AAD444727E26D1800D16707 /* UploadTaskManagerMock.swift in Sources */,
+				4A079FB928084134009AD932 /* WorkingSetEnumerationTests.swift in Sources */,
 				4AB1C33C265E9DBC00DC7A49 /* CloudTaskExecutorTestCase.swift in Sources */,
 				4AE5196727F495BF00BA6E4A /* WorkflowDependencyTasksCollectionMock.swift in Sources */,
 				4AC1157827F5BEFD0023F51B /* Promise+AllIgnoringResultsTests.swift in Sources */,

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -152,9 +152,11 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 	}
 
 	private func notifyFileProviderAboutLogLevelUpdate() {
-		let getProxyPromise: Promise<LogLevelUpdating> = fileProviderConnector.getProxy(serviceName: LogLevelUpdatingService.name, domain: nil)
-		getProxyPromise.then { proxy in
-			proxy.logLevelUpdated()
+		let getXPCPromise: Promise<XPC<LogLevelUpdating>> = fileProviderConnector.getXPC(serviceName: LogLevelUpdatingService.name, domain: nil)
+		getXPCPromise.then { xpc in
+			xpc.proxy.logLevelUpdated()
+		}.always {
+			self.fileProviderConnector.invalidateXPC(getXPCPromise)
 		}
 	}
 }

--- a/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewModel.swift
+++ b/Cryptomator/VaultDetail/ChangePassword/ChangePasswordViewModel.swift
@@ -169,9 +169,11 @@ class ChangePasswordViewModel: TableViewModel<ChangePasswordSection>, ChangePass
 
 	private func lockVault() -> Promise<Void> {
 		let domainIdentifier = NSFileProviderDomainIdentifier(vaultAccount.vaultUID)
-		let getProxyPromise: Promise<VaultLocking> = fileProviderConnector.getProxy(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
-		return getProxyPromise.then { proxy -> Void in
-			proxy.lockVault(domainIdentifier: domainIdentifier)
+		let getXPCPromise: Promise<XPC<VaultLocking>> = fileProviderConnector.getXPC(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
+		return getXPCPromise.then { xpc -> Void in
+			xpc.proxy.lockVault(domainIdentifier: domainIdentifier)
+		}.always {
+			self.fileProviderConnector.invalidateXPC(getXPCPromise)
 		}
 	}
 }

--- a/Cryptomator/VaultDetail/MoveVault/MoveVaultViewModel.swift
+++ b/Cryptomator/VaultDetail/MoveVault/MoveVaultViewModel.swift
@@ -73,9 +73,10 @@ class MoveVaultViewModel: ChooseFolderViewModel, MoveVaultViewModelProtocol {
 
 	private func lockVault() -> Promise<Void> {
 		let domainIdentifier = NSFileProviderDomainIdentifier(vaultInfo.vaultUID)
-		let getProxyPromise: Promise<VaultLocking> = fileProviderConnector.getProxy(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
-		return getProxyPromise.then { proxy -> Void in
-			proxy.lockVault(domainIdentifier: domainIdentifier)
+		let getXPCPromise: Promise<XPC<VaultLocking>> = fileProviderConnector.getXPC(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
+		return getXPCPromise.then { xpc -> Void in
+			xpc.proxy.lockVault(domainIdentifier: domainIdentifier)
+			self.fileProviderConnector.invalidateXPC(xpc)
 		}
 	}
 

--- a/Cryptomator/VaultDetail/VaultDetailViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewModel.swift
@@ -215,20 +215,21 @@ class VaultDetailViewModel: VaultDetailViewModelProtocol {
 
 	func lockVault() -> Promise<Void> {
 		let domainIdentifier = NSFileProviderDomainIdentifier(vaultUID)
-		let getProxyPromise: Promise<VaultLocking> = fileProviderConnector.getProxy(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
-		return getProxyPromise.then { proxy -> Void in
-			proxy.lockVault(domainIdentifier: domainIdentifier)
+		let getXPCPromise: Promise<XPC<VaultLocking>> = fileProviderConnector.getXPC(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
+
+		return getXPCPromise.then { xpc -> Void in
+			xpc.proxy.lockVault(domainIdentifier: domainIdentifier)
 			self.vaultInfo.vaultIsUnlocked.value = false
 		}
 	}
 
 	func refreshVaultStatus() -> Promise<Void> {
 		let domainIdentifier = NSFileProviderDomainIdentifier(vaultUID)
-		let getProxyPromise: Promise<VaultLocking> = fileProviderConnector.getProxy(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
+		let getXPCPromise: Promise<XPC<VaultLocking>> = fileProviderConnector.getXPC(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
 		switchCellViewModel?.isOn.value = biometricalUnlockEnabled
-		return getProxyPromise.then { proxy in
+		return getXPCPromise.then { xpc in
 			return wrap { handler in
-				proxy.getIsUnlockedVault(domainIdentifier: domainIdentifier, reply: handler)
+				xpc.proxy.getIsUnlockedVault(domainIdentifier: domainIdentifier, reply: handler)
 			}
 		}.then { isUnlocked -> Void in
 			self.vaultInfo.vaultIsUnlocked.value = isUnlocked

--- a/Cryptomator/VaultList/VaultCellViewModel.swift
+++ b/Cryptomator/VaultList/VaultCellViewModel.swift
@@ -42,13 +42,15 @@ class VaultCellViewModel: TableViewCellViewModel, VaultCellViewModelProtocol {
 
 	func lockVault() -> Promise<Void> {
 		let domainIdentifier = NSFileProviderDomainIdentifier(vault.vaultUID)
-		let getProxyPromise: Promise<VaultLocking> = fileProviderConnector.getProxy(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
-		return getProxyPromise.then { proxy in
-			proxy.lockVault(domainIdentifier: domainIdentifier)
+		let getXPCPromise: Promise<XPC<VaultLocking>> = fileProviderConnector.getXPC(serviceName: VaultLockingService.name, domainIdentifier: domainIdentifier)
+		return getXPCPromise.then { xpc in
+			xpc.proxy.lockVault(domainIdentifier: domainIdentifier)
 		}.then {
 			self.setVaultUnlockStatus(unlocked: false)
 		}.catch { error in
 			self.errorPublisher.send(error)
+		}.always {
+			self.fileProviderConnector.invalidateXPC(getXPCPromise)
 		}
 	}
 

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -6,27 +6,27 @@
 //  Copyright © 2022 Skymatic GmbH. All rights reserved.
 //
 
+import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
 import FileProvider
 import Promises
 import XCTest
 @testable import CryptomatorFileProvider
 
-class FileProviderEnumeratorTests: XCTestCase {
+class FileProviderEnumeratorTestCase: XCTestCase {
 	var enumerationObserverMock: NSFileProviderEnumerationObserverMock!
 	var changeObserverMock: NSFileProviderChangeObserverMock!
 	var notificatorMock: FileProviderNotificatorTypeMock!
 	var adapterProvidingMock: FileProviderAdapterProvidingMock!
 	var adapterMock: FileProviderAdapterTypeMock!
 	var localURLProviderMock: LocalURLProviderMock!
-	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
 	let dbPath = FileManager.default.temporaryDirectory
+	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
 	let items: [FileProviderItem] = [
 		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false)),
 		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false))
 	]
 	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
-	let currentSyncAnchorDate = Date.distantFuture
 
 	override func setUpWithError() throws {
 		enumerationObserverMock = NSFileProviderEnumerationObserverMock()
@@ -38,11 +38,30 @@ class FileProviderEnumeratorTests: XCTestCase {
 		localURLProviderMock = LocalURLProviderMock()
 	}
 
+	func createSyncAnchor(from date: Date, locked: Bool = false) throws -> NSFileProviderSyncAnchor {
+		return NSFileProviderSyncAnchor(try JSONEncoder().encode(SyncAnchor(invalidated: locked, date: date)))
+	}
+
+	func createFullyMockedEnumerator(for itemIdentifier: NSFileProviderItemIdentifier) -> FileProviderEnumerator {
+		return FileProviderEnumerator(enumeratedItemIdentifier: itemIdentifier, notificator: notificatorMock, domain: domain, dbPath: dbPath, localURLProvider: localURLProviderMock, adapterProvider: adapterProvidingMock)
+	}
+
+	func assertChangeObserverUpdated(deletedItems: [NSFileProviderItemIdentifier], updatedItems: [FileProviderItem], currentSyncAnchor: NSFileProviderSyncAnchor) {
+		XCTAssertEqual([deletedItems], changeObserverMock.didDeleteItemsWithIdentifiersReceivedInvocations)
+		let receivedUpdatedItems = changeObserverMock.didUpdateReceivedInvocations as? [[FileProviderItem]]
+		XCTAssertEqual([updatedItems], receivedUpdatedItems)
+		XCTAssertFalse(changeObserverMock.finishEnumeratingWithErrorCalled)
+	}
+}
+
+class FileProviderEnumeratorTests: FileProviderEnumeratorTestCase {
+	let currentSyncAnchorDate = Date.distantFuture
+
 	// MARK: Enumerate Items
 
 	func testEnumerateItemsFromScratch() {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
 		let itemList = FileProviderItemList(items: items, nextPageToken: nil)
 		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
@@ -59,7 +78,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 
 	func testEnumerateItemsFromScratchWithNextPageToken() {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
 		let nextPageToken = "Foo"
 		let nextFileProviderPage = NSFileProviderPage(nextPageToken.data(using: .utf8)!)
@@ -78,7 +97,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 
 	func testEnumerateItemsWithPageToken() {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		let pageToken = "Foo"
 		let page = NSFileProviderPage(pageToken.data(using: .utf8)!)
 		let itemList = FileProviderItemList(items: items, nextPageToken: nil)
@@ -96,7 +115,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 
 	func testEnumerateItemsFailed() {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
 		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
 		adapterMock.enumerateItemsForWithPageTokenReturnValue = Promise(CloudProviderError.noInternetConnection)
@@ -112,7 +131,7 @@ class FileProviderEnumeratorTests: XCTestCase {
 
 	func testEnumerateItemsFailedAdapterNotFound() {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
 		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = UnlockMonitorError.defaultLock
 		enumerationObserverMock.finishEnumeratingWithErrorClosure = { _ in
@@ -124,25 +143,11 @@ class FileProviderEnumeratorTests: XCTestCase {
 		assertErrorWrapped(.defaultLock)
 	}
 
-	func testEnumerateItemsFailedAdapterNotFoundForWorkingSet() {
-		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .workingSet)
-		let page = NSFileProviderPage(NSFileProviderPage.initialPageSortedByName as Data)
-		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = UnlockMonitorError.defaultLock
-		enumerationObserverMock.finishEnumeratingWithErrorClosure = { _ in
-			expectation.fulfill()
-		}
-		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: page)
-		wait(for: [expectation], timeout: 2.0)
-		assertWaitForSemaphoreCalled()
-		assertWorkingSetInvalidated()
-	}
-
 	// MARK: Enumerate Changes
 
 	func testEnumerateChanges() throws {
 		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .rootContainer)
+		let enumerator = createFullyMockedEnumerator(for: .rootContainer)
 		notificatorMock.popUpdateContainerItemsReturnValue = items
 		let syncAnchor = try createSyncAnchor(from: .distantPast)
 		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
@@ -154,82 +159,6 @@ class FileProviderEnumeratorTests: XCTestCase {
 		assertChangeObserverUpdated(deletedItems: [],
 		                            updatedItems: items,
 		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
-	}
-
-	func testEnumerateWorkingSet() throws {
-		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .workingSet)
-		let lastUnlockedDate = Date()
-		adapterMock.lastUnlockedDate = lastUnlockedDate
-		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
-
-		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
-		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
-		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, _ in
-			expectation.fulfill()
-		}
-		let syncAnchor = try createSyncAnchor(from: lastUnlockedDate)
-		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
-		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
-		wait(for: [expectation], timeout: 1.0)
-		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
-		                            updatedItems: items,
-		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
-	}
-
-	func testEnumerateWorkingSetLastUnlockedDateDistantPast() throws {
-		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .workingSet)
-		let lastUnlockedDate = Date.distantPast
-		adapterMock.lastUnlockedDate = lastUnlockedDate
-		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
-
-		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
-		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
-		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, _ in
-			expectation.fulfill()
-		}
-		let syncAnchor = try createSyncAnchor(from: Date())
-
-		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
-		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
-		wait(for: [expectation], timeout: 1.0)
-		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
-		                            updatedItems: items,
-		                            currentSyncAnchor: try createSyncAnchor(from: currentSyncAnchorDate))
-	}
-
-	func testEnumerateWorkingSetChangesFailedAdapterNotFound() throws {
-		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .workingSet)
-		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = UnlockMonitorError.defaultLock
-		changeObserverMock.finishEnumeratingWithErrorClosure = { _ in
-			expectation.fulfill()
-		}
-		let syncAnchor = try createSyncAnchor(from: .distantPast)
-		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
-		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
-		wait(for: [expectation], timeout: 1.0)
-		assertWorkingSetInvalidatedForEnumerateChanges()
-	}
-
-	func testEnumerateWorkingSetUnlockedAfterLastUpdate() throws {
-		let expectation = XCTestExpectation()
-		let enumerator = createEnumerator(for: .workingSet)
-		adapterMock.lastUnlockedDate = Date()
-		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
-		changeObserverMock.finishEnumeratingWithErrorClosure = { _ in
-			expectation.fulfill()
-		}
-		let syncAnchor = try createSyncAnchor(from: Date.distantPast)
-		notificatorMock.currentSyncAnchor = try JSONEncoder().encode(currentSyncAnchorDate)
-		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
-		wait(for: [expectation], timeout: 1.0)
-		assertWorkingSetInvalidatedForEnumerateChanges()
-	}
-
-	private func createEnumerator(for itemIdentifier: NSFileProviderItemIdentifier) -> FileProviderEnumerator {
-		return FileProviderEnumerator(enumeratedItemIdentifier: itemIdentifier, notificator: notificatorMock, domain: domain, dbPath: dbPath, localURLProvider: localURLProviderMock, adapterProvider: adapterProvidingMock)
 	}
 
 	private func assertWaitForSemaphoreCalled() {
@@ -266,32 +195,5 @@ class FileProviderEnumeratorTests: XCTestCase {
 		XCTAssertEqual([expectedWrappedError], receivedErrors)
 		XCTAssertFalse(enumerationObserverMock.finishEnumeratingUpToCalled)
 		XCTAssertFalse(enumerationObserverMock.didEnumerateCalled)
-	}
-
-	private func assertWorkingSetInvalidated() {
-		let receivedErrors = enumerationObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
-		XCTAssertEqual(1, notificatorMock.invalidatedWorkingSetCallsCount)
-		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
-		XCTAssertFalse(enumerationObserverMock.finishEnumeratingUpToCalled)
-		XCTAssertFalse(enumerationObserverMock.didEnumerateCalled)
-	}
-
-	private func createSyncAnchor(from date: Date) throws -> NSFileProviderSyncAnchor {
-		return NSFileProviderSyncAnchor(try JSONEncoder().encode(date))
-	}
-
-	private func assertChangeObserverUpdated(deletedItems: [NSFileProviderItemIdentifier], updatedItems: [FileProviderItem], currentSyncAnchor: NSFileProviderSyncAnchor) {
-		XCTAssertEqual([deletedItems], changeObserverMock.didDeleteItemsWithIdentifiersReceivedInvocations)
-		let receivedUpdatedItems = changeObserverMock.didUpdateReceivedInvocations as? [[FileProviderItem]]
-		XCTAssertEqual([updatedItems], receivedUpdatedItems)
-		XCTAssertFalse(changeObserverMock.finishEnumeratingWithErrorCalled)
-	}
-
-	private func assertWorkingSetInvalidatedForEnumerateChanges() {
-		let receivedErrors = changeObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
-		XCTAssertEqual(1, notificatorMock.invalidatedWorkingSetCallsCount)
-		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
-		XCTAssertFalse(changeObserverMock.finishEnumeratingChangesUpToMoreComingCalled)
-		XCTAssertFalse(changeObserverMock.didUpdateCalled)
 	}
 }

--- a/CryptomatorFileProviderTests/WorkingSetEnumerationTests.swift
+++ b/CryptomatorFileProviderTests/WorkingSetEnumerationTests.swift
@@ -1,0 +1,167 @@
+//
+//  WorkingSetEnumerationTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 14.04.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import Foundation
+import XCTest
+
+@testable import CryptomatorFileProvider
+
+class WorkingSetEnumerationTests: FileProviderEnumeratorTestCase {
+	var lastKnownSyncAnchor: NSFileProviderSyncAnchor!
+	var enumerator: FileProviderEnumerator!
+	let defaultStartPage = NSFileProviderPage(NSFileProviderPage.initialPageSortedByDate as Data)
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		lastKnownSyncAnchor = try createSyncAnchor(from: .distantPast, locked: false)
+		enumerator = FileProviderEnumerator(enumeratedItemIdentifier: .workingSet, notificator: FileProviderNotificator(manager: EnumerationSignalingMock()), domain: domain, dbPath: dbPath, localURLProvider: localURLProviderMock, adapterProvider: adapterProvidingMock)
+
+		setupEnumerateItemsObserver()
+		setupEnumerateChangesObserver()
+	}
+
+	func testEnumerateChangesWithLockedVault() throws {
+		let expectation = XCTestExpectation(description: "Invalidated working set eventually finishes without changing the set when calling enumerateChanges(for:from)")
+		setupChangeObserverMockFinishEnumeratingChanges(with: expectation)
+		simulateLockedVault()
+		enumerator.enumerateChanges(for: changeObserverMock, from: lastKnownSyncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssert(enumerationObserverMock.didEnumerateReceivedUpdatedItems?.isEmpty ?? false)
+		assertWorkingSetInvalidated()
+		XCTAssertEqual(1, enumerationObserverMock.didEnumerateCallsCount)
+	}
+
+	func testEnumerateItemWithLockedVault() throws {
+		let expectation = XCTestExpectation(description: "Locked vault returns empty working set when calling enumerateItems(for:startingAt)")
+		setupChangeObserverMockFinishEnumeratingChanges(with: expectation)
+		simulateLockedVault()
+		enumerator.enumerateItems(for: enumerationObserverMock, startingAt: defaultStartPage)
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssert(enumerationObserverMock.didEnumerateReceivedUpdatedItems?.isEmpty ?? false)
+		assertWorkingSetInvalidated()
+		XCTAssertEqual(2, enumerationObserverMock.didEnumerateCallsCount)
+	}
+
+	func testEnumerateWorkingSet() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createFullyMockedEnumerator(for: .workingSet)
+		let lastUnlockedDate = Date()
+		adapterMock.lastUnlockedDate = lastUnlockedDate
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+
+		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
+		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
+		setupChangeObserverMockFinishEnumeratingChanges(with: expectation)
+		let syncAnchor = try createSyncAnchor(from: lastUnlockedDate)
+
+		let updatedSyncAnchor = try createSyncAnchor(from: .distantFuture)
+		notificatorMock.currentSyncAnchor = updatedSyncAnchor.rawValue
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
+		                            updatedItems: items,
+		                            currentSyncAnchor: updatedSyncAnchor)
+	}
+
+	func testEnumerateWorkingSetLastUnlockedDateDistantPast() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createFullyMockedEnumerator(for: .workingSet)
+		let lastUnlockedDate = Date.distantPast
+		adapterMock.lastUnlockedDate = lastUnlockedDate
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+
+		notificatorMock.getItemIdentifiersToDeleteFromWorkingSetReturnValue = deleteItemIdentifiers
+		notificatorMock.popUpdateWorkingSetItemsReturnValue = items
+		setupChangeObserverMockFinishEnumeratingChanges(with: expectation)
+		let syncAnchor = try createSyncAnchor(from: Date())
+
+		let updatedSyncAnchor = try createSyncAnchor(from: .distantFuture)
+		notificatorMock.currentSyncAnchor = updatedSyncAnchor.rawValue
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertChangeObserverUpdated(deletedItems: deleteItemIdentifiers,
+		                            updatedItems: items,
+		                            currentSyncAnchor: updatedSyncAnchor)
+	}
+
+	func testEnumerateWorkingSetUnlockedAfterLastUpdate() throws {
+		let expectation = XCTestExpectation()
+		let enumerator = createFullyMockedEnumerator(for: .workingSet)
+		adapterMock.lastUnlockedDate = Date()
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		changeObserverMock.finishEnumeratingWithErrorClosure = { error in
+			XCTAssertEqual(NSFileProviderError(.syncAnchorExpired), error as? NSFileProviderError)
+			expectation.fulfill()
+		}
+		let syncAnchor = try createSyncAnchor(from: Date.distantPast)
+		let updatedSyncAnchor = try createSyncAnchor(from: .distantFuture)
+		notificatorMock.currentSyncAnchor = updatedSyncAnchor.rawValue
+		enumerator.enumerateChanges(for: changeObserverMock, from: syncAnchor)
+		wait(for: [expectation], timeout: 1.0)
+		assertWorkingSetInvalidatedForEnumerateChanges()
+	}
+
+	private func setupChangeObserverMockFinishEnumeratingChanges(with expectation: XCTestExpectation) {
+		changeObserverMock.finishEnumeratingChangesUpToMoreComingClosure = { _, moreComing in
+			if !moreComing {
+				expectation.fulfill()
+			}
+		}
+	}
+
+	private func simulateLockedVault() {
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorThrowableError = UnlockMonitorError.defaultLock
+	}
+
+	private func assertWorkingSetDidNotChange() {
+		XCTAssertFalse(changeObserverMock.didUpdateCalled)
+		XCTAssertFalse(changeObserverMock.didDeleteItemsWithIdentifiersCalled)
+	}
+
+	private func assertWorkingSetInvalidated() {
+		let receivedErrors = changeObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
+		XCTAssert(enumerationObserverMock.didEnumerateReceivedUpdatedItems?.isEmpty ?? false)
+		XCTAssertFalse(enumerationObserverMock.finishEnumeratingWithErrorCalled)
+		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
+		XCTAssertFalse(changeObserverMock.didUpdateCalled)
+		XCTAssertFalse(changeObserverMock.didDeleteItemsWithIdentifiersCalled)
+	}
+
+	private func assertWorkingSetInvalidatedForEnumerateChanges() {
+		let receivedErrors = changeObserverMock.finishEnumeratingWithErrorReceivedInvocations as? [NSFileProviderError]
+		XCTAssertEqual([NSFileProviderError(.syncAnchorExpired)], receivedErrors)
+	}
+
+	/// Mimics the behavior of the Files app by calling `enumerateChanges(for:from:)` with the currently known sync anchor after a successful enumeration.
+	private func setupEnumerateItemsObserver() {
+		enumerationObserverMock.finishEnumeratingUpToClosure = { page in
+			if let page = page {
+				self.enumerator.enumerateItems(for: self.enumerationObserverMock, startingAt: page)
+			} else {
+				self.enumerator.enumerateChanges(for: self.changeObserverMock, from: self.lastKnownSyncAnchor)
+			}
+		}
+	}
+
+	/// Mimics the behavior of the Files app by triggering a new enumeration after a `.syncAnchorExpired` error. This means that first the current sync anchor is queried and then `enumerateItems(for:startingAt:)` is called on the enumerator.
+	private func setupEnumerateChangesObserver() {
+		changeObserverMock.finishEnumeratingWithErrorClosure = { error in
+			XCTAssertEqual(NSFileProviderError(.syncAnchorExpired), error as? NSFileProviderError)
+			let updatedSyncAnchorExpectation = XCTestExpectation()
+			self.enumerator.currentSyncAnchor(completionHandler: { newSyncAnchor in
+				if let newSyncAnchor = newSyncAnchor {
+					self.lastKnownSyncAnchor = newSyncAnchor
+				}
+				updatedSyncAnchorExpectation.fulfill()
+			})
+			self.wait(for: [updatedSyncAnchorExpectation], timeout: 1.0)
+			self.enumerator.enumerateItems(for: self.enumerationObserverMock, startingAt: NSFileProviderPage(NSFileProviderPage.initialPageSortedByDate as Data))
+		}
+	}
+}

--- a/CryptomatorTests/ChangePasswordViewModelTests.swift
+++ b/CryptomatorTests/ChangePasswordViewModelTests.swift
@@ -59,6 +59,7 @@ class ChangePasswordViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testEnableMaintenanceModeFailed() throws {
@@ -112,6 +113,7 @@ class ChangePasswordViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testChangePasswordFailForEmptyOldPassword() {

--- a/CryptomatorTests/MoveVaultViewModelTests.swift
+++ b/CryptomatorTests/MoveVaultViewModelTests.swift
@@ -53,6 +53,7 @@ class MoveVaultViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testRejectVaultsInTheLocalFileSystem() throws {
@@ -164,6 +165,7 @@ class MoveVaultViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testIsAllowedToMove() throws {

--- a/CryptomatorTests/RenameVaultViewModelTests.swift
+++ b/CryptomatorTests/RenameVaultViewModelTests.swift
@@ -99,6 +99,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testRenameVaultWithOldNameAsSubstring() throws {
@@ -126,6 +127,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testRenameVaultWithSameName() throws {
@@ -205,6 +207,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	private func createViewModel(vaultAccount: VaultAccount, cloudProviderType: CloudProviderType, viewControllerTitle: String? = nil) -> RenameVaultViewModel {

--- a/CryptomatorTests/SettingsViewModelTests.swift
+++ b/CryptomatorTests/SettingsViewModelTests.swift
@@ -151,8 +151,12 @@ class SettingsViewModelTests: XCTestCase {
 	}
 
 	func testEnabledDebugMode() {
+		let invalidationExpectation = XCTestExpectation()
 		let logLevelUpdatingMock = LogLevelUpdatingMock()
 		fileProviderConnectorMock.proxy = logLevelUpdatingMock
+		fileProviderConnectorMock.doneHandler = {
+			invalidationExpectation.fulfill()
+		}
 		cryptomatorSettingsMock.debugModeEnabled = true
 		guard let debugSection = getSection(for: .debugSection) else {
 			XCTFail("Missing debugSection")
@@ -175,27 +179,37 @@ class SettingsViewModelTests: XCTestCase {
 			self.checkLogLevelUpdatingServiceSourceCall()
 			expectation.fulfill()
 		}
-		wait(for: [expectation], timeout: 1.0)
+		wait(for: [expectation, invalidationExpectation], timeout: 1.0)
 		checkSendLogFilesCellViewModel()
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testEnableDebugMode() {
+		let invalidationExpectation = XCTestExpectation()
 		let expectation = XCTestExpectation()
 		let logLevelUpdatingMock = LogLevelUpdatingMock()
 		fileProviderConnectorMock.proxy = logLevelUpdatingMock
+		fileProviderConnectorMock.doneHandler = {
+			invalidationExpectation.fulfill()
+		}
 		settingsViewModel.enableDebugMode()
 		logLevelUpdatingMock.updated.then {
 			XCTAssertTrue(self.cryptomatorSettingsMock.debugModeEnabled)
 			self.checkLogLevelUpdatingServiceSourceCall()
 			expectation.fulfill()
 		}
-		wait(for: [expectation], timeout: 1.0)
+		wait(for: [expectation, invalidationExpectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testDisableDebugMode() {
+		let invalidationExpectation = XCTestExpectation()
 		let expectation = XCTestExpectation()
 		let logLevelUpdatingMock = LogLevelUpdatingMock()
 		fileProviderConnectorMock.proxy = logLevelUpdatingMock
+		fileProviderConnectorMock.doneHandler = {
+			invalidationExpectation.fulfill()
+		}
 		guard let debugSection = getSection(for: .debugSection) else {
 			XCTFail("Missing debugSection")
 			return
@@ -213,7 +227,8 @@ class SettingsViewModelTests: XCTestCase {
 			self.checkLogLevelUpdatingServiceSourceCall()
 			expectation.fulfill()
 		}
-		wait(for: [expectation], timeout: 1.0)
+		wait(for: [expectation, invalidationExpectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	private func checkSendLogFilesCellViewModel() {

--- a/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
+++ b/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
@@ -104,6 +104,7 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 		XCTAssertEqual(.auto, currentKeepUnlockedDuration.value)
 		XCTAssertFalse(vaultKeepUnlockedSettingsMock.setKeepUnlockedDurationForVaultUIDCalled)
 		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testSetKeepUnlockedDurationForLockedVault() throws {
@@ -122,6 +123,7 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 		XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
 		assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .fiveMinutes)
 		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testSetKeepUnlockedDurationForUnlockedVaultNotAutoDuration() throws {
@@ -194,6 +196,7 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 		XCTAssertFalse(vaultInfo.vaultIsUnlocked.value)
 		assertFileProviderConnectorCalled()
 		XCTAssertEqual([NSFileProviderDomainIdentifier(vaultUID)], vaultLockingMock.lockedVaults)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	private func createViewModel(currentKeepUnlockedDuration: Bindable<KeepUnlockedDuration>) -> VaultKeepUnlockedViewModel {

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -126,6 +126,7 @@ class VaultListViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testRefreshVaultLockedStates() throws {
@@ -156,6 +157,7 @@ class VaultListViewModelTests: XCTestCase {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 }
 

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -161,7 +161,7 @@ class FileProviderExtension: NSFileProviderExtension {
 		 - create a fresh background NSURLSessionTask and schedule it to upload the current modifications
 		 - register the NSURLSessionTask with NSFileProviderManager to provide progress updates
 		 */
-		guard url != dbPath else {
+		guard url.path != dbPath?.path else {
 			return
 		}
 		DDLogDebug("FPExt: itemChanged(at: \(url)) called")
@@ -237,7 +237,6 @@ class FileProviderExtension: NSFileProviderExtension {
 			let notificator = try FileProviderNotificatorManager.shared.getFileProviderNotificator(for: domain)
 			self.notificator = notificator
 			localURLProvider = LocalURLProvider(domain: domain)
-			notificator.refreshWorkingSet()
 		} else {
 			DDLogInfo("setUpDecorator called with nil domain")
 			throw FileProviderDecoratorSetupError.domainIsNil
@@ -249,7 +248,7 @@ class FileProviderExtension: NSFileProviderExtension {
 	override func supportedServiceSources(for itemIdentifier: NSFileProviderItemIdentifier) throws -> [NSFileProviderServiceSource] {
 		var serviceSources = [NSFileProviderServiceSource]()
 		#if DEBUG
-		serviceSources.append(FileProviderValidationServiceSource(fileProviderExtension: self, itemIdentifier: itemIdentifier))
+//		serviceSources.append(FileProviderValidationServiceSource(fileProviderExtension: self, itemIdentifier: itemIdentifier))
 		#endif
 
 		#if SNAPSHOTS


### PR DESCRIPTION
Limits the background activity of the FileProviderExtension and thus fixes #206.
Due to the invalidation of the working set introduced in #156  a new enumeration of the working set was periodically triggered by the Files app in the case of a locked vault. This led to increased and unnecessary background activity of the FileProviderExtension.

This has now been fixed as follows:
When a vault is locked, the working set is invalidated once - this updates the sync anchor, which now has the invalidated flag set. If a subsequent `enumerateChanges(for:from:)` for the sync anchor fails with the invalidated flag set, the working set is not invalidated again, but the Files app is simply informed that there were no changes to the working set. This breaks the loop and the next time the vault is successfully unlocked, the working set will be enumerated from scratch again and the sync anchor will be updated, i.e. the updated date will be renewed and the invalidated flag will be removed.

Furthermore, XPC connections were not invalidated which caused the reference count for the `FileProviderExtension` to remain incremented after using an XPC connection. This has now also been fixed so that the `FileProviderExtension` object does not have to be held in memory longer than necessary.