### PR TITLE
Feature: recoverable uploads

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		4A707802278DC32800AEF4CE /* VaultKeepUnlockedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A707801278DC32800AEF4CE /* VaultKeepUnlockedViewModel.swift */; };
 		4A707804278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A707803278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift */; };
 		4A717CD924C835740048E08F /* ReparentTaskManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A717CD824C835740048E08F /* ReparentTaskManagerTests.swift */; };
+		4A74DBB1282132EC00A332C4 /* FileProviderAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A74DBB0282132EC00A332C4 /* FileProviderAction.swift */; };
 		4A753DB92678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A753DB82678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift */; };
 		4A797F8F24AC6731007DDBE1 /* FileProviderItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */; };
 		4A797F9624AC9936007DDBE1 /* CustomCloudProviderMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A797F9524AC9936007DDBE1 /* CustomCloudProviderMock.swift */; };
@@ -221,6 +222,7 @@
 		4AA22BFB261CA69F00A17486 /* WebDAVAuthenticationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA22BFA261CA69F00A17486 /* WebDAVAuthenticationViewController.swift */; };
 		4AA22C16261CA8D800A17486 /* URLFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA22C15261CA8D800A17486 /* URLFieldCell.swift */; };
 		4AA22C1E261CA94700A17486 /* UsernameFieldCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA22C1D261CA94700A17486 /* UsernameFieldCell.swift */; };
+		4AA2531928216BFD003B45EE /* UploadRetryingServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA2531828216BFD003B45EE /* UploadRetryingServiceSource.swift */; };
 		4AA2531B28216E45003B45EE /* ServiceSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA2531A28216E45003B45EE /* ServiceSource.swift */; };
 		4AA621D9249A6A8400A0BCBD /* FileProviderExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */; };
 		4AA8613725C19D4F002A59F5 /* DetectedMasterkeyViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA8613625C19D4F002A59F5 /* DetectedMasterkeyViewModel.swift */; };
@@ -290,6 +292,7 @@
 		4AEE468F25263B2E0045DA9F /* FileProviderExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4AEE469225263B2E0045DA9F /* FileProviderExtensionUI.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621E4249A6A8400A0BCBD /* FileProviderExtensionUI.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4AEE6EE12822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */; };
+		4AEE6EEA2825716400E1B35E /* ProgressManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE6EE92825716400E1B35E /* ProgressManager.swift */; };
 		4AEECD2F279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */; };
 		4AEECD31279EA50D00C6E2B5 /* WorkingSetObservingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */; };
 		4AEECD33279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */; };
@@ -316,6 +319,10 @@
 		4AF91CEB25A7306E00ACF01E /* DatabaseManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CEA25A7306E00ACF01E /* DatabaseManagerTests.swift */; };
 		4AF91CF425A8BB0D00ACF01E /* VaultListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CF325A8BB0D00ACF01E /* VaultListViewModelTests.swift */; };
 		4AF91D0D25A8D5EF00ACF01E /* ListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91D0C25A8D5EF00ACF01E /* ListViewModel.swift */; };
+		4AFBFA142829206D00E30818 /* UploadProgressAlertController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBFA132829206D00E30818 /* UploadProgressAlertController.swift */; };
+		4AFBFA1628293FE200E30818 /* UploadRetryingServiceSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBFA1528293FE200E30818 /* UploadRetryingServiceSourceTests.swift */; };
+		4AFBFA182829414A00E30818 /* ProgressManagerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBFA172829414A00E30818 /* ProgressManagerMock.swift */; };
+		4AFBFA1A282946BF00E30818 /* InMemoryProgressManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFBFA19282946BF00E30818 /* InMemoryProgressManagerTests.swift */; };
 		4AFCE4CB25B8419D0069C4FC /* FolderChoosing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFCE4CA25B8419D0069C4FC /* FolderChoosing.swift */; };
 		4AFCE4D425B842830069C4FC /* AccountListing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFCE4D325B842830069C4FC /* AccountListing.swift */; };
 		4AFCE4DD25B8514F0069C4FC /* EditableTableViewHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFCE4DC25B8514F0069C4FC /* EditableTableViewHeader.swift */; };
@@ -657,6 +664,7 @@
 		4A707801278DC32800AEF4CE /* VaultKeepUnlockedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultKeepUnlockedViewModel.swift; sourceTree = "<group>"; };
 		4A707803278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultKeepUnlockedViewModelTests.swift; sourceTree = "<group>"; };
 		4A717CD824C835740048E08F /* ReparentTaskManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReparentTaskManagerTests.swift; sourceTree = "<group>"; };
+		4A74DBB0282132EC00A332C4 /* FileProviderAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAction.swift; sourceTree = "<group>"; };
 		4A753DB82678A226005F79C1 /* OpenExistingLegacyVaultPasswordViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenExistingLegacyVaultPasswordViewModel.swift; sourceTree = "<group>"; };
 		4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderItemTests.swift; sourceTree = "<group>"; };
 		4A797F9524AC9936007DDBE1 /* CustomCloudProviderMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomCloudProviderMock.swift; sourceTree = "<group>"; };
@@ -699,6 +707,7 @@
 		4AA22BFA261CA69F00A17486 /* WebDAVAuthenticationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebDAVAuthenticationViewController.swift; sourceTree = "<group>"; };
 		4AA22C15261CA8D800A17486 /* URLFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLFieldCell.swift; sourceTree = "<group>"; };
 		4AA22C1D261CA94700A17486 /* UsernameFieldCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsernameFieldCell.swift; sourceTree = "<group>"; };
+		4AA2531828216BFD003B45EE /* UploadRetryingServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadRetryingServiceSource.swift; sourceTree = "<group>"; };
 		4AA2531A28216E45003B45EE /* ServiceSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceSource.swift; sourceTree = "<group>"; };
 		4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FileProviderExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		4AA621D8249A6A8400A0BCBD /* FileProviderExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderExtension.swift; sourceTree = "<group>"; };
@@ -777,6 +786,7 @@
 		4AEBE8BD2653F4280031487F /* UploadTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTaskExecutor.swift; sourceTree = "<group>"; };
 		4AEBE8C12653FAD40031487F /* WorkflowMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowMiddleware.swift; sourceTree = "<group>"; };
 		4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFileProviderItemIdentifier+Database.swift"; sourceTree = "<group>"; };
+		4AEE6EE92825716400E1B35E /* ProgressManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressManager.swift; sourceTree = "<group>"; };
 		4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetTagDataTests.swift; sourceTree = "<group>"; };
 		4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetObservingMock.swift; sourceTree = "<group>"; };
 		4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetFavoriteRankTests.swift; sourceTree = "<group>"; };
@@ -803,6 +813,10 @@
 		4AF91CEA25A7306E00ACF01E /* DatabaseManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DatabaseManagerTests.swift; sourceTree = "<group>"; };
 		4AF91CF325A8BB0D00ACF01E /* VaultListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultListViewModelTests.swift; sourceTree = "<group>"; };
 		4AF91D0C25A8D5EF00ACF01E /* ListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewModel.swift; sourceTree = "<group>"; };
+		4AFBFA132829206D00E30818 /* UploadProgressAlertController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadProgressAlertController.swift; sourceTree = "<group>"; };
+		4AFBFA1528293FE200E30818 /* UploadRetryingServiceSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadRetryingServiceSourceTests.swift; sourceTree = "<group>"; };
+		4AFBFA172829414A00E30818 /* ProgressManagerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressManagerMock.swift; sourceTree = "<group>"; };
+		4AFBFA19282946BF00E30818 /* InMemoryProgressManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryProgressManagerTests.swift; sourceTree = "<group>"; };
 		4AFCE4CA25B8419D0069C4FC /* FolderChoosing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderChoosing.swift; sourceTree = "<group>"; };
 		4AFCE4D325B842830069C4FC /* AccountListing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountListing.swift; sourceTree = "<group>"; };
 		4AFCE4DC25B8514F0069C4FC /* EditableTableViewHeader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTableViewHeader.swift; sourceTree = "<group>"; };
@@ -1042,10 +1056,12 @@
 				4AEECD38279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift */,
 				4A797F8E24AC6731007DDBE1 /* FileProviderItemTests.swift */,
 				4A9C8DFC27A007C2000063E4 /* FileProviderNotificatorTests.swift */,
+				4AFBFA19282946BF00E30818 /* InMemoryProgressManagerTests.swift */,
 				4AB1D4EF27D20420009060AB /* LocalURLProviderTests.swift */,
 				4AEFF7F327145CB400D6CB99 /* LogLevelUpdatingServiceSourceTests.swift */,
 				4AC1157727F5BEFD0023F51B /* Promise+AllIgnoringResultsTests.swift */,
 				4ADC66C427A7F6D6002E6CC7 /* UnlockMonitorTests.swift */,
+				4AFBFA1528293FE200E30818 /* UploadRetryingServiceSourceTests.swift */,
 				4A4F47F224B875070033328B /* URL+NameCollisionExtensionTests.swift */,
 				4AE5196427F48D6600BA6E4A /* WorkflowDependencyFactoryTests.swift */,
 				4AE5196627F495BF00BA6E4A /* WorkflowDependencyTasksCollectionMock.swift */,
@@ -1250,6 +1266,14 @@
 			path = KeepUnlocked;
 			sourceTree = "<group>";
 		};
+		4A74DBAF2821312200A332C4 /* Actions */ = {
+			isa = PBXGroup;
+			children = (
+				4A74DBB0282132EC00A332C4 /* FileProviderAction.swift */,
+			);
+			path = Actions;
+			sourceTree = "<group>";
+		};
 		4A7B97CA25B6F7340044B7FB /* CloudAccountList */ = {
 			isa = PBXGroup;
 			children = (
@@ -1445,6 +1469,7 @@
 			children = (
 				4AEFF7F127145ADD00D6CB99 /* LogLevelUpdatingServiceSource.swift */,
 				4AA2531A28216E45003B45EE /* ServiceSource.swift */,
+				4AA2531828216BFD003B45EE /* UploadRetryingServiceSource.swift */,
 				4A24001926AE9F3A009DBC2E /* VaultLockingServiceSource.swift */,
 				4A9BED63268F1DB000721BAA /* VaultUnlockingServiceSource.swift */,
 			);
@@ -1476,6 +1501,7 @@
 				4A6A520C268B5EF7006F7368 /* RootViewController.swift */,
 				4A9BED65268F2D9C00721BAA /* UnlockVaultViewController.swift */,
 				4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */,
+				4AFBFA132829206D00E30818 /* UploadProgressAlertController.swift */,
 				4A804083276952C600D7D999 /* Snapshots */,
 			);
 			path = FileProviderExtensionUI;
@@ -1538,6 +1564,7 @@
 				4ADC66C627A95E67002E6CC7 /* UnlockMonitorTaskExecutorMock.swift */,
 				4AB1D4F127D20510009060AB /* DocumentStorageURLProviderMock.swift */,
 				4AAD444627E26D1800D16707 /* UploadTaskManagerMock.swift */,
+				4AFBFA172829414A00E30818 /* ProgressManagerMock.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -1671,10 +1698,12 @@
 				740375F42587AEB50023FF53 /* ItemStatus.swift */,
 				4AB1D4EB27D0E027009060AB /* LocalURLProviderType.swift */,
 				4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */,
+				4AEE6EE92825716400E1B35E /* ProgressManager.swift */,
 				4AC1157527F5BD890023F51B /* Promise+AllIgnoringResult.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
 				4ADC66C027A7F426002E6CC7 /* UnlockMonitor.swift */,
 				740375F52587AEB50023FF53 /* URL+NameCollisionExtension.swift */,
+				4A74DBAF2821312200A332C4 /* Actions */,
 				4AE0D8D82653D8F200DF5D22 /* CloudTask */,
 				740376022587AEB60023FF53 /* DB */,
 				740375FD2587AEB60023FF53 /* Locks */,
@@ -2232,7 +2261,9 @@
 				4ADC66C727A95E67002E6CC7 /* UnlockMonitorTaskExecutorMock.swift in Sources */,
 				4A797F9824AC9A1B007DDBE1 /* CustomCloudProviderMockTests.swift in Sources */,
 				4AAD444727E26D1800D16707 /* UploadTaskManagerMock.swift in Sources */,
+				4AFBFA1A282946BF00E30818 /* InMemoryProgressManagerTests.swift in Sources */,
 				4A079FB928084134009AD932 /* WorkingSetEnumerationTests.swift in Sources */,
+				4AFBFA1628293FE200E30818 /* UploadRetryingServiceSourceTests.swift in Sources */,
 				4AB1C33C265E9DBC00DC7A49 /* CloudTaskExecutorTestCase.swift in Sources */,
 				4AE5196727F495BF00BA6E4A /* WorkflowDependencyTasksCollectionMock.swift in Sources */,
 				4AC1157827F5BEFD0023F51B /* Promise+AllIgnoringResultsTests.swift in Sources */,
@@ -2279,6 +2310,7 @@
 				4A8F14A2266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift in Sources */,
 				4AB1D4F027D20420009060AB /* LocalURLProviderTests.swift in Sources */,
 				4A3E2FEC271DC9670090BD44 /* MaintenanceManagerTests.swift in Sources */,
+				4AFBFA182829414A00E30818 /* ProgressManagerMock.swift in Sources */,
 				4A717CD924C835740048E08F /* ReparentTaskManagerTests.swift in Sources */,
 				4A9C8E0327A016CF000063E4 /* WorkingSetObserverTests.swift in Sources */,
 				4AB1C33A265E9D8600DC7A49 /* UploadTaskExecutorTests.swift in Sources */,
@@ -2322,6 +2354,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A6A520D268B5EF7006F7368 /* RootViewController.swift in Sources */,
+				4AFBFA142829206D00E30818 /* UploadProgressAlertController.swift in Sources */,
 				4A804082276952C300D7D999 /* FileProviderCoordinatorSnapshotMock.swift in Sources */,
 				4A9BED66268F2D9D00721BAA /* UnlockVaultViewController.swift in Sources */,
 				4A6A521B268B7147006F7368 /* FileProviderCoordinator.swift in Sources */,
@@ -2554,6 +2587,7 @@
 				747F2F3A2587BC4B0072FB30 /* LockManager.swift in Sources */,
 				4AEE6EE12822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift in Sources */,
 				4ADD233C267219E200374E4E /* LocalCachedFileInfo.swift in Sources */,
+				4AA2531928216BFD003B45EE /* UploadRetryingServiceSource.swift in Sources */,
 				747F2F3B2587BC4B0072FB30 /* FileSystemLock.swift in Sources */,
 				4A231B80271EF2CA00987492 /* DownloadTaskRecord.swift in Sources */,
 				4A511D592664F290000A0E01 /* DeleteItemHelper.swift in Sources */,
@@ -2610,7 +2644,9 @@
 				4AE5196927F4A24D00BA6E4A /* WorkflowDependencyFactory.swift in Sources */,
 				4A3E2FEE271DCA160090BD44 /* MaintenanceDBManager.swift in Sources */,
 				4AEBE8BC2653F2FD0031487F /* ReparentTaskExecutor.swift in Sources */,
+				4AEE6EEA2825716400E1B35E /* ProgressManager.swift in Sources */,
 				747F2F2C2587BC260072FB30 /* DeletionTaskDBManager.swift in Sources */,
+				4A74DBB1282132EC00A332C4 /* FileProviderAction.swift in Sources */,
 				747F2F2D2587BC260072FB30 /* FileProviderItemList.swift in Sources */,
 				747F2F2E2587BC260072FB30 /* FileProviderItem.swift in Sources */,
 				4A8F149E266A2A8200ADBCE4 /* FileProviderAdapter.swift in Sources */,

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -289,6 +289,7 @@
 		4AEBE8C22653FAD40031487F /* WorkflowMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEBE8C12653FAD40031487F /* WorkflowMiddleware.swift */; };
 		4AEE468F25263B2E0045DA9F /* FileProviderExtension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621D6249A6A8400A0BCBD /* FileProviderExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		4AEE469225263B2E0045DA9F /* FileProviderExtensionUI.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 4AA621E4249A6A8400A0BCBD /* FileProviderExtensionUI.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		4AEE6EE12822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */; };
 		4AEECD2F279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */; };
 		4AEECD31279EA50D00C6E2B5 /* WorkingSetObservingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */; };
 		4AEECD33279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */; };
