### PR TITLE
Manually resume URLSessionTask after it has been successfully registered

### DIFF
--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -350,6 +350,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 						DDLogError("Register URLSessionUploadTask for identifier: \(itemIdentifier) failed with error: \(error)")
 					} else {
 						DDLogInfo("Successfully registered URLSessionUploadTask for identifier: \(itemIdentifier)")
+						urlSessionTask.resume()
 					}
 				})
 			})
@@ -717,6 +718,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 						DDLogError("Register URLSessionTask for identifier: \(identifier) failed with error: \(error)")
 					} else {
 						DDLogInfo("Successfully registered URLSessionTask for identifier: \(identifier)")
+						urlSessionTask.resume()
 					}
 				})
 			})


### PR DESCRIPTION
We introduced with #293 the progress reporting for Download & Upload for WebDAV. However, it seems like the FileProviderExtension doesn't like when one registers a already running URLSessionTask and this could trigger `EXC_RESOURCE RESOURCE_TYPE_MEMORY`. Somehow registering and then resuming the task seem to fix this issue (and thus closing #299)… which is a bit unexpected but the documentation inside the header file of NSFileProvideManager (but not the online [documentation](https://developer.apple.com/documentation/fileprovider/nsfileprovidermanager/2890932-register)) also states:

> The task must be suspended at the time of calling.

So I guess we are interacting now a bit more according to the specifications.