### PR TITLE
Added support for limiting the page size of fetchItemList

### DIFF
--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/aws-amplify/aws-sdk-ios-spm",
         "state": {
           "branch": null,
-          "revision": "443e35abb0646fb685e0754db74249d3242625ab",
-          "version": "2.27.10"
+          "revision": "33ecff5497a9f3e582aeab51265617c64427f902",
+          "version": "2.27.12"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/cryptomator/cloud-access-swift.git",
         "state": {
           "branch": null,
-          "revision": "22ce57a793b2a6627119801ff9072c0f301cb389",
-          "version": "1.4.0"
+          "revision": "d39cc8bd3763755158bc8fda25fadca3fb308130",
+          "version": "1.5.0"
         }
       },
       {
@@ -66,11 +66,11 @@
       },
       {
         "package": "ObjectiveDropboxOfficial",
-        "repositoryURL": "https://github.com/phil1995/dropbox-sdk-obj-c.git",
+        "repositoryURL": "https://github.com/phil1995/dropbox-sdk-obj-c-spm.git",
         "state": {
           "branch": null,
-          "revision": "9d390f1cbae0f77066117f9b97370735914875b0",
-          "version": "6.2.3-fork"
+          "revision": "d4796b87b9dfff4a5164544ef1b865bc8a561638",
+          "version": "6.3.2"
         }
       },
       {
@@ -128,21 +128,21 @@
         }
       },
       {
-        "package": "MSGraphClientSDK",
-        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc.git",
+        "package": "MSGraphClientModels",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-models-spm.git",
         "state": {
           "branch": null,
-          "revision": "a4d0a18ab62176762e4efc2f56021c2f386d98bc",
-          "version": "1.0.0-fork"
+          "revision": "172b07fe8a7da6072149e2fd92051a510b25035e",
+          "version": "1.3.0"
         }
       },
       {
-        "package": "MSGraphClientModels",
-        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-models.git",
+        "package": "MSGraphClientSDK",
+        "repositoryURL": "https://github.com/phil1995/msgraph-sdk-objc-spm.git",
         "state": {
           "branch": null,
-          "revision": "50596f424c7496687f34666372c71a6fe6270ac2",
-          "version": "1.3.0-fork"
+          "revision": "0320c6a99207b53288970382afcf5054852f9724",
+          "version": "1.0.0"
         }
       },
       {

--- a/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
+++ b/Cryptomator/AddVault/CreateNewVault/CreateNewVaultCoordinator.swift
@@ -77,7 +77,13 @@ class CreateNewVaultCoordinator: AccountListing, CloudChoosing, DefaultShowEditA
 	}
 
 	func startAuthenticatedLocalFileSystemCreateNewVaultFlow(credential: LocalFileSystemCredential, account: CloudProviderAccount, item: Item) {
-		let provider = LocalFileSystemProvider(rootURL: credential.rootURL)
+		let provider: CloudProvider
+		do {
+			provider = try LocalFileSystemProvider(rootURL: credential.rootURL)
+		} catch {
+			handleError(error, for: navigationController)
+			return
+		}
 		let child = AuthenticatedCreateNewVaultCoordinator(navigationController: navigationController, provider: provider, account: account, vaultName: vaultName)
 		childCoordinators.append(child)
 		child.parentCoordinator = self

--- a/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewModel.swift
+++ b/Cryptomator/AddVault/LocalVault/LocalFileSystemAuthenticationViewModel.swift
@@ -82,7 +82,12 @@ class LocalFileSystemAuthenticationViewModel: SingleSectionTableViewModel, Local
 	}
 
 	private func validate(credential: LocalFileSystemCredential) -> Promise<Void> {
-		let provider = LocalizedCloudProviderDecorator(delegate: LocalFileSystemProvider(rootURL: credential.rootURL))
+		let provider: CloudProvider
+		do {
+			provider = try LocalizedCloudProviderDecorator(delegate: LocalFileSystemProvider(rootURL: credential.rootURL))
+		} catch {
+			return Promise(error)
+		}
 		return provider.fetchItemListExhaustively(forFolderAt: CloudPath("/")).then { itemList in
 			try self.validationLogic.validate(items: itemList.items)
 		}

--- a/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
+++ b/Cryptomator/AddVault/OpenExistingVault/OpenExistingVaultCoordinator.swift
@@ -75,7 +75,13 @@ class OpenExistingVaultCoordinator: AccountListing, CloudChoosing, DefaultShowEd
 	}
 
 	func startAuthenticatedLocalFileSystemOpenExistingVaultFlow(credential: LocalFileSystemCredential, account: CloudProviderAccount, item: Item) {
-		let provider = LocalFileSystemProvider(rootURL: credential.rootURL)
+		let provider: CloudProvider
+		do {
+			provider = try LocalFileSystemProvider(rootURL: credential.rootURL)
+		} catch {
+			handleError(error, for: navigationController)
+			return
+		}
 		let child = AuthenticatedOpenExistingVaultCoordinator(navigationController: navigationController, provider: provider, account: account)
 		childCoordinators.append(child)
 		child.parentCoordinator = self

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.4.0")),
+		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.5.0")),
 		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.7.0"))
 	],
 	targets: [

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
@@ -20,6 +20,8 @@ public class CloudProviderDBManager: CloudProviderManager {
 	public var useBackgroundSession = true
 	let accountManager: CloudProviderAccountDBManager
 
+	private let maxPageSizeForFileProvider = 500
+
 	init(accountManager: CloudProviderAccountDBManager) {
 		self.accountManager = accountManager
 	}
@@ -31,19 +33,29 @@ public class CloudProviderDBManager: CloudProviderManager {
 		return try createProvider(for: accountUID)
 	}
 
+	/**
+	 Creates and returns a cloud provider for the given `accountUID`.
+
+	 If `useBackgroundURLSession` is set to `true`, the number of returned items from a `fetchItemList(forFolderAt:pageToken:)` call is limited to 500.
+	 This is necessary because otherwise memory limit problems can occur with folders with many items in the `FileProviderExtension` where a background `URLSession` is used.
+	 */
 	func createProvider(for accountUID: String) throws -> CloudProvider {
 		let cloudProviderType = try accountManager.getCloudProviderType(for: accountUID)
 		let provider: CloudProvider
 		switch cloudProviderType {
 		case .dropbox:
 			let credential = DropboxCredential(tokenUID: accountUID)
-			provider = DropboxCloudProvider(credential: credential)
+			provider = DropboxCloudProvider(credential: credential, maxPageSize: useBackgroundSession ? maxPageSizeForFileProvider : .max)
 		case .googleDrive:
 			let credential = GoogleDriveCredential(userID: accountUID)
-			provider = try GoogleDriveCloudProvider(credential: credential, useBackgroundSession: useBackgroundSession)
+			provider = try GoogleDriveCloudProvider(credential: credential,
+			                                        useBackgroundSession: useBackgroundSession,
+			                                        maxPageSize: useBackgroundSession ? maxPageSizeForFileProvider : .max)
 		case .oneDrive:
 			let credential = try OneDriveCredential(with: accountUID)
-			provider = try OneDriveCloudProvider(credential: credential, useBackgroundSession: useBackgroundSession)
+			provider = try OneDriveCloudProvider(credential: credential,
+			                                     useBackgroundSession: useBackgroundSession,
+			                                     maxPageSize: useBackgroundSession ? maxPageSizeForFileProvider : .max)
 		case .pCloud:
 			let credential = try PCloudCredential(userID: accountUID)
 			provider = try PCloudCloudProvider(credential: credential)
@@ -57,12 +69,12 @@ public class CloudProviderDBManager: CloudProviderManager {
 			} else {
 				client = WebDAVClient(credential: credential)
 			}
-			provider = WebDAVProvider(with: client)
+			provider = try WebDAVProvider(with: client, maxPageSize: useBackgroundSession ? maxPageSizeForFileProvider : .max)
 		case .localFileSystem:
 			guard let rootURL = try LocalFileSystemBookmarkManager.getBookmarkedRootURL(for: accountUID) else {
 				throw CloudProviderAccountError.accountNotFoundError
 			}
-			provider = LocalFileSystemProvider(rootURL: rootURL)
+			provider = try LocalFileSystemProvider(rootURL: rootURL, maxPageSize: useBackgroundSession ? maxPageSizeForFileProvider : .max)
 		case .s3:
 			provider = try createS3Provider(for: accountUID)
 		}


### PR DESCRIPTION
Adds support for limiting the page size of fetchItemList in the main app for the changes introduced with https://github.com/cryptomator/cloud-access-swift/pull/14.

For the FileProviderExtension the max page size is set to 500, which ensures that not too many items are processed at once and thus fixes the memory limit described in #232.
An important note is that the Files app still requests all items of a folder. This means that the user may have to wait a very long time before seeing the items of a folder with a large number of items. According to Apple, this is the expected behavior and can only be fixed with a workaround via the working set. However, we have decided not to implement this workaround for now, as we are currently not implementing other workarounds via the working set due to (local) security concerns of some users.

Based on #243.