@@ -775,6 +776,7 @@
 		4AEBE8BB2653F2FD0031487F /* ReparentTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReparentTaskExecutor.swift; sourceTree = "<group>"; };
 		4AEBE8BD2653F4280031487F /* UploadTaskExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UploadTaskExecutor.swift; sourceTree = "<group>"; };
 		4AEBE8C12653FAD40031487F /* WorkflowMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkflowMiddleware.swift; sourceTree = "<group>"; };
+		4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSFileProviderItemIdentifier+Database.swift"; sourceTree = "<group>"; };
 		4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetTagDataTests.swift; sourceTree = "<group>"; };
 		4AEECD30279EA50D00C6E2B5 /* WorkingSetObservingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkingSetObservingMock.swift; sourceTree = "<group>"; };
 		4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterSetFavoriteRankTests.swift; sourceTree = "<group>"; };
@@ -1668,6 +1670,7 @@
 				4A2060CC2799645300DA6C62 /* FileProviderNotificatorManager.swift */,
 				740375F42587AEB50023FF53 /* ItemStatus.swift */,
 				4AB1D4EB27D0E027009060AB /* LocalURLProviderType.swift */,
+				4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */,
 				4AC1157527F5BD890023F51B /* Promise+AllIgnoringResult.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
 				4ADC66C027A7F426002E6CC7 /* UnlockMonitor.swift */,
@@ -2549,6 +2552,7 @@
 				4A231B82271EF35400987492 /* DownloadTaskDBManager.swift in Sources */,
 				4A03BD6527DF4AEE00B96FA7 /* WorkflowFactoryLocking.swift in Sources */,
 				747F2F3A2587BC4B0072FB30 /* LockManager.swift in Sources */,
+				4AEE6EE12822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift in Sources */,
 				4ADD233C267219E200374E4E /* LocalCachedFileInfo.swift in Sources */,
 				747F2F3B2587BC4B0072FB30 /* FileSystemLock.swift in Sources */,
 				4A231B80271EF2CA00987492 /* DownloadTaskRecord.swift in Sources */,

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/UploadRetrying.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/UploadRetrying.swift
@@ -1,0 +1,23 @@
+//
+//  UploadRetrying.swift
+//  CryptomatorCommonCore
+//
+//  Created by Philipp Schmid on 03.05.22.
+//  Copyright © 2021 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+@objc public protocol UploadRetrying: NSFileProviderServiceSource {
+	/**
+	 Retries the upload for the given item identifiers.
+	  */
+	func retryUpload(for itemIdentifiers: [NSFileProviderItemIdentifier], reply: @escaping (Error?) -> Void)
+
+	func getCurrentFractionalUploadProgress(for itemIdentifier: NSFileProviderItemIdentifier, reply: @escaping (NSNumber?) -> Void)
+}
+
+public extension NSFileProviderServiceName {
+	static let uploadRetryingService = NSFileProviderServiceName("org.cryptomator.ios.upload-retrying")
+}

--- a/CryptomatorFileProvider/Actions/FileProviderAction.swift
+++ b/CryptomatorFileProvider/Actions/FileProviderAction.swift
@@ -1,0 +1,14 @@
+//
+//  FileProviderAction.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 03.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import Foundation
+
+public enum FileProviderAction: String {
+	case retryUpload = "org.cryptomator.ios.fileprovider.retryUpload"
+	case retryWaitingUpload = "org.cryptomator.ios.fileprovider.retryWaitingUpload"
+}

--- a/CryptomatorFileProvider/DB/UploadTaskDBManager.swift
+++ b/CryptomatorFileProvider/DB/UploadTaskDBManager.swift
@@ -44,6 +44,13 @@ extension UploadTaskManager {
 		}
 		try removeTaskRecord(for: id)
 	}
