### PR TITLE
Updated dependencies

### DIFF
--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -20,6 +20,15 @@
         }
       },
       {
+        "package": "AWSiOSSDKV2",
+        "repositoryURL": "https://github.com/aws-amplify/aws-sdk-ios-spm",
+        "state": {
+          "branch": null,
+          "revision": "443e35abb0646fb685e0754db74249d3242625ab",
+          "version": "2.27.10"
+        }
+      },
+      {
         "package": "Base32",
         "repositoryURL": "https://github.com/norio-nomura/Base32.git",
         "state": {
@@ -33,8 +42,8 @@
         "repositoryURL": "https://github.com/cryptomator/cloud-access-swift.git",
         "state": {
           "branch": null,
-          "revision": "f8aa06dbc245368aee16ff3e4047ab0cb881a81d",
-          "version": "1.3.0"
+          "revision": "909edb215d6e0eae635830587748f00730ce6f52",
+          "version": "1.4.0"
         }
       },
       {
@@ -78,8 +87,8 @@
         "repositoryURL": "https://github.com/groue/GRDB.swift.git",
         "state": {
           "branch": null,
-          "revision": "5ee47c3c2765bdfde0f44c2ea9a263f6aa252d63",
-          "version": "4.14.0"
+          "revision": "e02f2c8abacff2799ed14926edcbf6e76fb9f805",
+          "version": "5.25.0"
         }
       },
       {

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,7 +42,7 @@
         "repositoryURL": "https://github.com/cryptomator/cloud-access-swift.git",
         "state": {
           "branch": null,
-          "revision": "909edb215d6e0eae635830587748f00730ce6f52",
+          "revision": "22ce57a793b2a6627119801ff9072c0f301cb389",
           "version": "1.4.0"
         }
       },

--- a/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
+++ b/Cryptomator/Common/CloudAccountList/AccountListViewModel.swift
@@ -23,7 +23,7 @@ class AccountListViewModel: AccountListViewModelProtocol {
 	let cloudProviderType: CloudProviderType
 	private let dbManager: DatabaseManager
 	private let cloudAuthenticator: CloudAuthenticator
-	private var observation: TransactionObserver?
+	private var observation: DatabaseCancellable?
 	private lazy var databaseChangedPublisher = CurrentValueSubject<Result<[TableViewCellViewModel], Error>, Never>(.success([]))
 	private var removedRow = false
 

--- a/Cryptomator/Common/DatabaseManager.swift
+++ b/Cryptomator/Common/DatabaseManager.swift
@@ -47,18 +47,18 @@ class DatabaseManager {
 		}
 	}
 
-	func observeVaultAccounts(onError: @escaping (Error) -> Void, onChange: @escaping ([VaultAccount]) -> Void) -> TransactionObserver {
+	func observeVaultAccounts(onError: @escaping (Error) -> Void, onChange: @escaping ([VaultAccount]) -> Void) -> DatabaseCancellable {
 		let observation = ValueObservation.tracking { db in
 			try VaultAccount.fetchAll(db)
-		}
-		return observation.start(in: dbPool, onError: onError, onChange: onChange)
+		}.removeDuplicates()
+		return observation.start(in: dbPool, scheduling: .immediate, onError: onError, onChange: onChange)
 	}
 
-	func observeVaultAccount(withVaultUID vaultUID: String, onError: @escaping (Error) -> Void, onChange: @escaping (VaultAccount?) -> Void) -> TransactionObserver {
+	func observeVaultAccount(withVaultUID vaultUID: String, onError: @escaping (Error) -> Void, onChange: @escaping (VaultAccount?) -> Void) -> DatabaseCancellable {
 		let observation = ValueObservation.tracking { db in
 			try VaultAccount.fetchOne(db, key: vaultUID)
 		}
-		return observation.start(in: dbPool, onError: onError, onChange: onChange)
+		return observation.start(in: dbPool, scheduling: .immediate, onError: onError, onChange: onChange)
 	}
 
 	func getAllAccounts(for cloudProviderType: CloudProviderType) throws -> [AccountInfo] {
@@ -89,11 +89,11 @@ class DatabaseManager {
 		}
 	}
 
-	func observeCloudProviderAccounts(onError: @escaping (Error) -> Void, onChange: @escaping ([CloudProviderAccount]) -> Void) -> TransactionObserver {
+	func observeCloudProviderAccounts(onError: @escaping (Error) -> Void, onChange: @escaping ([CloudProviderAccount]) -> Void) -> DatabaseCancellable {
 		let observation = ValueObservation.tracking { db in
 			try CloudProviderAccount.fetchAll(db)
-		}
-		return observation.start(in: dbPool, onError: onError, onChange: onChange)
+		}.removeDuplicates()
+		return observation.start(in: dbPool, scheduling: .immediate, onError: onError, onChange: onChange)
 	}
 }
 

--- a/Cryptomator/VaultDetail/VaultDetailViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewModel.swift
@@ -153,7 +153,7 @@ class VaultDetailViewModel: VaultDetailViewModelProtocol {
 		return Bindable(currentKeepUnlockedDuration)
 	}()
 
-	private var observation: TransactionObserver?
+	private var observation: DatabaseCancellable?
 
 	convenience init(vaultInfo: VaultInfo) {
 		self.init(vaultInfo: vaultInfo, vaultManager: VaultDBManager.shared, fileProviderConnector: FileProviderXPCConnector.shared, passwordManager: VaultPasswordKeychainManager(), dbManager: DatabaseManager.shared, vaultKeepUnlockedSettings: VaultKeepUnlockedManager.shared)

--- a/Cryptomator/VaultList/VaultListViewModel.swift
+++ b/Cryptomator/VaultList/VaultListViewModel.swift
@@ -28,7 +28,7 @@ class VaultListViewModel: ViewModel, VaultListViewModelProtocol {
 	private let dbManager: DatabaseManager
 	private let vaultManager: VaultDBManager
 	private let fileProviderConnector: FileProviderConnector
-	private var observation: TransactionObserver?
+	private var observation: DatabaseCancellable?
 	private lazy var subscribers = Set<AnyCancellable>()
 	private lazy var errorPublisher = PassthroughSubject<Error, Never>()
 	private lazy var databaseChangedPublisher = CurrentValueSubject<Result<[TableViewCellViewModel], Error>, Never>(.success([]))

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.3.0")),
+		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.4.0")),
 		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.7.0"))
 	],
 	targets: [

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderAccountDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderAccountDBManager.swift
@@ -9,7 +9,7 @@
 import Foundation
 import GRDB
 
-public struct CloudProviderAccount: Decodable, FetchableRecord, TableRecord {
+public struct CloudProviderAccount: Decodable, FetchableRecord, TableRecord, Equatable {
 	public static let databaseTableName = "cloudProviderAccounts"
 	static let accountUIDKey = "accountUID"
 	static let cloudProviderTypeKey = "cloudProviderType"

--- a/CryptomatorFileProvider/DB/WorkingSetObserver.swift
+++ b/CryptomatorFileProvider/DB/WorkingSetObserver.swift
@@ -16,7 +16,7 @@ protocol WorkingSetObserving {
 }
 
 class WorkingSetObserver: WorkingSetObserving {
-	private var observer: TransactionObserver?
+	private var observer: DatabaseCancellable?
 	private let database: DatabaseReader
 	private let uploadTaskManager: UploadTaskManager
 	private let cachedFileManager: CachedFileManager
@@ -36,18 +36,21 @@ class WorkingSetObserver: WorkingSetObserving {
 		let observation = ValueObservation.tracking { db in
 			try ItemMetadata.filterWorkingSet().fetchAll(db)
 		}.removeDuplicates()
-		observer = observation.start(in: database, onError: { error in
-			DDLogError("Working set startObservation error: \(error)")
-		}, onChange: { [weak self] (metadataList: [ItemMetadata]) in
-			let items: [FileProviderItem]
-			do {
-				items = try self?.createFileProviderItems(from: metadataList) ?? []
-			} catch {
-				DDLogError("Working set onChange error: \(error)")
-				return
-			}
-			self?.handleWorkingSetUpdate(items: items)
-		})
+		observer = observation.start(in: database,
+		                             scheduling: .immediate,
+		                             onError: { error in
+		                             	DDLogError("Working set startObservation error: \(error)")
+		                             },
+		                             onChange: { [weak self] (metadataList: [ItemMetadata]) in
+		                             	let items: [FileProviderItem]
+		                             	do {
+		                             		items = try self?.createFileProviderItems(from: metadataList) ?? []
+		                             	} catch {
+		                             		DDLogError("Working set onChange error: \(error)")
+		                             		return
+		                             	}
+		                             	self?.handleWorkingSetUpdate(items: items)
+		                             })
 	}
 
 	func handleWorkingSetUpdate(items: [FileProviderItem]) {


### PR DESCRIPTION
The following dependencies have been updated:
- cloud-access-swift (from `1.3.0` to `1.4.0`)
- GRDB (from `4.14.0` to `5.25.0`)

For the major update from GRDB 4 to GRDB 5, only changes regarding the ValueObservations were necessary. Because they now have a different runtime behavior (for more details see the [official GRDB 5 Migration Guide](https://github.com/groue/GRDB.swift/blob/e02f2c8abacff2799ed14926edcbf6e76fb9f805/Documentation/GRDB5MigrationGuide.md#runtime-behavior-of-valueobservation)).