### PR TITLE
Bugfix: Prevent flickering when vault list is empty

### DIFF
--- a/Cryptomator/Common/DatabaseManager.swift
+++ b/Cryptomator/Common/DatabaseManager.swift
@@ -48,9 +48,9 @@ class DatabaseManager {
 	}
 
 	func observeVaultAccounts(onError: @escaping (Error) -> Void, onChange: @escaping ([VaultAccount]) -> Void) -> DatabaseCancellable {
-		let observation = ValueObservation.tracking { db in
-			try VaultAccount.fetchAll(db)
-		}
+		let observation = ValueObservation
+			.tracking { try VaultAccount.fetchAll($0) }
+			.removeDuplicates()
 		return observation.start(in: dbPool, scheduling: .immediate, onError: onError, onChange: onChange)
 	}
 

--- a/Cryptomator/VaultDetail/MoveVault/MoveVaultCoordinator.swift
+++ b/Cryptomator/VaultDetail/MoveVault/MoveVaultCoordinator.swift
@@ -75,11 +75,9 @@ extension MoveVaultCoordinator: FolderChoosing {
 	private func popBackToFirstNonMoveVaultViewController() {
 		var viewControllers: [UIViewController] = navigationController.viewControllers
 		viewControllers = viewControllers.reversed()
-		for currentViewController in viewControllers {
-			if !currentViewController.isKind(of: MoveVaultViewController.self) {
-				navigationController.popToViewController(currentViewController, animated: true)
-				break
-			}
+		for currentViewController in viewControllers where !currentViewController.isKind(of: MoveVaultViewController.self) {
+			navigationController.popToViewController(currentViewController, animated: true)
+			break
 		}
 	}
 }


### PR DESCRIPTION
The vault list flickered briefly when the app was launched if the list was empty. This happened because the database observer outputs duplicates (in this case two times an empty array). Therefore, successive duplicates are now removed during database observation.