+
+	func updateTaskRecord(for itemMetadata: ItemMetadata, with error: NSError) throws {
+		guard let id = itemMetadata.id else {
+			throw DBManagerError.nonSavedItemMetadata
+		}
+		try updateTaskRecord(with: id, lastFailedUploadDate: Date(), uploadErrorCode: error.code, uploadErrorDomain: error.domain)
+	}
 }
 
 class UploadTaskDBManager: UploadTaskManager {

--- a/CryptomatorFileProvider/DB/WorkingSetObserver.swift
+++ b/CryptomatorFileProvider/DB/WorkingSetObserver.swift
@@ -22,8 +22,10 @@ class WorkingSetObserver: WorkingSetObserving {
 	private let cachedFileManager: CachedFileManager
 	private let notificator: FileProviderNotificatorType
 	private var currentWorkingSetItems = Set<FileProviderItem>()
+	private let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(database: DatabaseReader, notificator: FileProviderNotificatorType, uploadTaskManager: UploadTaskManager, cachedFileManager: CachedFileManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, database: DatabaseReader, notificator: FileProviderNotificatorType, uploadTaskManager: UploadTaskManager, cachedFileManager: CachedFileManager) {
+		self.domainIdentifier = domainIdentifier
 		self.database = database
 		self.notificator = notificator
 		self.uploadTaskManager = uploadTaskManager
@@ -72,7 +74,7 @@ class WorkingSetObserver: WorkingSetObserving {
 			let localCachedFileInfo = try cachedFileManager.getLocalCachedFileInfo(for: metadata)
 			let newestVersionLocallyCached = localCachedFileInfo?.isCurrentVersion(lastModifiedDateInCloud: metadata.lastModifiedDate) ?? false
 			let localURL = localCachedFileInfo?.localURL
-			return FileProviderItem(metadata: metadata, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTasks[index]?.failedWithError)
+			return FileProviderItem(metadata: metadata, domainIdentifier: domainIdentifier, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTasks[index]?.failedWithError)
 		}
 		return items
 	}

--- a/CryptomatorFileProvider/FileProviderItem.swift
+++ b/CryptomatorFileProvider/FileProviderItem.swift
@@ -21,10 +21,12 @@ public class FileProviderItem: NSObject, NSFileProviderItem {
 	let error: Error?
 	let newestVersionLocallyCached: Bool
 	let localURL: URL?
+	let domainIdentifier: NSFileProviderDomainIdentifier
 	private let fullVersionChecker: FullVersionChecker
 
-	init(metadata: ItemMetadata, newestVersionLocallyCached: Bool = false, localURL: URL? = nil, error: Error? = nil, fullVersionChecker: FullVersionChecker = UserDefaultsFullVersionChecker.shared) {
+	init(metadata: ItemMetadata, domainIdentifier: NSFileProviderDomainIdentifier, newestVersionLocallyCached: Bool = false, localURL: URL? = nil, error: Error? = nil, fullVersionChecker: FullVersionChecker = UserDefaultsFullVersionChecker.shared) {
 		self.metadata = metadata
+		self.domainIdentifier = domainIdentifier
 		self.error = error
 		self.newestVersionLocallyCached = newestVersionLocallyCached
 		self.localURL = localURL
@@ -33,17 +35,18 @@ public class FileProviderItem: NSObject, NSFileProviderItem {
 
 	public var itemIdentifier: NSFileProviderItemIdentifier {
 		assert(metadata.id != nil)
-		if metadata.id == ItemMetadataDBManager.rootContainerId {
+
+		guard let id = metadata.id, id != ItemMetadataDBManager.rootContainerId else {
 			return .rootContainer
 		}
-		return NSFileProviderItemIdentifier(String(metadata.id ?? -1)) // TODO: Change Optional Handling
+		return NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: id)
 	}
 
 	public var parentItemIdentifier: NSFileProviderItemIdentifier {
 		if metadata.parentID == ItemMetadataDBManager.rootContainerId {
 			return .rootContainer
 		}
-		return NSFileProviderItemIdentifier(String(metadata.parentID))
+		return NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: metadata.parentID)
 	}
 
 	public var capabilities: NSFileProviderItemCapabilities {

--- a/CryptomatorFileProvider/FileProviderItem.swift
+++ b/CryptomatorFileProvider/FileProviderItem.swift
@@ -156,4 +156,10 @@ public class FileProviderItem: NSObject, NSFileProviderItem {
 	public var tagData: Data? {
 		return metadata.tagData
 	}
+
+	/// Workaround to access the `isUploading` and `uploadingError` property in the `NSExtensionFileProviderActionActivationRule`
+	public var userInfo: [AnyHashable: Any]? {
+		return ["isUploading": isUploading,
+		        "hasUploadError": uploadingError != nil]
+	}
 }

--- a/CryptomatorFileProvider/LocalURLProviderType.swift
+++ b/CryptomatorFileProvider/LocalURLProviderType.swift
@@ -75,7 +75,11 @@ public class LocalURLProvider: LocalURLProviderType {
 		if identifier == .rootContainer {
 			return baseStorageDirectoryURL
 		}
-		return baseStorageDirectoryURL?.appendingPathComponent(identifier.rawValue, isDirectory: true)
+		if let itemID = identifier.databaseValue {
+			return baseStorageDirectoryURL?.appendingPathComponent(String(itemID), isDirectory: true)
+		} else {
+			return baseStorageDirectoryURL?.appendingPathComponent(identifier.rawValue, isDirectory: true)
+		}
 	}
 
 	private func getBaseStorageDirectory() -> URL? {

--- a/CryptomatorFileProvider/LocalURLProviderType.swift
+++ b/CryptomatorFileProvider/LocalURLProviderType.swift
@@ -12,6 +12,10 @@ import Foundation
 
 public protocol LocalURLProviderType: AnyObject {
 	/**
+	 The identifier for the corresponding domain of the item identifiers.
+	 */
+	var domainIdentifier: NSFileProviderDomainIdentifier { get }
+	/**
 	 Returns the item identifier directory for a given item identifier.
 
 	 All paths are structured as `<base storage directory>/<item identifier>/`
@@ -46,11 +50,18 @@ public extension LocalURLProviderType {
 	func persistentIdentifierForItem(at url: URL) -> NSFileProviderItemIdentifier? {
 		let pathComponents = url.pathComponents
 		assert(pathComponents.count > 2)
-		return NSFileProviderItemIdentifier(pathComponents[pathComponents.count - 2])
+		guard let itemID = Int64(pathComponents[pathComponents.count - 2]) else {
+			return nil
+		}
+		return NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: itemID)
 	}
 }
 
 public class LocalURLProvider: LocalURLProviderType {
+	public var domainIdentifier: NSFileProviderDomainIdentifier {
+		domain.identifier
+	}
+
 	private let domain: NSFileProviderDomain
 	private let documentStorageURLProvider: DocumentStorageURLProvider
 

--- a/CryptomatorFileProvider/LocalURLProviderType.swift
+++ b/CryptomatorFileProvider/LocalURLProviderType.swift
@@ -46,14 +46,19 @@ public extension LocalURLProviderType {
 
 	 This implementation exploits the fact that the path structure has been defined as
 	 `<base storage directory>/<item identifier>/<item file name>`.
+
+	 - Note: Returns the `.rootContainer` identifier for the special case that the passed `url` corresponds to the `<base storage directory>`. This is necessary to support "Open in Files app".
 	 */
 	func persistentIdentifierForItem(at url: URL) -> NSFileProviderItemIdentifier? {
 		let pathComponents = url.pathComponents
 		assert(pathComponents.count > 2)
-		guard let itemID = Int64(pathComponents[pathComponents.count - 2]) else {
+		if let itemID = Int64(pathComponents[pathComponents.count - 2]) {
+			return NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: itemID)
+		} else if pathComponents.last == domainIdentifier.rawValue {
+			return .rootContainer
+		} else {
 			return nil
 		}
-		return NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: itemID)
 	}
 }
 

--- a/CryptomatorFileProvider/Middleware/ErrorMapper.swift
+++ b/CryptomatorFileProvider/Middleware/ErrorMapper.swift
@@ -38,13 +38,19 @@ class ErrorMapper<T>: WorkflowMiddleware {
 	}
 
 	private func mapError(_ error: Error) -> Error {
-		guard let cloudProviderError = error as? CloudProviderError else {
-			return error
+		return error.toPresentableError()
+	}
+}
+
+extension Error {
+	func toPresentableError() -> Error {
+		guard let cloudProviderError = self as? CloudProviderError else {
+			return self
 		}
 		switch cloudProviderError {
 		case .itemNotFound, .parentFolderDoesNotExist:
 			return NSFileProviderError(.noSuchItem)
-		case .itemAlreadyExists:
+		case .itemAlreadyExists, .itemTypeMismatch:
 			return NSFileProviderError(.filenameCollision)
 		case .pageTokenInvalid:
 			return NSFileProviderError(.syncAnchorExpired)
@@ -54,8 +60,6 @@ class ErrorMapper<T>: WorkflowMiddleware {
 			return NSFileProviderError(.notAuthenticated)
 		case .noInternetConnection:
 			return NSFileProviderError(.serverUnreachable)
-		default:
-			return cloudProviderError
 		}
 	}
 }

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/DownloadTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/DownloadTaskExecutor.swift
@@ -29,8 +29,10 @@ class DownloadTaskExecutor: WorkflowMiddleware {
 	private let cachedFileManager: CachedFileManager
 	private let downloadTaskManager: DownloadTaskManager
 	private let provider: CloudProvider
+	private let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(provider: CloudProvider, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager, downloadTaskManager: DownloadTaskManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager, downloadTaskManager: DownloadTaskManager) {
+		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.itemMetadataManager = itemMetadataManager
 		self.cachedFileManager = cachedFileManager
@@ -85,6 +87,6 @@ class DownloadTaskExecutor: WorkflowMiddleware {
 		itemMetadata.statusCode = .isUploaded
 		try itemMetadataManager.updateMetadata(itemMetadata)
 		try cachedFileManager.cacheLocalFileInfo(for: itemMetadata.id!, localURL: localURL, lastModifiedDate: lastModifiedDate)
-		return FileProviderItem(metadata: itemMetadata, newestVersionLocallyCached: true, localURL: localURL)
+		return FileProviderItem(metadata: itemMetadata, domainIdentifier: domainIdentifier, newestVersionLocallyCached: true, localURL: localURL)
 	}
 }

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/FolderCreationTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/FolderCreationTaskExecutor.swift
@@ -7,6 +7,7 @@
 //
 
 import CryptomatorCloudAccessCore
+import FileProvider
 import Foundation
 import Promises
 
@@ -26,8 +27,10 @@ class FolderCreationTaskExecutor: WorkflowMiddleware {
 
 	private let itemMetadataManager: ItemMetadataManager
 	private let provider: CloudProvider
+	private let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(provider: CloudProvider, itemMetadataManager: ItemMetadataManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, itemMetadataManager: ItemMetadataManager) {
+		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.itemMetadataManager = itemMetadataManager
 	}
@@ -54,7 +57,7 @@ class FolderCreationTaskExecutor: WorkflowMiddleware {
 			itemMetadata.statusCode = .isUploaded
 			itemMetadata.isPlaceholderItem = false
 			try self.itemMetadataManager.updateMetadata(itemMetadata)
-			return FileProviderItem(metadata: itemMetadata, newestVersionLocallyCached: true)
+			return FileProviderItem(metadata: itemMetadata, domainIdentifier: self.domainIdentifier, newestVersionLocallyCached: true)
 		}
 	}
 }

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
@@ -35,8 +35,10 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 	private let itemEnumerationTaskManager: ItemEnumerationTaskManager
 	private let deleteItemHelper: DeleteItemHelper
 	private let provider: CloudProvider
+	private let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(provider: CloudProvider, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager, uploadTaskManager: UploadTaskManager, reparentTaskManager: ReparentTaskManager, deletionTaskManager: DeletionTaskManager, itemEnumerationTaskManager: ItemEnumerationTaskManager, deleteItemHelper: DeleteItemHelper) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager, uploadTaskManager: UploadTaskManager, reparentTaskManager: ReparentTaskManager, deletionTaskManager: DeletionTaskManager, itemEnumerationTaskManager: ItemEnumerationTaskManager, deleteItemHelper: DeleteItemHelper) {
+		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.itemMetadataManager = itemMetadataManager
 		self.cachedFileManager = cachedFileManager
@@ -97,7 +99,7 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 				let localCachedFileInfo = try self.cachedFileManager.getLocalCachedFileInfo(for: metadata)
 				let newestVersionLocallyCached = localCachedFileInfo?.isCurrentVersion(lastModifiedDateInCloud: metadata.lastModifiedDate) ?? false
 				let localURL = localCachedFileInfo?.localURL
-				return FileProviderItem(metadata: metadata, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTasks[index]?.failedWithError)
+				return FileProviderItem(metadata: metadata, domainIdentifier: self.domainIdentifier, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTasks[index]?.failedWithError)
 			}
 			if let nextPageTokenData = itemList.nextPageToken?.data(using: .utf8) {
 				return FileProviderItemList(items: items, nextPageToken: NSFileProviderPage(nextPageTokenData))
@@ -137,7 +139,7 @@ class ItemEnumerationTaskExecutor: WorkflowMiddleware {
 			let localURL = localCachedFileInfo?.localURL
 			let uploadTask = try self.uploadTaskManager.getTaskRecord(for: fileProviderItemMetadata)
 
-			let item = FileProviderItem(metadata: fileProviderItemMetadata, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTask?.failedWithError)
+			let item = FileProviderItem(metadata: fileProviderItemMetadata, domainIdentifier: self.domainIdentifier, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: uploadTask?.failedWithError)
 			return FileProviderItemList(items: [item], nextPageToken: nil)
 		}
 	}

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/ReparentTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/ReparentTaskExecutor.swift
@@ -7,6 +7,7 @@
 //
 
 import CryptomatorCloudAccessCore
+import FileProvider
 import Foundation
 import Promises
 
@@ -28,8 +29,10 @@ class ReparentTaskExecutor: WorkflowMiddleware {
 	private let reparentTaskManager: ReparentTaskManager
 	private let itemMetadataManager: ItemMetadataManager
 	private let cachedFileManager: CachedFileManager
+	private let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(provider: CloudProvider, reparentTaskManager: ReparentTaskManager, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, reparentTaskManager: ReparentTaskManager, itemMetadataManager: ItemMetadataManager, cachedFileManager: CachedFileManager) {
+		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.reparentTaskManager = reparentTaskManager
 		self.itemMetadataManager = itemMetadataManager
@@ -57,7 +60,7 @@ class ReparentTaskExecutor: WorkflowMiddleware {
 			let localCachedFileInfo = try self.cachedFileManager.getLocalCachedFileInfo(for: itemMetadata)
 			let newestVersionLocallyCached = localCachedFileInfo?.isCurrentVersion(lastModifiedDateInCloud: itemMetadata.lastModifiedDate) ?? false
 			try self.reparentTaskManager.removeTaskRecord(reparentTask.taskRecord)
-			return FileProviderItem(metadata: itemMetadata, newestVersionLocallyCached: newestVersionLocallyCached)
+			return FileProviderItem(metadata: itemMetadata, domainIdentifier: self.domainIdentifier, newestVersionLocallyCached: newestVersionLocallyCached)
 		}
 	}
 

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
@@ -31,13 +31,15 @@ class UploadTaskExecutor: WorkflowMiddleware {
 	let itemMetadataManager: ItemMetadataManager
 	let uploadTaskManager: UploadTaskManager
 	let domainIdentifier: NSFileProviderDomainIdentifier
+	let progressManager: ProgressManager
 
-	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, cachedFileManager: CachedFileManager, itemMetadataManager: ItemMetadataManager, uploadTaskManager: UploadTaskManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, cachedFileManager: CachedFileManager, itemMetadataManager: ItemMetadataManager, uploadTaskManager: UploadTaskManager, progressManager: ProgressManager = InMemoryProgressManager.shared) {
 		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.cachedFileManager = cachedFileManager
 		self.itemMetadataManager = itemMetadataManager
 		self.uploadTaskManager = uploadTaskManager
+		self.progressManager = progressManager
 	}
 
 	func execute(task: CloudTask) -> Promise<FileProviderItem> {
@@ -63,8 +65,17 @@ class UploadTaskExecutor: WorkflowMiddleware {
 			return Promise(error)
 		}
 
-		return provider.uploadFile(from: localURL, to: itemMetadata.cloudPath, replaceExisting: !itemMetadata.isPlaceholderItem).then { cloudItemMetadata in
+		let progress = Progress(totalUnitCount: 1)
+		if let itemID = itemMetadata.id {
+			progressManager.saveProgress(progress, for: NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: itemID))
+		}
+		progress.becomeCurrent(withPendingUnitCount: 1)
+		let uploadPromise = provider.uploadFile(from: localURL, to: itemMetadata.cloudPath, replaceExisting: !itemMetadata.isPlaceholderItem)
+		progress.resignCurrent()
+		return uploadPromise.then { cloudItemMetadata in
 			try self.uploadPostProcessing(taskItemMetadata: itemMetadata, cloudItemMetadata: cloudItemMetadata, localURL: localURL, localFileSizeBeforeUpload: localFileSize)
+		}.recover { error -> FileProviderItem in
+			try self.handleUploadError(error, taskItemMetadata: itemMetadata)
 		}
 	}
 
@@ -96,5 +107,16 @@ class UploadTaskExecutor: WorkflowMiddleware {
 			try cachedFileManager.removeCachedFile(for: taskItemMetadata.id!)
 			return FileProviderItem(metadata: taskItemMetadata, domainIdentifier: domainIdentifier)
 		}
+	}
+
+	func handleUploadError(_ error: Error, taskItemMetadata: ItemMetadata) throws -> FileProviderItem {
+		let convertedError = error.toPresentableError()
+		try uploadTaskManager.updateTaskRecord(for: taskItemMetadata, with: convertedError as NSError)
+		taskItemMetadata.statusCode = .uploadError
+		try itemMetadataManager.updateMetadata(taskItemMetadata)
+		let localCachedFileInfo = try cachedFileManager.getLocalCachedFileInfo(for: taskItemMetadata)
+		let newestVersionLocallyCached = localCachedFileInfo?.isCurrentVersion(lastModifiedDateInCloud: taskItemMetadata.lastModifiedDate) ?? false
+		let localURL = localCachedFileInfo?.localURL
+		return FileProviderItem(metadata: taskItemMetadata, domainIdentifier: domainIdentifier, newestVersionLocallyCached: newestVersionLocallyCached, localURL: localURL, error: convertedError)
 	}
 }

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
@@ -30,8 +30,10 @@ class UploadTaskExecutor: WorkflowMiddleware {
 	let cachedFileManager: CachedFileManager
 	let itemMetadataManager: ItemMetadataManager
 	let uploadTaskManager: UploadTaskManager
+	let domainIdentifier: NSFileProviderDomainIdentifier
 
-	init(provider: CloudProvider, cachedFileManager: CachedFileManager, itemMetadataManager: ItemMetadataManager, uploadTaskManager: UploadTaskManager) {
+	init(domainIdentifier: NSFileProviderDomainIdentifier, provider: CloudProvider, cachedFileManager: CachedFileManager, itemMetadataManager: ItemMetadataManager, uploadTaskManager: UploadTaskManager) {
+		self.domainIdentifier = domainIdentifier
 		self.provider = provider
 		self.cachedFileManager = cachedFileManager
 		self.itemMetadataManager = itemMetadataManager
@@ -88,11 +90,11 @@ class UploadTaskExecutor: WorkflowMiddleware {
 		if localFileSizeBeforeUpload == cloudItemMetadata.size {
 			DDLogInfo("uploadPostProcessing: received cloudItemMetadata seem to be correct: localSize = \(localFileSizeBeforeUpload ?? -1); cloudItemSize = \(cloudItemMetadata.size ?? -1)")
 			try cachedFileManager.cacheLocalFileInfo(for: taskItemMetadata.id!, localURL: localURL, lastModifiedDate: cloudItemMetadata.lastModifiedDate)
-			return FileProviderItem(metadata: taskItemMetadata, newestVersionLocallyCached: true, localURL: localURL)
+			return FileProviderItem(metadata: taskItemMetadata, domainIdentifier: domainIdentifier, newestVersionLocallyCached: true, localURL: localURL)
 		} else {
 			DDLogInfo("uploadPostProcessing: received cloudItemMetadata do not belong to the version that was uploaded - size differs!")
 			try cachedFileManager.removeCachedFile(for: taskItemMetadata.id!)
-			return FileProviderItem(metadata: taskItemMetadata)
+			return FileProviderItem(metadata: taskItemMetadata, domainIdentifier: domainIdentifier)
 		}
 	}
 }

--- a/CryptomatorFileProvider/NSFileProviderItemIdentifier+Database.swift
+++ b/CryptomatorFileProvider/NSFileProviderItemIdentifier+Database.swift
@@ -1,0 +1,63 @@
+//
+//  NSFileProviderItemIdentifier+Database.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 04.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+public extension NSFileProviderItemIdentifier {
+	static let rootContainerDatabaseValue: Int64 = 1
+	private static let delimiter: Character = ":"
+
+	/**
+	 Preferred constructor to create an `NSFileProviderItemIdentifier`.
+
+	 An `NSFileProviderItemIdentifier` has the format:
+	 `<domainIdentifier>:<itemID>`
+
+	 This ensures that the `NSFileProviderDomainIdentifier` can be derived from any `NSFileProviderItemIdentifier` (except the `.rootContainer` and `.workingSet`).
+	 This is necessary because the `extensionContext.domainIdentifier` in the FileProviderExtensionUI is not guaranteed to be the `domainIdentifier`
+	 of the currently visible `NSFileProviderDomain` and thus a correct XPC connection could not be established.
+	 */
+	init(domainIdentifier: NSFileProviderDomainIdentifier, itemID: Int64) {
+		if itemID == NSFileProviderItemIdentifier.rootContainerDatabaseValue {
+			self.init(rawValue: NSFileProviderItemIdentifier.rootContainer.rawValue)
+		} else {
+			self.init(rawValue: "\(domainIdentifier.rawValue)\(NSFileProviderItemIdentifier.delimiter)\(itemID)")
+		}
+	}
+
+	/**
+	 The identifier of the domain to which the item with this `NSFileProviderItemIdentifier` belongs.
+
+	 To use this attribute the `NSFileProviderItemIdentifier` must have been created with the constructor `init(domainIdentifier:itemID:)`.
+	 This attribute is always nil for `.rootContainer` and `.workingSet`.
+	 */
+	var domainIdentifier: NSFileProviderDomainIdentifier? {
+		guard let index = rawValue.firstIndex(of: NSFileProviderItemIdentifier.delimiter) else {
+			return nil
+		}
+		let before = rawValue.prefix(upTo: index)
+		return NSFileProviderDomainIdentifier(String(before))
+	}
+
+	/**
+	 Representation of the identifier as it is stored in the database.
+
+	 The database value corresponds to the `itemID` which was passed to the constructor `init(domainIdentifier:itemID:)` and `1` for the `.rootContainer`.
+	 */
+	var databaseValue: Int64? {
+		if self == .rootContainer {
+			return NSFileProviderItemIdentifier.rootContainerDatabaseValue
+		}
+		guard let index = rawValue.firstIndex(of: NSFileProviderItemIdentifier.delimiter) else {
+			return nil
+		}
+		let after = rawValue.suffix(from: index).dropFirst()
+		return Int64(after)
+	}
+}

--- a/CryptomatorFileProvider/ProgressManager.swift
+++ b/CryptomatorFileProvider/ProgressManager.swift
@@ -1,0 +1,43 @@
+//
+//  ProgressManager.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 06.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+
+protocol ProgressManager {
+	/**
+	 Returns the progress for the given `itemIdentifier` - `nil` if no progress could be found for the given `itemIdentifier`.
+	 */
+	func getProgress(for itemIdentifier: NSFileProviderItemIdentifier) -> Progress?
+
+	/**
+	 Saves the progress for the given `itemIdentifier`.
+
+	 - Note: If a progress object already exists for the given `itemIdentifier`, it will be replaced.
+	 */
+	func saveProgress(_ progress: Progress, for itemIdentifier: NSFileProviderItemIdentifier)
+}
+
+class InMemoryProgressManager: ProgressManager {
+	static let shared = InMemoryProgressManager()
+
+	private let queue = DispatchQueue(label: "InMemoryProgressManager", attributes: .concurrent)
+	private lazy var progressDictionary = [NSFileProviderItemIdentifier: Progress]()
+
+	func getProgress(for itemIdentifier: NSFileProviderItemIdentifier) -> Progress? {
+		return queue.sync {
+			progressDictionary[itemIdentifier]
+		}
+	}
+
+	func saveProgress(_ progress: Progress, for itemIdentifier: NSFileProviderItemIdentifier) {
+		queue.async(flags: .barrier) {
+			self.progressDictionary[itemIdentifier] = progress
+		}
+	}
+}

--- a/CryptomatorFileProvider/ServiceSource/UploadRetryingServiceSource.swift
+++ b/CryptomatorFileProvider/ServiceSource/UploadRetryingServiceSource.swift
@@ -1,0 +1,60 @@
+//
+//  UploadRetryingServiceSource.swift
+//  CryptomatorFileProvider
+//
+//  Created by Philipp Schmid on 03.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import FileProvider
+import Foundation
+
+public class UploadRetryingServiceSource: ServiceSource, UploadRetrying {
+	private let adapterManager: FileProviderAdapterProviding
+	private let domain: NSFileProviderDomain
+	private let notificator: FileProviderNotificatorType
+	private let dbPath: URL
+	private let localURLProvider: LocalURLProviderType
+	private let progressManager: ProgressManager
+
+	public convenience init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType, dbPath: URL, delegate: LocalURLProviderType) {
+		self.init(domain: domain,
+		          notificator: notificator,
+		          dbPath: dbPath,
+		          delegate: delegate,
+		          adapterManager: FileProviderAdapterManager.shared)
+	}
+
+	init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType, dbPath: URL, delegate: LocalURLProviderType, adapterManager: FileProviderAdapterProviding = FileProviderAdapterManager.shared, progressManager: ProgressManager = InMemoryProgressManager.shared) {
+		self.domain = domain
+		self.notificator = notificator
+		self.dbPath = dbPath
+		self.localURLProvider = delegate
+		self.adapterManager = adapterManager
+		self.progressManager = progressManager
+		super.init(serviceName: .uploadRetryingService, exportedInterface: NSXPCInterface(with: UploadRetrying.self))
+	}
+
+	public func retryUpload(for itemIdentifiers: [NSFileProviderItemIdentifier], reply: @escaping (Error?) -> Void) {
+		let adapter: FileProviderAdapterType
+		do {
+			adapter = try adapterManager.getAdapter(forDomain: domain,
+			                                        dbPath: dbPath,
+			                                        delegate: localURLProvider,
+			                                        notificator: notificator)
+		} catch {
+			reply(error)
+			return
+		}
+		for itemIdentifier in itemIdentifiers {
+			adapter.retryUpload(for: itemIdentifier)
+		}
+		reply(nil)
+	}
+
+	public func getCurrentFractionalUploadProgress(for itemIdentifier: NSFileProviderItemIdentifier, reply: @escaping (NSNumber?) -> Void) {
+		let progress = progressManager.getProgress(for: itemIdentifier)
+		reply(progress?.fractionCompleted as NSNumber?)
+	}
+}

--- a/CryptomatorFileProvider/Workflow/WorkflowFactory.swift
+++ b/CryptomatorFileProvider/Workflow/WorkflowFactory.swift
@@ -7,6 +7,7 @@
 //
 
 import CryptomatorCloudAccessCore
+import FileProvider
 import Foundation
 
 struct WorkflowFactory {
@@ -19,6 +20,7 @@ struct WorkflowFactory {
 	let itemEnumerationTaskManager: ItemEnumerationTaskManager
 	let downloadTaskManager: DownloadTaskManager
 	let dependencyFactory = WorkflowDependencyFactory()
+	let domainIdentifier: NSFileProviderDomainIdentifier
 
 	func createWorkflow(for deletionTask: DeletionTask) -> Workflow<Void> {
 		let taskExecutor = DeletionTaskExecutor(provider: provider, itemMetadataManager: itemMetadataManager)
@@ -33,7 +35,7 @@ struct WorkflowFactory {
 
 	func createWorkflow(for uploadTask: UploadTask) -> Workflow<FileProviderItem> {
 		let onlineItemNameCollisionHandler = OnlineItemNameCollisionHandler<FileProviderItem>(itemMetadataManager: itemMetadataManager)
-		let taskExecutor = UploadTaskExecutor(provider: provider, cachedFileManager: cachedFileManager, itemMetadataManager: itemMetadataManager, uploadTaskManager: uploadTaskManager)
+		let taskExecutor = UploadTaskExecutor(domainIdentifier: domainIdentifier, provider: provider, cachedFileManager: cachedFileManager, itemMetadataManager: itemMetadataManager, uploadTaskManager: uploadTaskManager)
 		let errorMapper = ErrorMapper<FileProviderItem>()
 
 		errorMapper.setNext(onlineItemNameCollisionHandler.eraseToAnyWorkflowMiddleware())
@@ -45,7 +47,7 @@ struct WorkflowFactory {
 	}
 
 	func createWorkflow(for downloadTask: DownloadTask) -> Workflow<FileProviderItem> {
-		let taskExecutor = DownloadTaskExecutor(provider: provider, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager, downloadTaskManager: downloadTaskManager)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: domainIdentifier, provider: provider, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager, downloadTaskManager: downloadTaskManager)
 		let errorMapper = ErrorMapper<FileProviderItem>()
 
 		errorMapper.setNext(taskExecutor.eraseToAnyWorkflowMiddleware())
@@ -57,7 +59,7 @@ struct WorkflowFactory {
 
 	func createWorkflow(for reparentTask: ReparentTask) -> Workflow<FileProviderItem> {
 		let onlineItemNameCollisionHandler = OnlineItemNameCollisionHandler<FileProviderItem>(itemMetadataManager: itemMetadataManager)
-		let taskExecutor = ReparentTaskExecutor(provider: provider, reparentTaskManager: reparentTaskManager, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager)
+		let taskExecutor = ReparentTaskExecutor(domainIdentifier: domainIdentifier, provider: provider, reparentTaskManager: reparentTaskManager, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager)
 		let errorMapper = ErrorMapper<FileProviderItem>()
 
 		errorMapper.setNext(onlineItemNameCollisionHandler.eraseToAnyWorkflowMiddleware())
@@ -72,7 +74,7 @@ struct WorkflowFactory {
 
 	func createWorkflow(for itemEnumerationTask: ItemEnumerationTask) -> Workflow<FileProviderItemList> {
 		let deleteItemHelper = DeleteItemHelper(itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager)
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: provider, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager, uploadTaskManager: uploadTaskManager, reparentTaskManager: reparentTaskManager, deletionTaskManager: deletionTaskManager, itemEnumerationTaskManager: itemEnumerationTaskManager, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: domainIdentifier, provider: provider, itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager, uploadTaskManager: uploadTaskManager, reparentTaskManager: reparentTaskManager, deletionTaskManager: deletionTaskManager, itemEnumerationTaskManager: itemEnumerationTaskManager, deleteItemHelper: deleteItemHelper)
 		let errorMapper = ErrorMapper<FileProviderItemList>()
 
 		errorMapper.setNext(taskExecutor.eraseToAnyWorkflowMiddleware())
@@ -85,7 +87,7 @@ struct WorkflowFactory {
 
 	func createWorkflow(for folderCreationTask: FolderCreationTask) -> Workflow<FileProviderItem> {
 		let onlineItemNameCollisionHandler = OnlineItemNameCollisionHandler<FileProviderItem>(itemMetadataManager: itemMetadataManager)
-		let taskExecutor = FolderCreationTaskExecutor(provider: provider, itemMetadataManager: itemMetadataManager)
+		let taskExecutor = FolderCreationTaskExecutor(domainIdentifier: domainIdentifier, provider: provider, itemMetadataManager: itemMetadataManager)
 		let errorMapper = ErrorMapper<FileProviderItem>()
 		errorMapper.setNext(onlineItemNameCollisionHandler.eraseToAnyWorkflowMiddleware())
 		onlineItemNameCollisionHandler.setNext(taskExecutor.eraseToAnyWorkflowMiddleware())

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterCreateDirectoryTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterCreateDirectoryTests.swift
@@ -15,7 +15,7 @@ class FileProviderAdapterCreateDirectoryTests: FileProviderAdapterTestCase {
 		let expectation = XCTestExpectation()
 		let rootItemMetadata = ItemMetadata(id: metadataManagerMock.getRootContainerID(), name: "Home", type: .folder, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(rootItemMetadata)
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
+		let adapter = FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
 		adapter.createDirectory(withName: "TestFolder", inParentItemIdentifier: .rootContainer) { item, error in
 			XCTAssertNil(error)
 			guard let fileProviderItem = item as? FileProviderItem else {
@@ -40,8 +40,8 @@ class FileProviderAdapterCreateDirectoryTests: FileProviderAdapterTestCase {
 
 	func testCreateDirectoryFailsIfParentDoesNotExist() throws {
 		let expectation = XCTestExpectation()
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: LocalURLProviderMock())
-		adapter.createDirectory(withName: "TestFolder", inParentItemIdentifier: NSFileProviderItemIdentifier("2")) { item, error in
+		let adapter = FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: LocalURLProviderMock())
+		adapter.createDirectory(withName: "TestFolder", inParentItemIdentifier: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)) { item, error in
 			XCTAssertNil(item)
 			guard let error = error else {
 				XCTFail("Error is nil")
@@ -79,7 +79,7 @@ class FileProviderAdapterCreateDirectoryTests: FileProviderAdapterTestCase {
 	}
 
 	func testCreatePlaceholderItemForFolderFailsIfParentDoesNotExist() throws {
-		XCTAssertThrowsError(try adapter.createPlaceholderItemForFolder(withName: "TestFolder", in: NSFileProviderItemIdentifier("2"))) { error in
+		XCTAssertThrowsError(try adapter.createPlaceholderItemForFolder(withName: "TestFolder", in: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2))) { error in
 			guard case FileProviderAdapterError.parentFolderNotFound = error else {
 				XCTFail("Throws the wrong error: \(error)")
 				return

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterDeleteItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterDeleteItemTests.swift
@@ -18,7 +18,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let itemMetadata = ItemMetadata(id: itemID, name: "test.txt", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(itemMetadata)
 		let adapter = createFullyMockedAdapter()
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
 		adapter.deleteItem(withIdentifier: itemIdentifier) { error in
 			XCTAssertNil(error)
 
@@ -44,8 +44,8 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let fileItemMetadata = ItemMetadata(id: fileItemID, name: "test.txt", type: .file, size: nil, parentID: folderItemID, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata([folderItemMetadata, fileItemMetadata])
 
-		let folderItemIdentifier = NSFileProviderItemIdentifier(rawValue: String(folderItemID))
-		let fileItemIdentifier = NSFileProviderItemIdentifier(rawValue: String(fileItemID))
+		let folderItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: folderItemID)
+		let fileItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: fileItemID)
 		let localURLForItem = tmpDirectory.appendingPathComponent("/\(fileItemIdentifier)/test.txt")
 		try cachedFileManagerMock.cacheLocalFileInfo(for: fileItemID, localURL: localURLForItem, lastModifiedDate: Date(timeIntervalSinceReferenceDate: 0))
 
@@ -72,7 +72,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 		let itemMetadata = ItemMetadata(id: itemID, name: "test.txt", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(itemMetadata)
 		let adapter = createFullyMockedAdapter()
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
 
 		let localURLForItem = tmpDirectory.appendingPathComponent("/\(itemIdentifier)/test.txt")
 		try cachedFileManagerMock.cacheLocalFileInfo(for: itemID, localURL: localURLForItem, lastModifiedDate: Date(timeIntervalSinceReferenceDate: 0))
@@ -98,7 +98,7 @@ class FileProviderAdapterDeleteItemTests: FileProviderAdapterTestCase {
 	func testDeleteItemWithNonExistentFile() throws {
 		let expectation = XCTestExpectation()
 		let itemID: Int64 = 2
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
 
 		let adapter = createFullyMockedAdapter()
 

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
@@ -18,6 +18,14 @@ class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 		}
 	}
 
+	// MARK: Error Handling
+
+	func testEnumerateItemsFailedWithNoInternetConnection() throws {
+		let metadata = ItemMetadata(id: 2, name: "noInternetConnection", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/noInternetConnection"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: Data())
+		try metadataManagerMock.cacheMetadata(metadata)
+		XCTAssertRejects(adapter.enumerateItems(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), withPageToken: nil), with: NSFileProviderError(.serverUnreachable))
+	}
+
 	// MARK: Enumerate Working Set
 
 	func testWorkingSet() {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
@@ -28,7 +28,7 @@ class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 		metadataManagerMock.workingSetMetadata = mockMetadata
 		let expectation = XCTestExpectation()
 		adapter.enumerateItems(for: .workingSet, withPageToken: nil).then { itemList in
-			XCTAssertEqual(mockMetadata.map { FileProviderItem(metadata: $0) }, itemList.items)
+			XCTAssertEqual(mockMetadata.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }, itemList.items)
 			XCTAssertNil(itemList.nextPageToken)
 		}.catch { error in
 			XCTFail("Error in promise: \(error)")

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterGetItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterGetItemTests.swift
@@ -12,7 +12,7 @@ import XCTest
 
 class FileProviderAdapterGetItemTests: FileProviderAdapterTestCase {
 	func testGetFileProviderItemThrowsForNonExistentItem() throws {
-		XCTAssertThrowsError(try adapter.item(for: NSFileProviderItemIdentifier("2")), "Did not throw for non existent Item") { error in
+		XCTAssertThrowsError(try adapter.item(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)), "Did not throw for non existent Item") { error in
 			guard let fileProviderError = error as? NSFileProviderError else {
 				XCTFail("Throws the wrong error: \(error)")
 				return
@@ -29,7 +29,7 @@ class FileProviderAdapterGetItemTests: FileProviderAdapterTestCase {
 		let itemMetadata = ItemMetadata(id: id, name: "TestItem", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestItem"), isPlaceholderItem: false)
 		metadataManagerMock.cachedMetadata[id] = itemMetadata
 
-		let item = try adapter.item(for: NSFileProviderItemIdentifier(String(id)))
+		let item = try adapter.item(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: id))
 		guard let fileProviderItem = item as? FileProviderItem else {
 			XCTFail("Item is not a FileProviderItem")
 			return
@@ -49,7 +49,7 @@ class FileProviderAdapterGetItemTests: FileProviderAdapterTestCase {
 			}
 			return uploadTask
 		}
-		let item = try adapter.item(for: NSFileProviderItemIdentifier(String(id)))
+		let item = try adapter.item(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: id))
 		guard let fileProviderItem = item as? FileProviderItem else {
 			XCTFail("Item is not a FileProviderItem")
 			return

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDirectoryTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDirectoryTests.swift
@@ -27,7 +27,7 @@ class FileProviderAdapterImportDirectoryTests: FileProviderAdapterTestCase {
 		metadataManagerMock.cachedMetadata[1] = ItemMetadata(item: .init(name: "/", cloudPath: CloudPath("/"), itemType: .folder, lastModifiedDate: nil, size: nil), withParentID: 1)
 		let provider = CloudProviderGraphMock()
 		let scheduler = WorkflowSchedulerMock(maxParallelUploads: 2, maxParallelDownloads: 2)
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: scheduler, provider: provider, localURLProvider: localURLProviderMock)
+		let adapter = FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: scheduler, provider: provider, localURLProvider: localURLProviderMock)
 		var parentIdentifier: NSFileProviderItemIdentifier = .rootContainer
 
 		for _ in 0 ..< 5 {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
@@ -219,9 +219,9 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 		let fileContent = "TestContent"
 		try fileContent.write(to: fileURL, atomically: true, encoding: .utf8)
 
-		let adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
+		let adapter = FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
 
-		adapter.deleteItem(withIdentifier: NSFileProviderItemIdentifier("\(itemID)"), completionHandler: ({ error in
+		adapter.deleteItem(withIdentifier: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID), completionHandler: ({ error in
 			XCTAssertNil(error)
 			adapter.importDocument(at: fileURL, toParentItemIdentifier: .rootContainer, completionHandler: ({ item, error in
 				XCTAssertNil(error)
@@ -265,13 +265,13 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 	}
 
 	private func assertLocalURLProviderCalledWithItemID() {
-		XCTAssertEqual([NSFileProviderItemIdentifier("\(itemID)")], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
+		XCTAssertEqual([NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
 	}
 
 	private func assertAllExpectedPropertiesSet(for item: NSFileProviderItem) throws {
 		let resourceValues = try expectedFileURL.resourceValues(forKeys: [.creationDateKey, .nameKey, .contentModificationDateKey, .typeIdentifierKey, .totalFileSizeKey])
 
-		XCTAssertEqual(NSFileProviderItemIdentifier("\(itemID)"), item.itemIdentifier)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID), item.itemIdentifier)
 		XCTAssertEqual(.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual(resourceValues.name, item.filename)
 		XCTAssertEqual(resourceValues.contentModificationDate, item.contentModificationDate)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
@@ -28,8 +28,8 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		let newParentItemMetadata = ItemMetadata(id: parentItemID, name: "Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: targetParentCloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata([itemMetadata, newParentItemMetadata])
 
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
-		let parentItemIdentifier = NSFileProviderItemIdentifier(rawValue: String(parentItemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
+		let parentItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: parentItemID)
 		let newName = "RenamedTest.txt"
 		let result = try adapter.moveItemLocally(withIdentifier: itemIdentifier, toParentItemWithIdentifier: parentItemIdentifier, newName: newName)
 		let item = result.item
@@ -64,7 +64,7 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		let itemID: Int64 = 2
 		let itemMetadata = ItemMetadata(id: itemID, name: "Test.txt", type: .file, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: sourceCloudPath, isPlaceholderItem: false)
 		metadataManagerMock.cachedMetadata[itemID] = itemMetadata
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemMetadata.id!))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: try XCTUnwrap(itemMetadata.id))
 		let newName = "RenamedTest.txt"
 		let result = try adapter.moveItemLocally(withIdentifier: itemIdentifier, toParentItemWithIdentifier: nil, newName: newName)
 		let item = result.item
@@ -102,8 +102,8 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		let newParentItemMetadata = ItemMetadata(id: parentItemID, name: "Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: targetParentCloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata([itemMetadata, newParentItemMetadata])
 
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemMetadata.id!))
-		let parentItemIdentifier = NSFileProviderItemIdentifier(rawValue: String(newParentItemMetadata.id!))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
+		let parentItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: parentItemID)
 		let result = try adapter.moveItemLocally(withIdentifier: itemIdentifier, toParentItemWithIdentifier: parentItemIdentifier, newName: nil)
 		let item = result.item
 		XCTAssertEqual("Test.txt", item.filename)
@@ -140,7 +140,7 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		let itemMetadata = ItemMetadata(id: itemID, name: "Test.txt", type: .file, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: sourceCloudPath, isPlaceholderItem: false)
 		metadataManagerMock.cachedMetadata[itemID] = itemMetadata
 		let newName = "RenamedTest.txt"
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
 		adapter.renameItem(withIdentifier: itemIdentifier, toName: newName) { item, error in
 			XCTAssertNil(error)
 			guard let fileProviderItem = item as? FileProviderItem else {
@@ -190,8 +190,8 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		let newParentItemMetadata = ItemMetadata(id: parentItemID, name: "Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: targetParentCloudPath, isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata([itemMetadata, newParentItemMetadata])
 
-		let itemIdentifier = NSFileProviderItemIdentifier(rawValue: String(itemID))
-		let parentItemIdentifier = NSFileProviderItemIdentifier(rawValue: String(parentItemID))
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)
+		let parentItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: parentItemID)
 		adapter.reparentItem(withIdentifier: itemIdentifier, toParentItemWithIdentifier: parentItemIdentifier, newName: nil) { item, error in
 			XCTAssertNil(error)
 			guard let fileProviderItem = item as? FileProviderItem else {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetFavoriteRankTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetFavoriteRankTests.swift
@@ -15,7 +15,7 @@ class FileProviderAdapterSetFavoriteRankTests: FileProviderAdapterTestCase {
 		let expectation = XCTestExpectation()
 		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
 		let favoriteRank: NSNumber = 100
-		let itemIdentifier = NSFileProviderItemIdentifier("2")
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
 		adapter.setFavoriteRank(favoriteRank, forItemIdentifier: itemIdentifier) { item, error in
 			XCTAssertNil(error)
 			XCTAssertEqual(favoriteRank, item?.favoriteRank)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetTagDataTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterSetTagDataTests.swift
@@ -12,11 +12,12 @@ import XCTest
 @testable import CryptomatorFileProvider
 
 class FileProviderAdapterSetTagDataTests: FileProviderAdapterTestCase {
+	let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
 	func testSetTagData() throws {
 		let expectation = XCTestExpectation()
 		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .file, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
 		let tagData = "Foo".data(using: .utf8)!
-		let itemIdentifier = NSFileProviderItemIdentifier("2")
+
 		adapter.setTagData(tagData, forItemIdentifier: itemIdentifier) { item, error in
 			XCTAssertNil(error)
 			XCTAssertEqual(tagData, item?.tagData)
@@ -30,7 +31,6 @@ class FileProviderAdapterSetTagDataTests: FileProviderAdapterTestCase {
 		let expectation = XCTestExpectation()
 		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "Test", type: .file, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false, isCandidateForCacheCleanup: false, favoriteRank: nil, tagData: nil)
 		let emptyTagData = Data()
-		let itemIdentifier = NSFileProviderItemIdentifier("2")
 		adapter.setTagData(emptyTagData, forItemIdentifier: itemIdentifier) { item, error in
 			XCTAssertNil(error)
 			guard let item = item else {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingItemTests.swift
@@ -108,7 +108,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 		}
 		wait(for: [expectation], timeout: 1.0)
 		assertItemRemovedFromWorkingSet()
-		XCTAssertEqual([NSFileProviderItemIdentifier("3")], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
+		XCTAssertEqual([NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 3)], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
 	}
 
 	func testStartProvidingItemWithTagData() throws {
@@ -149,7 +149,7 @@ class FileProviderAdapterStartProvidingItemTests: FileProviderAdapterTestCase {
 	}
 
 	private func assertItemRemovedFromWorkingSet() {
-		XCTAssertEqual([String(itemID)], fileProviderItemUpdateDelegateMock.removeItemFromWorkingSetWithReceivedInvocations.map { $0.rawValue })
+		XCTAssertEqual(["\(NSFileProviderDomainIdentifier.test.rawValue):\(itemID)"], fileProviderItemUpdateDelegateMock.removeItemFromWorkingSetWithReceivedInvocations.map { $0.rawValue })
 	}
 
 	private func simulateExistingLocalFileByDownloadingFile() {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -21,10 +21,12 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	override func setUpWithError() throws {
 		try super.setUpWithError()
 		localURLProviderMock = LocalURLProviderMock()
+		localURLProviderMock.domainIdentifier = .test
 		fileProviderItemUpdateDelegateMock = FileProviderItemUpdateDelegateMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
-		adapter = FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock,
+		adapter = FileProviderAdapter(domainIdentifier: .test,
+		                              uploadTaskManager: uploadTaskManagerMock,
 		                              cachedFileManager: cachedFileManagerMock,
 		                              itemMetadataManager: metadataManagerMock,
 		                              reparentTaskManager: reparentTaskManagerMock,
@@ -57,7 +59,7 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	}
 
 	func createFullyMockedAdapter() -> FileProviderAdapter {
-		return FileProviderAdapter(uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
+		return FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, localURLProvider: localURLProviderMock)
 	}
 }
 
@@ -65,4 +67,8 @@ extension UploadTaskRecord: Equatable {
 	public static func == (lhs: UploadTaskRecord, rhs: UploadTaskRecord) -> Bool {
 		lhs.correspondingItem == rhs.correspondingItem && lhs.lastFailedUploadDate == rhs.lastFailedUploadDate && lhs.uploadErrorCode == rhs.uploadErrorCode && lhs.uploadErrorDomain == rhs.uploadErrorDomain
 	}
+}
+
+extension NSFileProviderDomainIdentifier {
+	static let test = NSFileProviderDomainIdentifier("Test")
 }

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -23,8 +23,8 @@ class FileProviderEnumeratorTestCase: XCTestCase {
 	let dbPath = FileManager.default.temporaryDirectory
 	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
 	let items: [FileProviderItem] = [
-		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false)),
-		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false))
+		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false), domainIdentifier: .test),
+		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false), domainIdentifier: .test)
 	]
 	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
 

--- a/CryptomatorFileProviderTests/FileProviderItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderItemTests.swift
@@ -16,7 +16,7 @@ class FileProviderItemTests: XCTestCase {
 	func testRootItem() {
 		let cloudPath = CloudPath("/")
 		let metadata = ItemMetadata(id: ItemMetadataDBManager.rootContainerId, name: "root", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual("public.folder", item.typeIdentifier)
@@ -25,8 +25,8 @@ class FileProviderItemTests: XCTestCase {
 	func testFileItem() {
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata)
-		XCTAssertEqual(NSFileProviderItemIdentifier("2"), item.itemIdentifier)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), item.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual("test.txt", item.filename)
 		XCTAssertEqual(100, item.documentSize)
@@ -40,8 +40,8 @@ class FileProviderItemTests: XCTestCase {
 	func testFolderItem() {
 		let cloudPath = CloudPath("/test Folder/")
 		let metadata = ItemMetadata(id: 2, name: "test Folder", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata)
-		XCTAssertEqual(NSFileProviderItemIdentifier("2"), item.itemIdentifier)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), item.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual("test Folder", item.filename)
 		XCTAssertNil(item.documentSize)
@@ -57,8 +57,8 @@ class FileProviderItemTests: XCTestCase {
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
 		let lastFailedUploadDate = Date(timeIntervalSinceReferenceDate: 0)
 		let failedUploadTask = UploadTaskRecord(correspondingItem: 2, lastFailedUploadDate: lastFailedUploadDate, uploadErrorCode: NSFileProviderError.insufficientQuota.rawValue, uploadErrorDomain: NSFileProviderErrorDomain)
-		let item = FileProviderItem(metadata: metadata, error: failedUploadTask.failedWithError)
-		XCTAssertEqual(NSFileProviderItemIdentifier("2"), item.itemIdentifier)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, error: failedUploadTask.failedWithError)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), item.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual("test.txt", item.filename)
 		XCTAssertEqual(100, item.documentSize)
@@ -80,8 +80,8 @@ class FileProviderItemTests: XCTestCase {
 		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: false)
 		let localURL = tmpDir.appendingPathComponent("test.txt")
 
-		let item = FileProviderItem(metadata: metadata, newestVersionLocallyCached: false, localURL: localURL)
-		XCTAssertEqual(NSFileProviderItemIdentifier("2"), item.itemIdentifier)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, newestVersionLocallyCached: false, localURL: localURL)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), item.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, item.parentItemIdentifier)
 		XCTAssertEqual("test.txt", item.filename)
 		XCTAssertEqual(100, item.documentSize)
@@ -93,8 +93,8 @@ class FileProviderItemTests: XCTestCase {
 
 		try "Foo".write(to: localURL, atomically: true, encoding: .utf8)
 
-		let newestItem = FileProviderItem(metadata: metadata, newestVersionLocallyCached: false, localURL: localURL)
-		XCTAssertEqual(NSFileProviderItemIdentifier("2"), newestItem.itemIdentifier)
+		let newestItem = FileProviderItem(metadata: metadata, domainIdentifier: .test, newestVersionLocallyCached: false, localURL: localURL)
+		XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), newestItem.itemIdentifier)
 		XCTAssertEqual(NSFileProviderItemIdentifier.rootContainer, newestItem.parentItemIdentifier)
 		XCTAssertEqual("test.txt", newestItem.filename)
 		XCTAssertEqual(100, newestItem.documentSize)
@@ -113,7 +113,7 @@ class FileProviderItemTests: XCTestCase {
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, item.capabilities)
 	}
 
@@ -123,7 +123,7 @@ class FileProviderItemTests: XCTestCase {
 
 		let cloudPath = CloudPath("/test")
 		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
 		XCTAssertEqual([.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], item.capabilities)
 	}
 
@@ -133,7 +133,7 @@ class FileProviderItemTests: XCTestCase {
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, item.capabilities)
 	}
 
@@ -143,7 +143,7 @@ class FileProviderItemTests: XCTestCase {
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, item.capabilities)
 	}
 
@@ -153,7 +153,7 @@ class FileProviderItemTests: XCTestCase {
 
 		let cloudPath = CloudPath("/test")
 		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: 100, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, item.capabilities)
 	}
 }

--- a/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
@@ -14,11 +14,11 @@ import XCTest
 class FileProviderNotificatorTests: XCTestCase {
 	var notificator: FileProviderNotificator!
 	var enumerationSignalingMock: EnumerationSignalingMock!
-	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
+	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: $0) }
 	let updatedMetadataIDs: [Int64] = [2, 3, 4]
-	lazy var updatedItemIdentifiers = updatedMetadataIDs.map { NSFileProviderItemIdentifier("\($0)") }
+	lazy var updatedItemIdentifiers = updatedMetadataIDs.map { NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: $0) }
 	lazy var updatedItems: [FileProviderItem] = updatedMetadataIDs.map {
-		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false))
+		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false), domainIdentifier: .test)
 	}
 
 	override func setUpWithError() throws {
@@ -48,7 +48,7 @@ class FileProviderNotificatorTests: XCTestCase {
 		notificator.removeItemsFromWorkingSet(with: deleteItemIdentifiers)
 		notificator.updateWorkingSetItems(updatedItems)
 
-		XCTAssertEqual([NSFileProviderItemIdentifier("1")], getSortedItemIdentifiersToDeleteFromWorkingSet())
+		XCTAssertEqual([NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 1)], getSortedItemIdentifiersToDeleteFromWorkingSet())
 		assertUpdateWorkingSetHasUpdatedItems()
 		XCTAssertFalse(enumerationSignalingMock.signalEnumeratorForCompletionHandlerCalled)
 	}

--- a/CryptomatorFileProviderTests/InMemoryProgressManagerTests.swift
+++ b/CryptomatorFileProviderTests/InMemoryProgressManagerTests.swift
@@ -1,0 +1,46 @@
+//
+//  InMemoryProgressManagerTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 09.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import CryptomatorFileProvider
+
+class InMemoryProgressManagerTests: XCTestCase {
+	var progressManager: InMemoryProgressManager!
+
+	override func setUpWithError() throws {
+		progressManager = InMemoryProgressManager()
+	}
+
+	func testSaveProgress() {
+		let progress = Progress(totalUnitCount: 10)
+		let firstItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
+		progressManager.saveProgress(progress, for: firstItemIdentifier)
+
+		let secondProgress = Progress(totalUnitCount: 20)
+		let secondItemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 3)
+		progressManager.saveProgress(secondProgress, for: secondItemIdentifier)
+
+		XCTAssertEqual(progress, progressManager.getProgress(for: firstItemIdentifier))
+		XCTAssertEqual(secondProgress, progressManager.getProgress(for: secondItemIdentifier))
+	}
+
+	func testSaveProgressOverwritesExisting() {
+		let progress = Progress(totalUnitCount: 10)
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
+		progressManager.saveProgress(progress, for: itemIdentifier)
+
+		let secondProgress = Progress(totalUnitCount: 20)
+		progressManager.saveProgress(secondProgress, for: itemIdentifier)
+		XCTAssertEqual(secondProgress, progressManager.getProgress(for: itemIdentifier))
+	}
+
+	func testGetMissingProgress() {
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
+		XCTAssertNil(progressManager.getProgress(for: itemIdentifier))
+	}
+}

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/DownloadTaskExecutorTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/DownloadTaskExecutorTests.swift
@@ -24,7 +24,7 @@ class DownloadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let downloadTaskRecord = DownloadTaskRecord(correspondingItem: itemMetadata.id!, replaceExisting: false, localURL: localURL)
 		let downloadTask = DownloadTask(taskRecord: downloadTaskRecord, itemMetadata: itemMetadata)
 
-		let taskExecutor = DownloadTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
 
 		taskExecutor.execute(task: downloadTask).then { _ in
 			let localContent = try Data(contentsOf: localURL)
@@ -63,7 +63,7 @@ class DownloadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let downloadTaskRecord = DownloadTaskRecord(correspondingItem: itemMetadata.id!, replaceExisting: false, localURL: localURL)
 		let downloadTask = DownloadTask(taskRecord: downloadTaskRecord, itemMetadata: itemMetadata)
 
-		let taskExecutor = DownloadTaskExecutor(provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
 
 		taskExecutor.execute(task: downloadTask).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")
@@ -94,7 +94,7 @@ class DownloadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let downloadTaskRecord = DownloadTaskRecord(correspondingItem: itemMetadata.id!, replaceExisting: true, localURL: localURL)
 		let downloadTask = DownloadTask(taskRecord: downloadTaskRecord, itemMetadata: itemMetadata)
 
-		let taskExecutor = DownloadTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
 
 		taskExecutor.execute(task: downloadTask).then { _ in
 			let localContent = try Data(contentsOf: localURL)
@@ -133,7 +133,7 @@ class DownloadTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let lastModifiedDate = Date(timeIntervalSince1970: 0)
 
-		let taskExecutor = DownloadTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
 
 		let item = try taskExecutor.downloadPostProcessing(for: itemMetadata, lastModifiedDate: lastModifiedDate, localURL: localURL, downloadDestination: downloadDestination)
 		XCTAssert(FileManager.default.fileExists(atPath: localURL.path))
@@ -163,7 +163,7 @@ class DownloadTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let lastModifiedDate = Date(timeIntervalSince1970: 0)
 
-		let taskExecutor = DownloadTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
+		let taskExecutor = DownloadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, downloadTaskManager: downloadTaskManagerMock)
 
 		let item = try taskExecutor.downloadPostProcessing(for: itemMetadata, lastModifiedDate: lastModifiedDate, localURL: localURL, downloadDestination: localURL)
 		XCTAssert(FileManager.default.fileExists(atPath: localURL.path))

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/FolderCreationTaskExecutorTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/FolderCreationTaskExecutorTests.swift
@@ -19,7 +19,7 @@ class FolderCreationTaskExecutorTests: CloudTaskExecutorTestCase {
 		let itemMetadata = ItemMetadata(id: 2, name: "NewFolder", type: .folder, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true, isCandidateForCacheCleanup: false)
 
 		let task = FolderCreationTask(itemMetadata: itemMetadata)
-		let taskExecutor = FolderCreationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock)
+		let taskExecutor = FolderCreationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock)
 		taskExecutor.execute(task: task).then { item in
 			XCTAssertEqual(1, self.metadataManagerMock.updatedMetadata.count)
 			XCTAssertEqual(itemMetadata, self.metadataManagerMock.updatedMetadata[0])
@@ -47,7 +47,7 @@ class FolderCreationTaskExecutorTests: CloudTaskExecutorTestCase {
 		}
 
 		let task = FolderCreationTask(itemMetadata: itemMetadata)
-		let taskExecutor = FolderCreationTaskExecutor(provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock)
+		let taskExecutor = FolderCreationTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock)
 		taskExecutor.execute(task: task).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")
 		}.catch { error in

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
@@ -30,7 +30,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: fileMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: fileMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { itemList in
 			XCTAssertEqual(1, itemList.items.count)
@@ -81,7 +81,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: fileMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: fileMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { itemList in
 			XCTAssertEqual(1, itemList.items.count)
@@ -127,7 +127,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: fileMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: fileMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { itemList in
 			XCTAssertEqual(1, itemList.items.count)
@@ -182,7 +182,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			Promise(CloudTaskTestError.correctPassthrough)
 		}
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")
@@ -218,12 +218,12 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		                                            ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false),
 		                                            ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false)]
 
-		let expectedRootFolderFileProviderItems = expectedItemMetadataInsideRootFolder.map { FileProviderItem(metadata: $0) }
+		let expectedRootFolderFileProviderItems = expectedItemMetadataInsideRootFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
 		let expectedItemMetadataInsideSubFolder = [ItemMetadata(id: 7, name: "Directory 2", type: .folder, size: 0, parentID: 2, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/Directory 2"), isPlaceholderItem: false),
 		                                           ItemMetadata(id: 8, name: "File 5", type: .file, size: 14, parentID: 2, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/File 5"), isPlaceholderItem: false)]
-		let expectedSubFolderFileProviderItems = expectedItemMetadataInsideSubFolder.map { FileProviderItem(metadata: $0) }
+		let expectedSubFolderFileProviderItems = expectedItemMetadataInsideSubFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> FileProviderItem in
 			XCTAssertEqual(5, fileProviderItemList.items.count)
@@ -274,18 +274,18 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let expectedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false)),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 3, name: "File 1", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 1"), isPlaceholderItem: false)),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false)),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false)),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false))]
-		let expectedChangedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false)),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false)),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false)),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false)),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false))]
+		let expectedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                           FileProviderItem(metadata: ItemMetadata(id: 3, name: "File 1", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 1"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                           FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                           FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test)]
+		let expectedChangedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                                  FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                                  FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test),
+		                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false), domainIdentifier: .test)]
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
 			XCTAssertEqual(5, fileProviderItemList.items.count)
@@ -318,7 +318,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		let lastFailedUploadDate = Date()
 		taskExecutor.execute(task: enumerationTask).then { _ -> Void in
@@ -369,7 +369,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: paginatedMockedProvider, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: paginatedMockedProvider, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 		let id: Int64 = 2
 		let itemMetadata = ItemMetadata(id: 2, name: "TestItem", type: .file, size: nil, parentID: ItemMetadataDBManager.rootContainerId, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestItem"), isPlaceholderItem: false)
 		metadataManagerMock.cachedMetadata[itemMetadata.id!] = itemMetadata
@@ -405,7 +405,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: paginatedMockedProvider, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: paginatedMockedProvider, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
 			XCTAssertEqual(2, fileProviderItemList.items.count)
@@ -453,7 +453,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		let newCloudPath = CloudPath("/RenamedItem")
 		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
@@ -499,7 +499,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
 			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
@@ -545,7 +545,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			Promise(CloudTaskTestError.correctPassthrough)
 		}
 
-		let taskExecutor = ItemEnumerationTaskExecutor(provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
+		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
 		taskExecutor.execute(task: enumerationTask).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ReparentTaskExecutorTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ReparentTaskExecutorTests.swift
@@ -22,7 +22,7 @@ class ReparentTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let reparentTaskRecord = ReparentTaskRecord(correspondingItem: itemMetadata.id!, sourceCloudPath: sourceCloudPath, targetCloudPath: targetCloudPath, oldParentID: itemMetadata.parentID, newParentID: itemMetadata.parentID)
 		let reparentTask = ReparentTask(taskRecord: reparentTaskRecord, itemMetadata: itemMetadata)
-		let taskExecutor = ReparentTaskExecutor(provider: cloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
+		let taskExecutor = ReparentTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
 
 		taskExecutor.execute(task: reparentTask).then { item in
 			XCTAssertEqual(.rootContainer, item.parentItemIdentifier)
@@ -54,7 +54,7 @@ class ReparentTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let reparentTaskRecord = ReparentTaskRecord(correspondingItem: itemMetadata.id!, sourceCloudPath: sourceCloudPath, targetCloudPath: targetCloudPath, oldParentID: itemMetadata.parentID, newParentID: itemMetadata.parentID)
 		let reparentTask = ReparentTask(taskRecord: reparentTaskRecord, itemMetadata: itemMetadata)
-		let taskExecutor = ReparentTaskExecutor(provider: cloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
+		let taskExecutor = ReparentTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
 
 		taskExecutor.execute(task: reparentTask).then { item in
 			XCTAssertEqual(.rootContainer, item.parentItemIdentifier)
@@ -91,7 +91,7 @@ class ReparentTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let reparentTaskRecord = ReparentTaskRecord(correspondingItem: itemMetadata.id!, sourceCloudPath: sourceCloudPath, targetCloudPath: targetCloudPath, oldParentID: itemMetadata.parentID, newParentID: itemMetadata.parentID)
 		let reparentTask = ReparentTask(taskRecord: reparentTaskRecord, itemMetadata: itemMetadata)
-		let taskExecutor = ReparentTaskExecutor(provider: errorCloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
+		let taskExecutor = ReparentTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
 		taskExecutor.execute(task: reparentTask).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")
 		}.catch { error in
@@ -121,7 +121,7 @@ class ReparentTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let reparentTaskRecord = ReparentTaskRecord(correspondingItem: itemMetadata.id!, sourceCloudPath: sourceCloudPath, targetCloudPath: targetCloudPath, oldParentID: itemMetadata.parentID, newParentID: itemMetadata.parentID)
 		let reparentTask = ReparentTask(taskRecord: reparentTaskRecord, itemMetadata: itemMetadata)
-		let taskExecutor = ReparentTaskExecutor(provider: errorCloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
+		let taskExecutor = ReparentTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, reparentTaskManager: reparentTaskManagerMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock)
 		taskExecutor.execute(task: reparentTask).then { _ in
 			XCTFail("Promise should not fulfill if the provider fails with an error")
 		}.catch { error in

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/UploadTaskExecutorTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/UploadTaskExecutorTests.swift
@@ -21,7 +21,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let itemMetadata = ItemMetadata(id: itemID, name: "FileToBeUploaded", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true, isCandidateForCacheCleanup: false)
 		cachedFileManagerMock.cachedLocalFileInfo[itemID] = LocalCachedFileInfo(lastModifiedDate: nil, correspondingItem: itemID, localLastModifiedDate: Date(), localURL: localURL)
 
-		let uploadTaskExecutor = UploadTaskExecutor(provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
+		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
 
 		let mockedCloudDate = Date(timeIntervalSinceReferenceDate: 0)
 		cloudProviderMock.lastModifiedDate[itemMetadata.cloudPath.path] = mockedCloudDate
@@ -61,7 +61,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let mockedCloudDate = Date(timeIntervalSinceReferenceDate: 0)
 		cloudProviderMock.lastModifiedDate[itemMetadata.cloudPath.path] = mockedCloudDate
 
-		let uploadTaskExecutor = UploadTaskExecutor(provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
+		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
 
 		let uploadTaskRecord = UploadTaskRecord(correspondingItem: itemMetadata.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil)
 		let uploadTask = UploadTask(taskRecord: uploadTaskRecord, itemMetadata: itemMetadata)
@@ -92,7 +92,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let mockedCloudDate = Date(timeIntervalSinceReferenceDate: 0)
 		cloudProviderUploadInconsistencyMock.lastModifiedDate[itemMetadata.cloudPath.path] = mockedCloudDate
 
-		let uploadTaskExecutor = UploadTaskExecutor(provider: cloudProviderUploadInconsistencyMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
+		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: cloudProviderUploadInconsistencyMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
 
 		let uploadTaskRecord = UploadTaskRecord(correspondingItem: itemMetadata.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil)
 		let uploadTask = UploadTask(taskRecord: uploadTaskRecord, itemMetadata: itemMetadata)
@@ -138,7 +138,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 			Promise(CloudTaskTestError.correctPassthrough)
 		}
 
-		let uploadTaskExecutor = UploadTaskExecutor(provider: errorCloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
+		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
 
 		let uploadTaskRecord = UploadTaskRecord(correspondingItem: itemMetadata.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil)
 		let uploadTask = UploadTask(taskRecord: uploadTaskRecord, itemMetadata: itemMetadata)

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/UploadTaskExecutorTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/UploadTaskExecutorTests.swift
@@ -7,9 +7,9 @@
 //
 
 import CryptomatorCloudAccessCore
-import Promises
 import XCTest
 @testable import CryptomatorFileProvider
+@testable import Promises
 
 class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 	func testUploadFile() throws {
@@ -18,10 +18,11 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let localURL = tmpDirectory.appendingPathComponent("FileToBeUploaded", isDirectory: false)
 		try "TestContent".write(to: localURL, atomically: true, encoding: .utf8)
 		let cloudPath = CloudPath("/FileToBeUploaded")
+		let progressManagerMock = ProgressManagerMock()
 		let itemMetadata = ItemMetadata(id: itemID, name: "FileToBeUploaded", type: .file, size: nil, parentID: metadataManagerMock.getRootContainerID(), lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true, isCandidateForCacheCleanup: false)
 		cachedFileManagerMock.cachedLocalFileInfo[itemID] = LocalCachedFileInfo(lastModifiedDate: nil, correspondingItem: itemID, localLastModifiedDate: Date(), localURL: localURL)
 
-		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
+		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock, progressManager: progressManagerMock)
 
 		let mockedCloudDate = Date(timeIntervalSinceReferenceDate: 0)
 		cloudProviderMock.lastModifiedDate[itemMetadata.cloudPath.path] = mockedCloudDate
@@ -42,6 +43,10 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 
 			// Verify that the upload task has been removed
 			XCTAssertEqual([itemMetadata.id], self.uploadTaskManagerMock.removeTaskRecordForReceivedInvocations)
+
+			// Verify that the corresponding upload progress has been saved
+			XCTAssertEqual(NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID), progressManagerMock.saveProgressForReceivedArguments?.itemIdentifier)
+			XCTAssertEqual(1, progressManagerMock.saveProgressForCallsCount)
 		}
 		.catch { error in
 			XCTFail("Promise failed with error: \(error)")
@@ -124,9 +129,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		wait(for: [expectation], timeout: 1.0)
 	}
 
-	func testUploadFileFailWithSameErrorAsProvider() throws {
-		let expectation = XCTestExpectation()
-
+	func testUploadFileFailReportsUploadError() throws {
 		let localURL = tmpDirectory.appendingPathComponent("itemNotFound.txt", isDirectory: false)
 		try "".write(to: localURL, atomically: true, encoding: .utf8)
 		let cloudPath = CloudPath("/itemNotFound.txt")
@@ -135,7 +138,7 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 
 		let errorCloudProviderMock = CloudProviderErrorMock()
 		errorCloudProviderMock.uploadFileResponse = { _, _, _ in
-			Promise(CloudTaskTestError.correctPassthrough)
+			Promise(CloudProviderError.noInternetConnection)
 		}
 
 		let uploadTaskExecutor = UploadTaskExecutor(domainIdentifier: .test, provider: errorCloudProviderMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, uploadTaskManager: uploadTaskManagerMock)
@@ -143,19 +146,20 @@ class UploadTaskExecutorTests: CloudTaskExecutorTestCase {
 		let uploadTaskRecord = UploadTaskRecord(correspondingItem: itemMetadata.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil)
 		let uploadTask = UploadTask(taskRecord: uploadTaskRecord, itemMetadata: itemMetadata)
 
-		uploadTaskExecutor.execute(task: uploadTask).then { _ in
-			XCTFail("Promise should not fulfill if the provider fails with an error")
-		}.catch { error in
-			guard case CloudTaskTestError.correctPassthrough = error else {
-				XCTFail("Promise rejected but with the wrong error: \(error)")
-				return
-			}
-			XCTAssert(self.metadataManagerMock.cachedMetadata.isEmpty, "Unexpected change of cached metadata.")
-			XCTAssertFalse(self.uploadTaskManagerMock.removeTaskRecordForCalled, "Unexpected removal of the upload task")
-		}.always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 1.0)
+		let promise = uploadTaskExecutor.execute(task: uploadTask)
+		wait(for: promise)
+		let updatedItem = try XCTUnwrap(promise.value)
+		let expectedError = NSFileProviderError(.serverUnreachable)._nsError
+		XCTAssertEqual(expectedError, updatedItem.uploadingError as NSError?)
+		XCTAssertEqual(ItemStatus.uploadError, updatedItem.metadata.statusCode)
+		XCTAssertFalse(uploadTaskManagerMock.removeTaskRecordForCalled, "Unexpected removal of the upload task")
+
+		let updatedTaskRecordReceivedArguments = uploadTaskManagerMock.updateTaskRecordWithLastFailedUploadDateUploadErrorCodeUploadErrorDomainReceivedArguments
+
+		XCTAssertEqual(2, updatedTaskRecordReceivedArguments?.id)
+		XCTAssertEqual(expectedError.code, updatedTaskRecordReceivedArguments?.uploadErrorCode)
+		XCTAssertEqual(expectedError.domain, updatedTaskRecordReceivedArguments?.uploadErrorDomain)
+		XCTAssertEqual([itemMetadata], metadataManagerMock.updatedMetadata)
 	}
 
 	private class CloudProviderUploadInconsistencyMock: CustomCloudProviderMock {

--- a/CryptomatorFileProviderTests/Mocks/FileProviderAdapterTypeMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/FileProviderAdapterTypeMock.swift
@@ -263,6 +263,24 @@ final class FileProviderAdapterTypeMock: FileProviderAdapterType {
 		setTagDataForItemIdentifierCompletionHandlerReceivedInvocations.append((tagData: tagData, itemIdentifier: itemIdentifier, completionHandler: completionHandler))
 		setTagDataForItemIdentifierCompletionHandlerClosure?(tagData, itemIdentifier, completionHandler)
 	}
+
+	// MARK: - retryUpload
+
+	var retryUploadForCallsCount = 0
+	var retryUploadForCalled: Bool {
+		retryUploadForCallsCount > 0
+	}
+
+	var retryUploadForReceivedItemIdentifier: NSFileProviderItemIdentifier?
+	var retryUploadForReceivedInvocations: [NSFileProviderItemIdentifier] = []
+	var retryUploadForClosure: ((NSFileProviderItemIdentifier) -> Void)?
+
+	func retryUpload(for itemIdentifier: NSFileProviderItemIdentifier) {
+		retryUploadForCallsCount += 1
+		retryUploadForReceivedItemIdentifier = itemIdentifier
+		retryUploadForReceivedInvocations.append(itemIdentifier)
+		retryUploadForClosure?(itemIdentifier)
+	}
 }
 
 // swiftlint:enable all

--- a/CryptomatorFileProviderTests/Mocks/LocalURLProviderMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/LocalURLProviderMock.swift
@@ -12,6 +12,15 @@ import Foundation
 
 // swiftlint:disable all
 final class LocalURLProviderMock: LocalURLProviderType {
+	// MARK: - domainIdentifier
+
+	var domainIdentifier: NSFileProviderDomainIdentifier {
+		get { underlyingDomainIdentifier }
+		set(value) { underlyingDomainIdentifier = value }
+	}
+
+	private var underlyingDomainIdentifier: NSFileProviderDomainIdentifier!
+
 	// MARK: - itemIdentifierDirectoryURLForItem
 
 	var itemIdentifierDirectoryURLForItemWithPersistentIdentifierCallsCount = 0

--- a/CryptomatorFileProviderTests/Mocks/ProgressManagerMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/ProgressManagerMock.swift
@@ -1,0 +1,50 @@
+//
+//  ProgressManagerMock.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 09.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import FileProvider
+import Foundation
+@testable import CryptomatorFileProvider
+
+final class ProgressManagerMock: ProgressManager {
+	// MARK: - getProgress
+
+	var getProgressForCallsCount = 0
+	var getProgressForCalled: Bool {
+		getProgressForCallsCount > 0
+	}
+
+	var getProgressForReceivedItemIdentifier: NSFileProviderItemIdentifier?
+	var getProgressForReceivedInvocations: [NSFileProviderItemIdentifier] = []
+	var getProgressForReturnValue: Progress?
+	var getProgressForClosure: ((NSFileProviderItemIdentifier) -> Progress?)?
+
+	func getProgress(for itemIdentifier: NSFileProviderItemIdentifier) -> Progress? {
+		getProgressForCallsCount += 1
+		getProgressForReceivedItemIdentifier = itemIdentifier
+		getProgressForReceivedInvocations.append(itemIdentifier)
+		return getProgressForClosure.map({ $0(itemIdentifier) }) ?? getProgressForReturnValue
+	}
+
+	// MARK: - saveProgress
+
+	var saveProgressForCallsCount = 0
+	var saveProgressForCalled: Bool {
+		saveProgressForCallsCount > 0
+	}
+
+	var saveProgressForReceivedArguments: (progress: Progress, itemIdentifier: NSFileProviderItemIdentifier)?
+	var saveProgressForReceivedInvocations: [(progress: Progress, itemIdentifier: NSFileProviderItemIdentifier)] = []
+	var saveProgressForClosure: ((Progress, NSFileProviderItemIdentifier) -> Void)?
+
+	func saveProgress(_ progress: Progress, for itemIdentifier: NSFileProviderItemIdentifier) {
+		saveProgressForCallsCount += 1
+		saveProgressForReceivedArguments = (progress: progress, itemIdentifier: itemIdentifier)
+		saveProgressForReceivedInvocations.append((progress: progress, itemIdentifier: itemIdentifier))
+		saveProgressForClosure?(progress, itemIdentifier)
+	}
+}

--- a/CryptomatorFileProviderTests/UploadRetryingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/UploadRetryingServiceSourceTests.swift
@@ -1,0 +1,67 @@
+//
+//  UploadRetryingServiceSourceTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Philipp Schmid on 09.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import XCTest
+@testable import CryptomatorFileProvider
+
+class UploadRetryingServiceSourceTests: XCTestCase {
+	var serviceSource: UploadRetryingServiceSource!
+	var adapterProvidingMock: FileProviderAdapterProvidingMock!
+	var urlProviderMock: LocalURLProviderMock!
+	var notificatorMock: FileProviderNotificatorTypeMock!
+	var progressManagerMock: ProgressManagerMock!
+	let dbPath = FileManager.default.temporaryDirectory
+	let testDomain = NSFileProviderDomain(identifier: .test, displayName: "Test", pathRelativeToDocumentStorage: "")
+
+	override func setUpWithError() throws {
+		adapterProvidingMock = FileProviderAdapterProvidingMock()
+		urlProviderMock = LocalURLProviderMock()
+		notificatorMock = FileProviderNotificatorTypeMock()
+		progressManagerMock = ProgressManagerMock()
+
+		serviceSource = UploadRetryingServiceSource(domain: testDomain,
+		                                            notificator: notificatorMock,
+		                                            dbPath: dbPath,
+		                                            delegate: urlProviderMock,
+		                                            adapterManager: adapterProvidingMock,
+		                                            progressManager: progressManagerMock)
+	}
+
+	override func tearDownWithError() throws {
+		// Put teardown code here. This method is called after the invocation of each test method in the class.
+	}
+
+	func testRetryUpload() throws {
+		let adapterMock = FileProviderAdapterTypeMock()
+		adapterProvidingMock.getAdapterForDomainDbPathDelegateNotificatorReturnValue = adapterMock
+		let expectation = XCTestExpectation()
+		let itemIdentifiers = [NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2),
+		                       NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 3)]
+		serviceSource.retryUpload(for: itemIdentifiers) { error in
+			XCTAssertNil(error)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+
+		XCTAssertEqual(itemIdentifiers, adapterMock.retryUploadForReceivedInvocations)
+	}
+
+	func testGetCurrentFractionalUploadProgress() throws {
+		let expectation = XCTestExpectation()
+		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
+		let mockedProgress = Progress(totalUnitCount: 100)
+		mockedProgress.completedUnitCount = 42
+		progressManagerMock.getProgressForReturnValue = mockedProgress
+		serviceSource.getCurrentFractionalUploadProgress(for: itemIdentifier) { progress in
+			XCTAssertEqual(0.42, progress)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 1.0)
+		XCTAssertEqual([itemIdentifier], progressManagerMock.getProgressForReceivedInvocations)
+	}
+}

--- a/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
+++ b/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
@@ -16,12 +16,12 @@ class WorkingSetObserverTests: XCTestCase {
 	var notificatorMock: FileProviderNotificatorTypeMock!
 	let updatedMetadataIDs: [Int64] = [1, 2, 3]
 	lazy var updatedItems: [FileProviderItem] = updatedMetadataIDs.map {
-		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false))
+		FileProviderItem(metadata: ItemMetadata(id: $0, name: "\($0)", type: .file, size: nil, parentID: 0, lastModifiedDate: nil, statusCode: .isDownloading, cloudPath: CloudPath("/\($0)"), isPlaceholderItem: false), domainIdentifier: .test)
 	}
 
 	override func setUpWithError() throws {
 		notificatorMock = FileProviderNotificatorTypeMock()
-		observer = WorkingSetObserver(database: DatabaseQueue(), notificator: notificatorMock, uploadTaskManager: UploadTaskManagerMock(), cachedFileManager: CloudTaskExecutorTestCase.CachedFileManagerMock())
+		observer = WorkingSetObserver(domainIdentifier: .test, database: DatabaseQueue(), notificator: notificatorMock, uploadTaskManager: UploadTaskManagerMock(), cachedFileManager: CloudTaskExecutorTestCase.CachedFileManagerMock())
 	}
 
 	func testHandleNewWorkingSetUpdate() throws {

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -259,8 +259,9 @@ class FileProviderExtension: NSFileProviderExtension {
 		                                                              dbPath: dbPath,
 		                                                              delegate: LocalURLProvider(domain: snapshotDomain)))
 		#else
-		if let domain = domain, let localURLProvider = localURLProvider {
+		if let domain = domain, let localURLProvider = localURLProvider, let dbPath = dbPath, let notificator = notificator {
 			serviceSources.append(VaultUnlockingServiceSource(domain: domain, notificator: notificator, dbPath: dbPath, delegate: localURLProvider))
+			serviceSources.append(UploadRetryingServiceSource(domain: domain, notificator: notificator, dbPath: dbPath, delegate: localURLProvider))
 		}
 		#endif
 		serviceSources.append(VaultLockingServiceSource())

--- a/FileProviderExtensionUI/Info.plist
+++ b/FileProviderExtensionUI/Info.plist
@@ -31,6 +31,26 @@
 		<string>$(PRODUCT_MODULE_NAME).RootViewController</string>
 		<key>NSExtensionPointIdentifier</key>
 		<string>com.apple.fileprovider-actionsui</string>
+        <key>NSExtensionFileProviderActions</key>
+        <array>
+            <dict>
+
+				<key>NSExtensionFileProviderActionIdentifier</key>
+				<string>org.cryptomator.ios.fileprovider.retryUpload</string>
+				<key>NSExtensionFileProviderActionName</key>
+				<string>Retry Upload</string>
+				<key>NSExtensionFileProviderActionActivationRule</key>
+				<string>SUBQUERY( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo."hasUploadError" == YES).@count > 0</string>
+            </dict>
+			<dict>
+				<key>NSExtensionFileProviderActionIdentifier</key>
+				<string>org.cryptomator.ios.fileprovider.retryWaitingUpload</string>
+				<key>NSExtensionFileProviderActionName</key>
+				<string>Retry Upload</string>
+				<key>NSExtensionFileProviderActionActivationRule</key>
+				<string>SUBQUERY( fileproviderItems, $fileproviderItem, $fileproviderItem.userInfo."isUploading" == YES).@count > 0</string>
+			</dict>
+        </array>
 	</dict>
 </dict>
 </plist>

--- a/FileProviderExtensionUI/UploadProgressAlertController.swift
+++ b/FileProviderExtensionUI/UploadProgressAlertController.swift
@@ -1,0 +1,94 @@
+//
+//  UploadProgressAlertController.swift
+//  FileProviderExtensionUI
+//
+//  Created by Philipp Schmid on 09.05.22.
+//  Copyright © 2022 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import Promises
+import UIKit
+
+class UploadProgressAlertController: UIAlertController {
+	/// Promise fulfills as soon as a alert action gets triggered
+	let alertActionTriggered = Promise<Void>.pending()
+
+	var progress: Double? {
+		didSet {
+			DispatchQueue.main.async {
+				if let progress = self.progress {
+					self.setMessage(with: progress)
+				} else {
+					self.setMessageForMissingProgress()
+				}
+			}
+		}
+	}
+
+	private lazy var formatter: NumberFormatter = {
+		let formatter = NumberFormatter()
+		formatter.minimumFractionDigits = 0
+		formatter.maximumFractionDigits = 2
+		formatter.numberStyle = .decimal
+		return formatter
+	}()
+
+	func setMessage(with progress: Double) {
+		let formattedProgress = formatter.string(from: progress * 100.0 as NSNumber) ?? "n/a"
+		let text = "Current Progress: \(formattedProgress)%\n\nIf you're noticing that the upload progress is stuck, you can retry the upload."
+		message = text
+	}
+
+	func setMessageForMissingProgress() {
+		message = "Progress could not be determined. It may still be running in the background."
+	}
+
+	func observeProgress(itemIdentifier: NSFileProviderItemIdentifier, proxy: UploadRetrying) -> Promise<Void> {
+		return Promise<Void> { fulfill, _ in
+			Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] timer in
+				let isVisible = self?.viewIfLoaded?.window != nil
+				if isVisible {
+					proxy.getCurrentFractionalUploadProgress(for: itemIdentifier) { number in
+						let currentProgress = number?.doubleValue
+						self?.progress = currentProgress
+						if let progress = currentProgress, progress >= 1.0 {
+							timer.invalidate()
+							fulfill(())
+						}
+					}
+				} else {
+					timer.invalidate()
+				}
+			}
+		}
+	}
+}
+
+enum RetryUploadAlertControllerFactory {
+	static func createUploadProgressAlert(dismissAction: @escaping () -> Void, retryAction: @escaping () -> Void) -> UploadProgressAlertController {
+		let alertController = UploadProgressAlertController(title: "Uploading…", message: "Connecting…", preferredStyle: .alert)
+		let dismissAlertAction = UIAlertAction(title: LocalizedString.getValue("Dismiss"), style: .cancel) { _ in
+			dismissAction()
+			alertController.alertActionTriggered.fulfill(())
+		}
+		let retryAlertAction = UIAlertAction(title: LocalizedString.getValue("Retry"), style: .default) { _ in
+			retryAction()
+			alertController.alertActionTriggered.fulfill(())
+		}
+		alertController.addAction(dismissAlertAction)
+		alertController.addAction(retryAlertAction)
+		alertController.preferredAction = dismissAlertAction
+		return alertController
+	}
+
+	static func createDomainNotFoundAlert(okAction: @escaping () -> Void) -> UIAlertController {
+		let alertController = UIAlertController(title: "Error", message: "Could not find domain.", preferredStyle: .alert)
+		let okAlertAction = UIAlertAction(title: LocalizedString.getValue("common.button.ok"), style: .cancel) { _ in
+			okAction()
+		}
+		alertController.addAction(okAlertAction)
+		alertController.preferredAction = okAlertAction
+		return alertController
+	}
+}

--- a/FileProviderExtensionUI/UploadProgressAlertController.swift
+++ b/FileProviderExtensionUI/UploadProgressAlertController.swift
@@ -36,12 +36,11 @@ class UploadProgressAlertController: UIAlertController {
 
 	func setMessage(with progress: Double) {
 		let formattedProgress = formatter.string(from: progress * 100.0 as NSNumber) ?? "n/a"
-		let text = "Current Progress: \(formattedProgress)%\n\nIf you're noticing that the upload progress is stuck, you can retry the upload."
-		message = text
+		message = String(format: LocalizedString.getValue("fileProvider.uploadProgress.message"), formattedProgress)
 	}
 
 	func setMessageForMissingProgress() {
-		message = "Progress could not be determined. It may still be running in the background."
+		message = LocalizedString.getValue("fileProvider.uploadProgress.missing")
 	}
 
 	func observeProgress(itemIdentifier: NSFileProviderItemIdentifier, proxy: UploadRetrying) -> Promise<Void> {
@@ -67,12 +66,14 @@ class UploadProgressAlertController: UIAlertController {
 
 enum RetryUploadAlertControllerFactory {
 	static func createUploadProgressAlert(dismissAction: @escaping () -> Void, retryAction: @escaping () -> Void) -> UploadProgressAlertController {
-		let alertController = UploadProgressAlertController(title: "Uploading…", message: "Connecting…", preferredStyle: .alert)
-		let dismissAlertAction = UIAlertAction(title: LocalizedString.getValue("Dismiss"), style: .cancel) { _ in
+		let alertController = UploadProgressAlertController(title: LocalizedString.getValue("fileProvider.uploadProgress.title"),
+		                                                    message: LocalizedString.getValue("fileProvider.uploadProgress.connecting"),
+		                                                    preferredStyle: .alert)
+		let dismissAlertAction = UIAlertAction(title: LocalizedString.getValue("common.button.dismiss"), style: .cancel) { _ in
 			dismissAction()
 			alertController.alertActionTriggered.fulfill(())
 		}
-		let retryAlertAction = UIAlertAction(title: LocalizedString.getValue("Retry"), style: .default) { _ in
+		let retryAlertAction = UIAlertAction(title: LocalizedString.getValue("common.button.retry"), style: .default) { _ in
 			retryAction()
 			alertController.alertActionTriggered.fulfill(())
 		}
@@ -83,7 +84,7 @@ enum RetryUploadAlertControllerFactory {
 	}
 
 	static func createDomainNotFoundAlert(okAction: @escaping () -> Void) -> UIAlertController {
-		let alertController = UIAlertController(title: "Error", message: "Could not find domain.", preferredStyle: .alert)
+		let alertController = UIAlertController(title: LocalizedString.getValue("common.alert.error.title"), message: LocalizedString.getValue("fileProvider.uploadProgress.missingDomainError"), preferredStyle: .alert)
 		let okAlertAction = UIAlertAction(title: LocalizedString.getValue("common.button.ok"), style: .cancel) { _ in
 			okAction()
 		}

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -255,3 +255,5 @@
 
 "webDAVAuthenticator.error.unsupportedProtocol" = "Server doesn't seem to be WebDAV compatible. Please check if you've used the correct URL.";
 "webDAVAuthenticator.error.untrustedCertificate" = "Certificate of this server is untrusted. You may have to re-add this WebDAV connection.";
+
+"Retry Upload" = "Retry Upload";

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -13,6 +13,7 @@
 "common.button.confirm" = "Confirm";
 "common.button.create" = "Create";
 "common.button.createFolder" = "Create Folder";
+"common.button.dismiss" = "Dismiss";
 "common.button.done" = "Done";
 "common.button.download" = "Download";
 "common.button.edit" = "Edit";
@@ -20,6 +21,7 @@
 "common.button.next" = "Next";
 "common.button.ok" = "OK";
 "common.button.remove" = "Remove";
+"common.button.retry" = "Retry";
 "common.button.signOut" = "Sign Out";
 "common.button.verify" = "Verify";
 "common.cells.openInFilesApp" = "Open in Files App";
@@ -95,6 +97,11 @@
 "fileProvider.error.defaultLock.title" = "Unlock Required";
 "fileProvider.error.defaultLock.message" = "To access and show the contents of your vault, it has to be unlocked.";
 "fileProvider.error.unlockButton" = "Unlock";
+"fileProvider.uploadProgress.connecting" = "Connecting…";
+"fileProvider.uploadProgress.message" = "Current Progress: %@%\n\nIf you're noticing that the upload progress is stuck, you can retry the upload.";
+"fileProvider.uploadProgress.missing" = "Progress could not be determined. It may still be running in the background.";
+"fileProvider.uploadProgress.title" = "Uploading…";
+"fileProvider.uploadProgress.missingDomainError" = "Could not find domain.";
 
 "keepUnlocked.alert.title" = "Lock Vault?";
 "keepUnlocked.alert.message" = "This change requires your vault to be locked in order to take effect.";


### PR DESCRIPTION
Allows the user to restart uploads that have the status "waiting..." or "failed" via customized FileProvider actions in the Files app by long pressing on the file to open the context menu and selecting "Retry Upload".

The upload will be retried directly in case of failed uploads in this case. For files with the status "waiting..." an alert is presented to the user, which shows him, the current upload progress. If there is no upload progress, the user will also be informed. In both cases the user has the possibility to decide if the upload is stuck and if an upload should be tried again.

To enable the customized FileProvider actions, the `NSFileProviderItemIdentifier` had to be changed so that the corresponding `NSFileProviderDomainIdentifier` can be derived from them. Because the `domainIdentifier` provided in the FileProviderExtensionUI over the `extensionContext` is not guaranteed the correct `NSFileProviderDomainIdentifier` from which the action was started. However, it is important for the XPC call to have the correct `NSFileProviderDomainIdentifier` (otherwise, in the worst case, the upload would be retried for a different file in a different vault).

In addition, failed uploads are now correctly displayed again with an upload error in the Files app - the CloudProviderErrors are mapped to an appropriate NSFileProviderError. 