### PR TITLE
Bugfix: Prevent flickering when Dropbox or pCloud account list is empty 

### DIFF
--- a/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
+++ b/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
@@ -169,13 +169,21 @@ class AccountListViewModel: AccountListViewModelProtocol {
 				self.databaseChangedPublisher.send(.failure(error))
 				return
 			}
-			if self.cloudProviderType == .dropbox, !self.removedRow {
+			guard !self.removedRow else {
+				return
+			}
+			guard !self.accounts.isEmpty else {
+				// Only query the cloud provider online for the additional info if there are actually accounts to query.
+				// Also fixes the problem that an empty account list is sent a second time via the `databaseChangedPublisher`.
+				return
+			}
+			if self.cloudProviderType == .dropbox {
 				self.refreshDropboxItems().then {
 					self.databaseChangedPublisher.send(.success(self.accounts))
 				}.catch { error in
 					self.databaseChangedPublisher.send(.failure(error))
 				}
-			} else if self.cloudProviderType == .pCloud, !self.removedRow {
+			} else if self.cloudProviderType == .pCloud {
 				self.refreshPCloudItems().then {
 					self.databaseChangedPublisher.send(.success(self.accounts))
 				}.catch { error in


### PR DESCRIPTION
When the account list for Dropbox or pCloud is called and no account is available, the empty account list message flickers once. This is due to the fact that until now, even though no account was available, it still tried to retrieve info online for an empty account list. This caused that the table view was notified about the empty account list a second time. 

Therefore, it is now checked if the account list is empty before performing such a query, which prevents the table view from being notified about the empty account list again. Thus, this fixes #235. 