### PR TITLE
`ItemMetadataDBManager` improvements

### DIFF
--- a/CryptomatorFileProvider/DB/ItemMetadataDBManager.swift
+++ b/CryptomatorFileProvider/DB/ItemMetadataDBManager.swift
@@ -153,11 +153,7 @@ class ItemMetadataDBManager: ItemMetadataManager {
 		_ = try database.write { db in
 			try ItemMetadata
 				.filter(ItemMetadata.Columns.parentID == parentId && !ItemMetadata.Columns.isPlaceholderItem)
-				.fetchAll(db)
-				.forEach {
-					$0.isMaybeOutdated = true
-					try $0.save(db)
-				}
+				.updateAll(db, ItemMetadata.Columns.isMaybeOutdated.set(to: true))
 		}
 	}
 

--- a/CryptomatorFileProvider/DB/ItemMetadataDBManager.swift
+++ b/CryptomatorFileProvider/DB/ItemMetadataDBManager.swift
@@ -80,19 +80,38 @@ class ItemMetadataDBManager: ItemMetadataManager {
 		}
 	}
 
-	// TODO: Optimize Code and/or DB Scheme
 	func cacheMetadata(_ itemMetadataList: [ItemMetadata]) throws {
 		try database.write { db in
 			for metadata in itemMetadataList {
-				if let cachedMetadata = try ItemMetadata.fetchOne(db, key: ["cloudPath": metadata.cloudPath]) {
-					metadata.id = cachedMetadata.id
-					metadata.statusCode = cachedMetadata.statusCode
-					metadata.tagData = cachedMetadata.tagData
-					metadata.favoriteRank = cachedMetadata.favoriteRank
-					try metadata.update(db)
-				} else {
-					try metadata.insert(db)
-				}
+				try db.execute(
+					sql: """
+					INSERT INTO \(ItemMetadata.databaseTableName)
+					(\(ItemMetadata.Columns.name), \(ItemMetadata.Columns.type), \(ItemMetadata.Columns.size), \(ItemMetadata.Columns.parentID), \(ItemMetadata.Columns.lastModifiedDate), \(ItemMetadata.Columns.statusCode), \(ItemMetadata.Columns.cloudPath), \(ItemMetadata.Columns.isPlaceholderItem), \(ItemMetadata.Columns.isMaybeOutdated), \(ItemMetadata.Columns.favoriteRank), \(ItemMetadata.Columns.tagData)) VALUES
+					(:name, :type, :size, :parentID, :lastModifiedDate, :statusCode, :cloudPath, :isPlaceholderItem, :isMaybeOutdated, :favoriteRank, :tagData)
+					ON CONFLICT (\(ItemMetadata.Columns.cloudPath))
+					DO UPDATE SET \(ItemMetadata.Columns.name) = excluded.\(ItemMetadata.Columns.name),
+					\(ItemMetadata.Columns.type) = excluded.\(ItemMetadata.Columns.type),
+					\(ItemMetadata.Columns.size) = excluded.\(ItemMetadata.Columns.size),
+					\(ItemMetadata.Columns.parentID) = excluded.\(ItemMetadata.Columns.parentID),
+					\(ItemMetadata.Columns.lastModifiedDate) = excluded.\(ItemMetadata.Columns.lastModifiedDate),
+					\(ItemMetadata.Columns.cloudPath) = excluded.\(ItemMetadata.Columns.cloudPath),
+					\(ItemMetadata.Columns.isPlaceholderItem) = excluded.\(ItemMetadata.Columns.isPlaceholderItem),
+					\(ItemMetadata.Columns.isMaybeOutdated) = excluded.\(ItemMetadata.Columns.isMaybeOutdated)
+					""",
+					arguments: ["name": metadata.name,
+					            "type": metadata.type,
+					            "size": metadata.size,
+					            "parentID": metadata.parentID,
+					            "lastModifiedDate": metadata.lastModifiedDate,
+					            "statusCode": metadata.statusCode,
+					            "cloudPath": metadata.cloudPath,
+					            "isPlaceholderItem": metadata.isPlaceholderItem,
+					            "isMaybeOutdated": metadata.isMaybeOutdated,
+					            "favoriteRank": metadata.favoriteRank,
+					            "tagData": metadata.tagData]
+				)
+				let metadataID = db.lastInsertedRowID
+				metadata.id = metadataID
 			}
 		}
 	}


### PR DESCRIPTION
In detail, two optimizations were made:

- `cacheMetadata(itemMetadataList:)` now uses a [UPSERT](https://www.sqlite.org/lang_UPSERT.html) instead of a manual fetch and subsequent match.

- `flagAllItemsAsMaybeOutdated(withParentID:)`now updates the entire request at once instead of iterating through each individual item.

Both optimizations take advantage of SQLite's standard features instead of using more inefficient "workarounds" in Swift.
Furthermore, both optimizations lead to a smaller memory footprint and are thus relevant for #232.