### PR TITLE
Bugfix: Show untrusted TLS certificate alert

### DIFF
--- a/Cryptomator/WebDAV/WebDAVAuthentication.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthentication.swift
@@ -42,35 +42,6 @@ struct WebDAVAuthentication: View {
 		.introspectTableView(customize: { tableView in
 			tableView.backgroundColor = .cryptomatorBackground
 		})
-		.alert(isPresented: $viewModel.showUntrustedCertificateError) {
-			untrustedCertificateAlert
-		}
-		.alert(isPresented: $viewModel.showAllowInsecureConnectionAlert) {
-			insecureConnectionAlert
-		}
-	}
-
-	private var untrustedCertificateAlert: Alert {
-		Alert(title: Text(LocalizedString.getValue("untrustedTLSCertificate.title")),
-		      message: Text(LocalizedString.getValue("untrustedTLSCertificate.message")),
-		      primaryButton: .default(Text(LocalizedString.getValue("untrustedTLSCertificate.add")),
-		                              action: {
-		                              	viewModel.allowCertificate()
-		                              }),
-		      secondaryButton: .cancel(Text(LocalizedString.getValue("untrustedTLSCertificate.dismiss"))))
-	}
-
-	private var insecureConnectionAlert: Alert {
-		Alert(title: Text(LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.title")),
-		      message: Text(LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.message")),
-		      primaryButton: .default(Text(LocalizedString.getValue("webDAVAuthentication.httpConnection.change")),
-		                              action: {
-		                              	viewModel.saveAccountWithTransformedURL()
-		                              }),
-		      secondaryButton: .destructive(Text(LocalizedString.getValue("webDAVAuthentication.httpConnection.continue")),
-		                                    action: {
-		                                    	viewModel.saveAccountWithInsecureConnection()
-		                                    }))
 	}
 }
 

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
@@ -60,7 +60,11 @@ class WebDAVAuthenticationViewController: UIViewController {
 			hud?.transformToSelfDismissingSuccess().then {
 				self.coordinator?.authenticated(with: credential)
 			}
-		case .initial, .insecureConnectionNotAllowed, .untrustedCertificate:
+		case .insecureConnectionNotAllowed:
+			showInsecureConnectionAlert()
+		case let .untrustedCertificate(certificate: certificate, url: url):
+			showUntrustedCertificateAlert(certificate: certificate, url: url)
+		case .initial:
 			break
 		}
 	}
@@ -84,6 +88,51 @@ class WebDAVAuthenticationViewController: UIViewController {
 		hud?.text = LocalizedString.getValue("common.hud.authenticating")
 		hud?.show(presentingViewController: self)
 		hud?.showLoadingIndicator()
+	}
+
+	private func showUntrustedCertificateAlert(certificate: TLSCertificate, url: URL) {
+		let precondition: Promise<Void>
+		if let hud = hud {
+			precondition = hud.dismiss(animated: true)
+		} else {
+			precondition = Promise(())
+		}
+		precondition.then { [weak self] in
+			let message = String(format: LocalizedString.getValue("untrustedTLSCertificate.message"), url.absoluteString, certificate.fingerprint)
+			let alertController = UIAlertController(title: LocalizedString.getValue("untrustedTLSCertificate.title"),
+			                                        message: message,
+			                                        preferredStyle: .alert)
+			let addAction = UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.add"),
+			                              style: .default,
+			                              handler: { _ in self?.viewModel.allowCertificate() })
+			alertController.addAction(addAction)
+			alertController.addAction(UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.dismiss"), style: .cancel))
+			self?.present(alertController, animated: true)
+		}
+	}
+
+	private func showInsecureConnectionAlert() {
+		let precondition: Promise<Void>
+		if let hud = hud {
+			precondition = hud.dismiss(animated: true)
+		} else {
+			precondition = Promise(())
+		}
+		precondition.then { [weak self] in
+			let alertController = UIAlertController(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.title"),
+			                                        message: LocalizedString.getValue("webDAVAuthentication.httpConnection.alert.message"),
+			                                        preferredStyle: .alert)
+			let changeToHTTPSAction = UIAlertAction(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.change"), style: .default, handler: { _ in
+				self?.viewModel.saveAccountWithTransformedURL()
+			})
+
+			alertController.addAction(changeToHTTPSAction)
+			alertController.preferredAction = changeToHTTPSAction
+			alertController.addAction(UIAlertAction(title: LocalizedString.getValue("webDAVAuthentication.httpConnection.continue"), style: .destructive, handler: { _ in
+				self?.viewModel.saveAccountWithInsecureConnection()
+			}))
+			self?.present(alertController, animated: true)
+		}
 	}
 
 	@objc func cancel() {

--- a/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
+++ b/Cryptomator/WebDAV/WebDAVAuthenticationViewController.swift
@@ -104,7 +104,7 @@ class WebDAVAuthenticationViewController: UIViewController {
 			                                        preferredStyle: .alert)
 			let addAction = UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.add"),
 			                              style: .default,
-			                              handler: { _ in self?.viewModel.allowCertificate() })
+			                              handler: { _ in self?.viewModel.saveAccountWithCertificate() })
 			alertController.addAction(addAction)
 			alertController.addAction(UIAlertAction(title: LocalizedString.getValue("untrustedTLSCertificate.dismiss"), style: .cancel))
 			self?.present(alertController, animated: true)


### PR DESCRIPTION
Fixes the issue #295  where the untrusted TLS certificate wasn't shown to the user because of the currently presented ProgressHUD.