### PR TITLE
Feature:  Support for quick unlock

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: macos-latest
+    runs-on: macos-12
     env:
       DERIVED_DATA_PATH: 'DerivedData'
       DEVICE: 'iPhone 12 Pro'

--- a/FileProviderExtensionUI/UnlockVaultViewController.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewController.swift
@@ -9,6 +9,7 @@
 import CryptomatorCommonCore
 import CryptomatorCryptoLib
 import FileProviderUI
+import LocalAuthentication
 import Promises
 import UIKit
 
@@ -87,7 +88,11 @@ class UnlockVaultViewController: UITableViewController {
 		}.then { [weak self] in
 			self?.coordinator?.done()
 		}.catch { [weak self] error in
-			self?.handleError(error, hud: hud)
+			if case LAError.userFallback = error {
+				// Do not show the fallback action as an error
+			} else {
+				self?.handleError(error, hud: hud)
+			}
 		}
 	}
 

--- a/FileProviderExtensionUI/UnlockVaultViewModel.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewModel.swift
@@ -62,6 +62,10 @@ class UnlockVaultViewModel {
 		}
 	}
 
+	var canQuickUnlock: Bool {
+		return biometricalUnlockEnabled && !wrongBiometricalPassword
+	}
+
 	private let domain: NSFileProviderDomain
 	private var vaultName: String {
 		return domain.displayName
@@ -123,8 +127,10 @@ class UnlockVaultViewModel {
 		self.wrongBiometricalPassword = wrongBiometricalPassword
 		self.fileProviderConnector = fileProviderConnector
 		let context = LAContext()
-		// Remove fallback title because "Enter password" also closes the FileProviderExtensionUI and does not display the password input
-		context.localizedFallbackTitle = ""
+		if #unavailable(iOS 16) {
+			// Remove fallback title because "Enter password" also closes FileProviderExtensionUI (prior to iOS 16) and does not display the password input
+			context.localizedFallbackTitle = ""
+		}
 		self.context = context
 		self.passwordManager = passwordManager
 		self.vaultAccountManager = vaultAccountManager

--- a/Scripts/process.sh
+++ b/Scripts/process.sh
@@ -17,8 +17,9 @@ function process_output() {
   printf '\n# Running %s\n' "$1"
   local start=$(date +%s)
   local output=$(eval "$2" 2>&1)
-  if [[ ! -z "$output" ]]; then
-    printf -- '---\n%s\n---\n' "$output"
+  local cleaned_output=$(echo "$output" | sed '/.*xcodebuild.*/d')
+  if [[ ! -z "$cleaned_output" ]]; then
+    printf -- '---\n%s\n---\n' "$cleaned_output"
     final_status=1
   fi
   local end=$(date +%s)


### PR DESCRIPTION
Performs a quick unlock, i.e. biometric authentication gets triggered immediately and thus fixes #225.
If the biometric authentication has failed several times, the user is shown "Enter password" as a fallback option - this is possible from iOS 16 and later, because Apple fixed a bug in iOS 16 which caused the FileProviderExtensionUI to close too early during biometric authentication. In this case, the regular unlock screen will be shown.
