### PR TITLE
Bugfix: Fix iOS 14 SwiftUI HostingViewController missing Navigation Items

### DIFF
--- a/Cryptomator/S3/S3AuthenticationViewController.swift
+++ b/Cryptomator/S3/S3AuthenticationViewController.swift
@@ -11,14 +11,14 @@ import CryptomatorCommonCore
 import SwiftUI
 import UIKit
 
-class S3AuthenticationViewController: UIHostingController<S3AuthenticationView> {
+class S3AuthenticationViewController: UIViewController {
 	weak var coordinator: (Coordinator & S3Authenticating)?
 	let viewModel: S3AuthenticationViewModel
 	private var subscriptions = Set<AnyCancellable>()
 
 	init(viewModel: S3AuthenticationViewModel) {
 		self.viewModel = viewModel
-		super.init(rootView: S3AuthenticationView(viewModel: viewModel))
+		super.init(nibName: nil, bundle: nil)
 	}
 
 	@available(*, unavailable)
@@ -28,6 +28,8 @@ class S3AuthenticationViewController: UIHostingController<S3AuthenticationView> 
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		setupSwiftUIView()
+
 		let doneButton = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(done))
 		navigationItem.rightBarButtonItem = doneButton
 		let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
@@ -63,5 +65,14 @@ class S3AuthenticationViewController: UIHostingController<S3AuthenticationView> 
 
 	@objc func cancel() {
 		coordinator?.cancel()
+	}
+
+	private func setupSwiftUIView() {
+		let child = UIHostingController(rootView: S3AuthenticationView(viewModel: viewModel))
+		addChild(child)
+		view.addSubview(child.view)
+		child.didMove(toParent: self)
+		child.view.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate(child.view.constraints(equalTo: view))
 	}
 }

--- a/Cryptomator/WebDAV/WebDAVAuthentication.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthentication.swift
@@ -20,7 +20,7 @@ struct WebDAVAuthentication: View {
 	@FocusStateLegacy private var focusedField: Fields? = .url
 
 	var body: some View {
-		List {
+		Form {
 			TextField(LocalizedString.getValue("common.cells.url"), text: $viewModel.url)
 				.keyboardType(.URL)
 				.disableAutocorrection(true)

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
@@ -13,15 +13,15 @@ import Promises
 import SwiftUI
 import UIKit
 
-class WebDAVAuthenticationViewController: UIHostingController<WebDAVAuthentication> {
+class WebDAVAuthenticationViewController: UIViewController {
 	weak var coordinator: (Coordinator & WebDAVAuthenticating)?
-	private var viewModel: WebDAVAuthenticationViewModel
+	private let viewModel: WebDAVAuthenticationViewModel
 	private var cancellables = Set<AnyCancellable>()
 	private var hud: ProgressHUD?
 
 	init(viewModel: WebDAVAuthenticationViewModel) {
 		self.viewModel = viewModel
-		super.init(rootView: WebDAVAuthentication(viewModel: viewModel))
+		super.init(nibName: nil, bundle: nil)
 	}
 
 	@available(*, unavailable)
@@ -31,6 +31,8 @@ class WebDAVAuthenticationViewController: UIHostingController<WebDAVAuthenticati
 
 	override func viewDidLoad() {
 		super.viewDidLoad()
+		setupSwiftUIView()
+
 		title = "WebDAV"
 		let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(cancel))
 		navigationItem.leftBarButtonItem = cancelButton
@@ -86,6 +88,15 @@ class WebDAVAuthenticationViewController: UIHostingController<WebDAVAuthenticati
 
 	@objc func cancel() {
 		coordinator?.cancel()
+	}
+
+	private func setupSwiftUIView() {
+		let child = UIHostingController(rootView: WebDAVAuthentication(viewModel: viewModel))
+		addChild(child)
+		view.addSubview(child.view)
+		child.didMove(toParent: self)
+		child.view.translatesAutoresizingMaskIntoConstraints = false
+		NSLayoutConstraint.activate(child.view.constraints(equalTo: view))
 	}
 }
 


### PR DESCRIPTION
On iOS 14 `viewDidLoad` gets not called when subclassing `HostingViewController`.
As we used the `viewDidLoad` for setting the title, navigationItems and setting up the bindings this leads to errors (see #280).
This PR fixes these problems and thus closes #280 by using a standard `UIViewController` and just embed the view of the `HostingViewController`.

Furthermore, the appearance of the `WebDAVAuthentication` Screen has been updated for iOS 14 to be also `insetGrouped`. 