### PR TITLE
Dependency Injection: Improve injection of main database

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -353,6 +353,7 @@
 		4AF45359271F38FC00CF1919 /* RenameVaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF45358271F38FC00CF1919 /* RenameVaultViewModelTests.swift */; };
 		4AF4535D27205F6200CF1919 /* VaultDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF4535C27205F6200CF1919 /* VaultDetailCoordinator.swift */; };
 		4AF4535F272066A600CF1919 /* RenameVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF4535E272066A600CF1919 /* RenameVaultViewController.swift */; };
+		4AF91A0F2AC2F025002357BA /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = 4AF91A0E2AC2F025002357BA /* Dependencies */; };
 		4AF91CBE25A63FD600ACF01E /* VaultListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CBD25A63FD600ACF01E /* VaultListViewModel.swift */; };
 		4AF91CC725A6437000ACF01E /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4AF91CC625A6437000ACF01E /* Colors.xcassets */; };
 		4AF91CD025A71C5800ACF01E /* UIImage+CloudProviderType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF91CCF25A71C5800ACF01E /* UIImage+CloudProviderType.swift */; };
@@ -1095,6 +1096,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4A91728B2619F1D0003C4043 /* CryptomatorCommonCore in Frameworks */,
+				4AF91A0F2AC2F025002357BA /* Dependencies in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2220,6 +2222,7 @@
 			name = CryptomatorFileProvider;
 			packageProductDependencies = (
 				4A91728A2619F1D0003C4043 /* CryptomatorCommonCore */,
+				4AF91A0E2AC2F025002357BA /* Dependencies */,
 			);
 			productName = CryptomatorFileProvider;
 			productReference = 740375D72587AE7A0023FF53 /* libCryptomatorFileProvider.a */;
@@ -3704,6 +3707,10 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 4AED9A6D286B38D900352951 /* XCRemoteSwiftPackageReference "SwiftUI-Introspect" */;
 			productName = Introspect;
+		};
+		4AF91A0E2AC2F025002357BA /* Dependencies */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = Dependencies;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -164,6 +164,15 @@
         }
       },
       {
+        "package": "Dependencies",
+        "repositoryURL": "https://github.com/PhilLibs/simple-swift-dependencies",
+        "state": {
+          "branch": null,
+          "revision": "36e2e7732b5fe2bfec76e4af78d2ef532fe09456",
+          "version": "0.1.0"
+        }
+      },
+      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {
@@ -188,6 +197,15 @@
           "branch": null,
           "revision": "5b830d6ce6c34bb4bb976917576ab560e7945037",
           "version": "3.3.4"
+        }
+      },
+      {
+        "package": "xctest-dynamic-overlay",
+        "repositoryURL": "https://github.com/pointfreeco/xctest-dynamic-overlay",
+        "state": {
+          "branch": null,
+          "revision": "23cbf2294e350076ea4dbd7d5d047c1e76b03631",
+          "version": "1.0.2"
         }
       }
     ]

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -29,22 +29,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		setupIAP()
 
 		// Set up database
-		guard let dbURL = CryptomatorDatabase.sharedDBURL else {
-			// MARK: Handle error
+		DatabaseManager.shared = DatabaseManager()
 
-			DDLogError("dbURL is nil")
-			return false
-		}
-		do {
-			let dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-			CryptomatorDatabase.shared = try CryptomatorDatabase(dbPool)
-			DatabaseManager.shared = try DatabaseManager(dbPool: dbPool)
-		} catch {
-			// MARK: Handle error
-
-			DDLogError("Initializing CryptomatorDatabase failed with error: \(error)")
-			return false
-		}
 		VaultDBManager.shared.recoverMissingFileProviderDomains().catch { error in
 			DDLogError("Recover missing FileProvider domains failed with error: \(error)")
 		}

--- a/Cryptomator/Common/Cells/BindableTableViewCellViewModel.swift
+++ b/Cryptomator/Common/Cells/BindableTableViewCellViewModel.swift
@@ -1,5 +1,5 @@
 //
-//  TableViewCellViewModel.swift
+//  BindableTableViewCellViewModel.swift
 //  Cryptomator
 //
 //  Created by Philipp Schmid on 29.07.21.

--- a/Cryptomator/Onboarding/OnboardingViewController.swift
+++ b/Cryptomator/Onboarding/OnboardingViewController.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingWelcomeViewController.swift
+//  OnboardingViewController.swift
 //  Cryptomator
 //
 //  Created by Tobias Hagemann on 08.09.21.

--- a/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailUnlockVaultViewModel.swift
@@ -47,7 +47,7 @@ class VaultDetailUnlockVaultViewModel: SingleSectionTableViewModel, ReturnButton
 	}
 
 	func unlockVault() throws {
-		let cachedVault = try VaultDBCache(dbWriter: CryptomatorDatabase.shared.dbPool).getCachedVault(withVaultUID: vault.vaultUID)
+		let cachedVault = try VaultDBCache().getCachedVault(withVaultUID: vault.vaultUID)
 		let masterkeyFile = try MasterkeyFile.withContentFromData(data: cachedVault.masterkeyFileData)
 		_ = try masterkeyFile.unlock(passphrase: password)
 		try passwordManager.setPassword(password, forVaultUID: vault.vaultUID)

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -27,7 +27,8 @@ let package = Package(
 	],
 	dependencies: [
 		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.7.0")),
-		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.8.0"))
+		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.8.0")),
+		.package(url: "https://github.com/PhilLibs/simple-swift-dependencies", .upToNextMajor(from: "0.1.0"))
 	],
 	targets: [
 		.target(
@@ -41,7 +42,8 @@ let package = Package(
 			name: "CryptomatorCommonCore",
 			dependencies: [
 				"CocoaLumberjackSwift",
-				"CryptomatorCloudAccessCore"
+				"CryptomatorCloudAccessCore",
+				.product(name: "Dependencies", package: "simple-swift-dependencies")
 			]
 		),
 		.testTarget(

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorDatabase.swift
@@ -6,8 +6,43 @@
 //  Copyright © 2020 Skymatic GmbH. All rights reserved.
 //
 
+import CocoaLumberjackSwift
+import Dependencies
 import Foundation
 import GRDB
+
+private enum CryptomatorDatabaseKey: DependencyKey {
+	static let liveValue: DatabaseWriter = CryptomatorDatabase.live
+
+	static var testValue: DatabaseWriter {
+		let inMemoryDB = DatabaseQueue(configuration: .defaultCryptomatorConfiguration)
+		do {
+			try CryptomatorDatabase.migrator.migrate(inMemoryDB)
+		} catch {
+			DDLogError("Failed to migrate in-memory database: \(error)")
+		}
+		return inMemoryDB
+	}
+}
+
+public extension DependencyValues {
+	var database: DatabaseWriter {
+		get { self[CryptomatorDatabaseKey.self] }
+		set { self[CryptomatorDatabaseKey.self] = newValue }
+	}
+}
+
+private enum CryptomatorDatabaseLocationKey: DependencyKey {
+	static var liveValue: URL? { CryptomatorDatabase.sharedDBURL }
+	static var testValue: URL? { FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString, isDirectory: false) }
+}
+
+public extension DependencyValues {
+	var databaseLocation: URL? {
+		get { self[CryptomatorDatabaseLocationKey.self] }
+		set { self[CryptomatorDatabaseLocationKey.self] = newValue }
+	}
+}
 
 public enum CryptomatorDatabaseError: Error {
 	case dbDoesNotExist
@@ -15,22 +50,30 @@ public enum CryptomatorDatabaseError: Error {
 }
 
 public class CryptomatorDatabase {
-	public static var shared: CryptomatorDatabase!
+	static var live: DatabaseWriter {
+		@Dependency(\.databaseLocation) var databaseURL
 
-	public static var sharedDBURL: URL? {
+		guard let dbURL = databaseURL else {
+			fatalError("Could not get URL for shared database")
+		}
+		let database: DatabaseWriter
+		do {
+			database = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
+		} catch {
+			DDLogError("Failed to open shared database: \(error)")
+			fatalError("Could not open shared database")
+		}
+		do {
+			try CryptomatorDatabase.migrator.migrate(database)
+		} catch {
+			DDLogError("Failed to migrate database: \(error)")
+		}
+		return database
+	}
+
+	static var sharedDBURL: URL? {
 		let sharedContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: CryptomatorConstants.appGroupName)
 		return sharedContainer?.appendingPathComponent("db.sqlite")
-	}
-
-	public let dbPool: DatabasePool
-	private static var oldSharedDBURL: URL? {
-		let sharedContainer = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: CryptomatorConstants.appGroupName)
-		return sharedContainer?.appendingPathComponent("main.sqlite")
-	}
-
-	public init(_ dbPool: DatabasePool) throws {
-		self.dbPool = dbPool
-		try CryptomatorDatabase.migrator.migrate(dbPool)
 	}
 
 	static var migrator: DatabaseMigrator {
@@ -48,7 +91,7 @@ public class CryptomatorDatabase {
 	}
 
 	// swiftlint:disable:next function_body_length
-	public class func v1Migration(_ db: Database) throws {
+	class func v1Migration(_ db: Database) throws {
 		// Common
 		try db.create(table: "cloudProviderAccounts") { table in
 			table.column("accountUID", .text).primaryKey()
@@ -157,12 +200,10 @@ public class CryptomatorDatabase {
 		var coordinatorError: NSError?
 		var dbPool: DatabasePool?
 		var dbError: Error?
-		var configuration = Configuration()
-		// Workaround for a SQLite regression (see https://github.com/groue/GRDB.swift/issues/1171 for more details)
-		configuration.acceptsDoubleQuotedStringLiterals = true
+
 		coordinator.coordinate(writingItemAt: databaseURL, options: .forMerging, error: &coordinatorError, byAccessor: { _ in
 			do {
-				dbPool = try DatabasePool(path: databaseURL.path, configuration: configuration)
+				dbPool = try DatabasePool(path: databaseURL.path, configuration: .defaultCryptomatorConfiguration)
 			} catch {
 				dbError = error
 			}
@@ -193,7 +234,7 @@ public class CryptomatorDatabase {
 
 	private static func openReadOnlyDatabase(at databaseURL: URL) throws -> DatabasePool {
 		do {
-			var configuration = Configuration()
+			var configuration = Configuration.defaultCryptomatorConfiguration
 			configuration.readonly = true
 			let dbPool = try DatabasePool(path: databaseURL.path, configuration: configuration)
 
@@ -209,5 +250,14 @@ public class CryptomatorDatabase {
 				throw CryptomatorDatabaseError.dbDoesNotExist
 			}
 		}
+	}
+}
+
+extension Configuration {
+	static var defaultCryptomatorConfiguration: Configuration {
+		var configuration = Configuration()
+		// Workaround for a SQLite regression (see https://github.com/groue/GRDB.swift/issues/1171 for more details)
+		configuration.acceptsDoubleQuotedStringLiterals = true
+		return configuration
 	}
 }

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/FileProviderConnector.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/FileProviderXPC/FileProviderConnector.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  FileProviderConnector.swift
 //  CryptomatorCommonCore
 //
 //  Created by Philipp Schmid on 26.07.21.

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBCache.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBCache.swift
@@ -8,6 +8,7 @@
 
 import CryptomatorCloudAccessCore
 import CryptomatorCryptoLib
+import Dependencies
 import Foundation
 import GRDB
 import Promises
@@ -49,20 +50,18 @@ public enum VaultCacheError: Error {
 }
 
 public class VaultDBCache: VaultCache {
-	private let dbWriter: DatabaseWriter
+	@Dependency(\.database) var database
 
-	public init(dbWriter: DatabaseWriter) {
-		self.dbWriter = dbWriter
-	}
+	public init() {}
 
 	public func cache(_ entry: CachedVault) throws {
-		try dbWriter.write({ db in
+		try database.write({ db in
 			try entry.save(db)
 		})
 	}
 
 	public func getCachedVault(withVaultUID vaultUID: String) throws -> CachedVault {
-		try dbWriter.read({ db in
+		try database.read({ db in
 			guard let cachedVault = try CachedVault.fetchOne(db, key: vaultUID) else {
 				throw VaultCacheError.vaultNotFound
 			}
@@ -83,7 +82,7 @@ public class VaultDBCache: VaultCache {
 	}
 
 	public func setMasterkeyFileData(_ data: Data, forVaultUID vaultUID: String, lastModifiedDate: Date?) throws {
-		_ = try dbWriter.write { db in
+		_ = try database.write { db in
 			try CachedVault.filter(CachedVault.Columns.vaultUID == vaultUID).updateAll(db,
 			                                                                           CachedVault.Columns.masterkeyFileData.set(to: data),
 			                                                                           CachedVault.Columns.masterkeyFileLastModifiedDate.set(to: lastModifiedDate))
@@ -153,7 +152,7 @@ public class VaultDBCache: VaultCache {
 	}
 
 	private func setVaultConfigData(_ data: Data?, forVaultUID vaultUID: String, lastModifiedDate: Date?) throws {
-		_ = try dbWriter.write { db in
+		_ = try database.write { db in
 			try CachedVault.filter(CachedVault.Columns.vaultUID == vaultUID).updateAll(db,
 			                                                                           CachedVault.Columns.vaultConfigToken.set(to: data),
 			                                                                           CachedVault.Columns.vaultConfigLastModifiedDate.set(to: lastModifiedDate))

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBManager.swift
@@ -36,7 +36,7 @@ public protocol VaultManager {
 public class VaultDBManager: VaultManager {
 	public static let shared = VaultDBManager(providerManager: CloudProviderDBManager.shared,
 	                                          vaultAccountManager: VaultAccountDBManager.shared,
-	                                          vaultCache: VaultDBCache(dbWriter: CryptomatorDatabase.shared.dbPool),
+	                                          vaultCache: VaultDBCache(),
 	                                          passwordManager: VaultPasswordKeychainManager(),
 	                                          masterkeyCacheManager: MasterkeyCacheKeychainManager.shared,
 	                                          masterkeyCacheHelper: VaultKeepUnlockedManager.shared)

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultPasswordManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultPasswordManager.swift
@@ -1,5 +1,5 @@
 //
-//  VaultPasswordKeychainManager.swift
+//  VaultPasswordManager.swift
 //  CryptomatorCommonCore
 //
 //  Created by Philipp Schmid on 09.07.21.

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/S3/CryptomatorKeychain+S3.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/S3/CryptomatorKeychain+S3.swift
@@ -1,5 +1,5 @@
 //
-//  CryptomatorKeychain+S3.swift.swift
+//  CryptomatorKeychain+S3.swift
 //
 //
 //  Created by Philipp Schmid on 29.06.22.

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderAccountManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderAccountManagerTests.swift
@@ -10,27 +10,13 @@ import Foundation
 import GRDB
 import XCTest
 @testable import CryptomatorCommonCore
+@testable import Dependencies
 
 class CloudProviderAccountManagerTests: XCTestCase {
 	var accountManager: CloudProviderAccountDBManager!
-	var tmpDir: URL!
 
 	override func setUpWithError() throws {
-		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		let dbPool = try DatabasePool(path: tmpDir.appendingPathComponent("db.sqlite").path)
-		try dbPool.write { db in
-			try db.create(table: CloudProviderAccount.databaseTableName) { table in
-				table.column(CloudProviderAccount.accountUIDKey, .text).primaryKey()
-				table.column(CloudProviderAccount.cloudProviderTypeKey, .text).notNull()
-			}
-		}
-		accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
-	}
-
-	override func tearDownWithError() throws {
-		accountManager = nil
-		try FileManager.default.removeItem(at: tmpDir)
+		accountManager = CloudProviderAccountDBManager()
 	}
 
 	func testSaveAccount() throws {

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderManagerTests.swift
@@ -15,23 +15,10 @@ import XCTest
 class CloudProviderManagerTests: XCTestCase {
 	var manager: CloudProviderDBManager!
 	var accountManager: CloudProviderAccountDBManager!
-	var tmpDir: URL!
-	override func setUpWithError() throws {
-		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		let dbPool = try DatabasePool(path: tmpDir.appendingPathComponent("db.sqlite").path)
-		try dbPool.write { db in
-			try db.create(table: CloudProviderAccount.databaseTableName) { table in
-				table.column(CloudProviderAccount.accountUIDKey, .text).primaryKey()
-				table.column(CloudProviderAccount.cloudProviderTypeKey, .text).notNull()
-			}
-		}
-		accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
-		manager = CloudProviderDBManager(accountManager: accountManager)
-	}
 
-	override func tearDownWithError() throws {
-		try FileManager.default.removeItem(at: tmpDir)
+	override func setUpWithError() throws {
+		accountManager = CloudProviderAccountDBManager()
+		manager = CloudProviderDBManager(accountManager: accountManager)
 	}
 
 	func testCreateProviderCachesTheProvider() throws {

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/S3CredentialManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/S3CredentialManagerTests.swift
@@ -16,13 +16,8 @@ class S3CredentialManagerTests: XCTestCase {
 	let displayName = "Cryptomator S3"
 
 	override func setUpWithError() throws {
-		var configuration = Configuration()
-		// Workaround for a SQLite regression (see https://github.com/groue/GRDB.swift/issues/1171 for more details)
-		configuration.acceptsDoubleQuotedStringLiterals = true
-		let inMemoryDB = DatabaseQueue(configuration: configuration)
-		try CryptomatorDatabase.migrator.migrate(inMemoryDB)
 		cryptomatorKeychainMock = CryptomatorKeychainMock()
-		manager = S3CredentialManager(dbWriter: inMemoryDB, keychain: cryptomatorKeychainMock)
+		manager = S3CredentialManager(keychain: cryptomatorKeychainMock)
 	}
 
 	func testSaveCredential() throws {

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/VaultManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/VaultManagerTests.swift
@@ -61,8 +61,6 @@ class VaultManagerTests: XCTestCase {
 	var masterkeyCacheManagerMock: MasterkeyCacheManagerMock!
 	var masterkeyCacheHelperMock: MasterkeyCacheHelperMock!
 	var cloudProviderMock: CloudProviderMock!
-	var tmpDir: URL!
-	var dbPool: DatabasePool!
 	let vaultUID = "VaultUID-12345"
 	let passphrase = "PW"
 	let delegateAccountUID = UUID().uuidString
@@ -74,17 +72,10 @@ class VaultManagerTests: XCTestCase {
 
 	override func setUpWithError() throws {
 		cloudProviderMock = CloudProviderMock()
-		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		var configuration = Configuration()
-		// Workaround for a SQLite regression (see https://github.com/groue/GRDB.swift/issues/1171 for more details)
-		configuration.acceptsDoubleQuotedStringLiterals = true
-		dbPool = try DatabasePool(path: tmpDir.appendingPathComponent("db.sqlite").path, configuration: configuration)
-		try CryptomatorDatabase.migrator.migrate(dbPool)
 
-		providerAccountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		providerAccountManager = CloudProviderAccountDBManager()
 		providerManager = CloudProviderManagerMock(provider: cloudProviderMock, accountManager: providerAccountManager)
-		accountManager = VaultAccountDBManager(dbPool: dbPool)
+		accountManager = VaultAccountDBManager()
 		vaultCacheMock = VaultCacheMock()
 		vaultCacheMock.refreshVaultCacheForWithReturnValue = Promise(())
 		passwordManagerMock = VaultPasswordManagerMock()
@@ -92,16 +83,6 @@ class VaultManagerTests: XCTestCase {
 		masterkeyCacheHelperMock = MasterkeyCacheHelperMock()
 		masterkeyCacheHelperMock.shouldCacheMasterkeyForVaultUIDReturnValue = false
 		manager = VaultManagerMock(providerManager: providerManager, vaultAccountManager: accountManager, vaultCache: vaultCacheMock, passwordManager: passwordManagerMock, masterkeyCacheManager: masterkeyCacheManagerMock, masterkeyCacheHelper: masterkeyCacheHelperMock)
-	}
-
-	override func tearDownWithError() throws {
-		// Set all objects related to the sqlite database to nil to avoid warnings about database integrity when deleting the test database.
-		manager = nil
-		providerAccountManager = nil
-		providerManager = nil
-		accountManager = nil
-		dbPool = nil
-		try FileManager.default.removeItem(at: tmpDir)
 	}
 
 	func testCreateNewVault() throws {

--- a/CryptomatorFileProvider/DatabaseURLProvider.swift
+++ b/CryptomatorFileProvider/DatabaseURLProvider.swift
@@ -13,10 +13,6 @@ public struct DatabaseURLProvider {
 	public static let shared = DatabaseURLProvider(documentStorageURLProvider: NSFileProviderManager.default)
 	let documentStorageURLProvider: DocumentStorageURLProvider
 
-	init(documentStorageURLProvider: DocumentStorageURLProvider) {
-		self.documentStorageURLProvider = documentStorageURLProvider
-	}
-
 	public func getDatabaseURL(for domain: NSFileProviderDomain) -> URL {
 		let documentStorageURL = documentStorageURLProvider.documentStorageURL
 		let domainURL = documentStorageURL.appendingPathComponent(domain.pathRelativeToDocumentStorage, isDirectory: true)

--- a/CryptomatorFileProvider/FileProviderAdapterError.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterError.swift
@@ -1,5 +1,5 @@
 //
-//  FileProviderDecoratorError.swift
+//  FileProviderAdapterError.swift
 //  CryptomatorFileProvider
 //
 //  Created by Philipp Schmid on 24.06.20.

--- a/CryptomatorFileProvider/FileProviderItemList.swift
+++ b/CryptomatorFileProvider/FileProviderItemList.swift
@@ -12,9 +12,4 @@ import Foundation
 public struct FileProviderItemList {
 	public let items: [FileProviderItem]
 	public let nextPageToken: NSFileProviderPage?
-
-	init(items: [FileProviderItem], nextPageToken: NSFileProviderPage?) {
-		self.items = items
-		self.nextPageToken = nextPageToken
-	}
 }

--- a/CryptomatorFileProvider/LocalURLProviderType.swift
+++ b/CryptomatorFileProvider/LocalURLProviderType.swift
@@ -1,5 +1,5 @@
 //
-//  LocalURLProvider.swift
+//  LocalURLProviderType.swift
 //  CryptomatorFileProvider
 //
 //  Created by Philipp Schmid on 03.03.22.

--- a/CryptomatorFileProvider/Promise+AllIgnoringResult.swift
+++ b/CryptomatorFileProvider/Promise+AllIgnoringResult.swift
@@ -1,5 +1,5 @@
 //
-//  Promises+FinishedAll.swift
+//  Promise+AllIgnoringResult.swift
 //  CryptomatorFileProvider
 //
 //  Created by Philipp Schmid on 31.03.22.

--- a/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMockTests.swift
+++ b/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMockTests.swift
@@ -1,5 +1,5 @@
 //
-//  CloudProviderMockTests.swift
+//  CustomCloudProviderMockTests.swift
 //  CryptomatorFileProviderTests
 //
 //  Created by Philipp Schmid on 01.07.20.

--- a/CryptomatorIntents/IntentHandler.swift
+++ b/CryptomatorIntents/IntentHandler.swift
@@ -34,13 +34,5 @@ class IntentHandler: INExtension {
 	private static var oneTimeSetup: () -> Void = {
 		// Set up logger
 		LoggerSetup.oneTimeSetup()
-		if let dbURL = CryptomatorDatabase.sharedDBURL {
-			do {
-				let dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-				CryptomatorDatabase.shared = try CryptomatorDatabase(dbPool)
-			} catch {
-				DDLogError("Open shared database at \(dbURL) failed with error: \(error)")
-			}
-		}
 	}
 }

--- a/CryptomatorTests/AccountListViewModelTests.swift
+++ b/CryptomatorTests/AccountListViewModelTests.swift
@@ -13,27 +13,9 @@ import XCTest
 @testable import CryptomatorCommonCore
 
 class AccountListViewModelTests: XCTestCase {
-	var tmpDir: URL!
-	var dbPool: DatabasePool!
-	var cryptomatorDB: CryptomatorDatabase!
-	override func setUpWithError() throws {
-		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		let dbURL = tmpDir.appendingPathComponent("db.sqlite")
-		dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-		cryptomatorDB = try CryptomatorDatabase(dbPool)
-		_ = try DatabaseManager(dbPool: dbPool)
-	}
-
-	override func tearDownWithError() throws {
-		dbPool = nil
-		cryptomatorDB = nil
-		try FileManager.default.removeItem(at: tmpDir)
-	}
-
 	func testMoveRow() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
-		let accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		let dbManagerMock = try DatabaseManagerMock()
+		let accountManager = CloudProviderAccountDBManager()
 		let cloudAuthenticatorMock = CloudAuthenticatorMock(accountManager: accountManager)
 		let accountListViewModel = AccountListViewModelMock(with: .dropbox, dbManager: dbManagerMock, cloudAuthenticator: cloudAuthenticatorMock)
 		try accountListViewModel.refreshItems()
@@ -57,8 +39,8 @@ class AccountListViewModelTests: XCTestCase {
 	}
 
 	func testRemoveRow() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
-		let accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
+		let accountManager = CloudProviderAccountDBManager()
 		let cloudAuthenticatorMock = CloudAuthenticatorMock(accountManager: accountManager)
 		let accountListViewModel = AccountListViewModelMock(with: .dropbox, dbManager: dbManagerMock, cloudAuthenticator: cloudAuthenticatorMock)
 		try accountListViewModel.refreshItems()
@@ -78,8 +60,8 @@ class AccountListViewModelTests: XCTestCase {
 	}
 
 	func testWebDAVAccountCellContent() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
-		let accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
+		let accountManager = CloudProviderAccountDBManager()
 		let cloudAuthenticatorMock = CloudAuthenticatorMock(accountManager: accountManager)
 		let accountListViewModel = AccountListViewModel(with: .dropbox, dbManager: dbManagerMock, cloudAuthenticator: cloudAuthenticatorMock)
 		let baseURL = URL(string: "https://www.example.com")!
@@ -90,8 +72,8 @@ class AccountListViewModelTests: XCTestCase {
 	}
 
 	func testWebDAVAccountCellContentWithPathInDetailLabel() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
-		let accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
+		let accountManager = CloudProviderAccountDBManager()
 		let cloudAuthenticatorMock = CloudAuthenticatorMock(accountManager: accountManager)
 		let accountListViewModel = AccountListViewModel(with: .dropbox, dbManager: dbManagerMock, cloudAuthenticator: cloudAuthenticatorMock)
 		let baseURL = URL(string: "https://www.example.com/path")!
@@ -102,8 +84,8 @@ class AccountListViewModelTests: XCTestCase {
 	}
 
 	func testWebDAVAccountCellContentWithUnknownHost() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
-		let accountManager = CloudProviderAccountDBManager(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
+		let accountManager = CloudProviderAccountDBManager()
 		let cloudAuthenticatorMock = CloudAuthenticatorMock(accountManager: accountManager)
 		let accountListViewModel = AccountListViewModel(with: .dropbox, dbManager: dbManagerMock, cloudAuthenticator: cloudAuthenticatorMock)
 		let baseURL = URL(string: "www")!

--- a/CryptomatorTests/Mocks/IAPManagerMock.swift
+++ b/CryptomatorTests/Mocks/IAPManagerMock.swift
@@ -1,5 +1,5 @@
 //
-//  IAPManager.swift
+//  IAPManagerMock.swift
 //  CryptomatorTests
 //
 //  Created by Philipp Schmid on 26.11.21.

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -15,38 +15,23 @@ import XCTest
 @testable import CryptomatorCommonCore
 
 class VaultListViewModelTests: XCTestCase {
-	var tmpDir: URL!
-	var dbPool: DatabasePool!
-	var cryptomatorDB: CryptomatorDatabase!
 	private var vaultManagerMock: VaultDBManagerMock!
 	private var vaultAccountManagerMock: VaultAccountManagerMock!
 	private var passwordManagerMock: VaultPasswordManagerMock!
 	private var vaultCacheMock: VaultCacheMock!
 	private var fileProviderConnectorMock: FileProviderConnectorMock!
-	override func setUpWithError() throws {
-		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
-		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		let dbURL = tmpDir.appendingPathComponent("db.sqlite")
-		dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-		cryptomatorDB = try CryptomatorDatabase(dbPool)
 
-		let cloudProviderManager = CloudProviderDBManager(accountManager: CloudProviderAccountDBManager(dbPool: dbPool))
+	override func setUpWithError() throws {
+		let cloudProviderManager = CloudProviderDBManager(accountManager: CloudProviderAccountDBManager())
 		vaultAccountManagerMock = VaultAccountManagerMock()
 		passwordManagerMock = VaultPasswordManagerMock()
 		vaultCacheMock = VaultCacheMock()
 		vaultManagerMock = VaultDBManagerMock(providerManager: cloudProviderManager, vaultAccountManager: vaultAccountManagerMock, vaultCache: vaultCacheMock, passwordManager: passwordManagerMock, masterkeyCacheManager: MasterkeyCacheManagerMock(), masterkeyCacheHelper: MasterkeyCacheHelperMock())
 		fileProviderConnectorMock = FileProviderConnectorMock()
-		_ = try DatabaseManager(dbPool: dbPool)
-	}
-
-	override func tearDownWithError() throws {
-		dbPool = nil
-		cryptomatorDB = nil
-		try FileManager.default.removeItem(at: tmpDir)
 	}
 
 	func testRefreshVaultsIsSorted() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		XCTAssert(vaultListViewModel.getVaults().isEmpty)
 		try vaultListViewModel.refreshItems()
@@ -59,7 +44,7 @@ class VaultListViewModelTests: XCTestCase {
 	}
 
 	func testMoveRow() throws {
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		try vaultListViewModel.refreshItems()
 
@@ -82,7 +67,7 @@ class VaultListViewModelTests: XCTestCase {
 		let cachedVault = CachedVault(vaultUID: "vault2", masterkeyFileData: "".data(using: .utf8)!, vaultConfigToken: nil, lastUpToDateCheck: Date(), masterkeyFileLastModifiedDate: nil, vaultConfigLastModifiedDate: nil)
 		try vaultCacheMock.cache(cachedVault)
 
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		try vaultListViewModel.refreshItems()
 
@@ -105,7 +90,7 @@ class VaultListViewModelTests: XCTestCase {
 
 	func testLockVault() throws {
 		let expectation = XCTestExpectation()
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		let vaultInfo = VaultInfo(vaultAccount: VaultAccount(vaultUID: "vault1", delegateAccountUID: "1", vaultPath: CloudPath("/vault1"), vaultName: "vault1"),
 		                          cloudProviderAccount: CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox),
@@ -131,7 +116,7 @@ class VaultListViewModelTests: XCTestCase {
 
 	func testRefreshVaultLockedStates() throws {
 		let expectation = XCTestExpectation()
-		let dbManagerMock = try DatabaseManagerMock(dbPool: dbPool)
+		let dbManagerMock = DatabaseManagerMock()
 		let vaultListViewModel = VaultListViewModel(dbManager: dbManagerMock, vaultManager: vaultManagerMock, fileProviderConnector: fileProviderConnectorMock)
 		try vaultListViewModel.refreshItems()
 

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -25,27 +25,19 @@ class FileProviderExtension: NSFileProviderExtension {
 		LoggerSetup.oneTimeSetup()
 		FileProviderExtension.setupIAP()
 		if !FileProviderExtension.sharedDatabaseInitialized {
-			if let dbURL = CryptomatorDatabase.sharedDBURL {
-				do {
-					let dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-					CryptomatorDatabase.shared = try CryptomatorDatabase(dbPool)
-					FileProviderExtension.sharedDatabaseInitialized = true
-					DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: CryptomatorConstants.appGroupName, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: false)
-					GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
-					OneDriveSetup.sharedContainerIdentifier = CryptomatorConstants.appGroupName
-					let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
-					oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
-					OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
-				} catch {
-					// MARK: Handle error
-
-					FileProviderExtension.databaseError = error
-					DDLogError("Failed to initialize FPExt sharedDB: \(error)")
-				}
-			} else {
+			do {
+				FileProviderExtension.sharedDatabaseInitialized = true
+				DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: CryptomatorConstants.appGroupName, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: false)
+				GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
+				OneDriveSetup.sharedContainerIdentifier = CryptomatorConstants.appGroupName
+				let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
+				oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
+				OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			} catch {
 				// MARK: Handle error
 
-				DDLogError("FPExt - dbURL is nil")
+				FileProviderExtension.databaseError = error
+				DDLogError("Failed to initialize FPExt sharedDB: \(error)")
 			}
 		}
 

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -56,22 +56,7 @@ class RootViewController: FPUIActionExtensionViewController {
 	static var oneTimeSetup: () -> Void = {
 		// Set up logger
 		LoggerSetup.oneTimeSetup()
-		// Set up database
-		guard let dbURL = CryptomatorDatabase.sharedDBURL else {
-			// MARK: Handle error
 
-			DDLogError("dbURL is nil")
-			return {}
-		}
-		do {
-			let dbPool = try CryptomatorDatabase.openSharedDatabase(at: dbURL)
-			CryptomatorDatabase.shared = try CryptomatorDatabase(dbPool)
-		} catch {
-			// MARK: Handle error
-
-			DDLogError("Initializing CryptomatorDatabase failed with error: \(error)")
-			return {}
-		}
 		// Set up cloud storage services
 		CloudProviderDBManager.shared.useBackgroundSession = false
 		DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: nil, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: true)

--- a/FileProviderExtensionUI/UnlockVaultViewModel.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewModel.swift
@@ -119,7 +119,7 @@ class UnlockVaultViewModel {
 		          passwordManager: VaultPasswordKeychainManager(),
 		          vaultAccountManager: VaultAccountDBManager.shared,
 		          providerManager: CloudProviderDBManager.shared,
-		          vaultCache: VaultDBCache(dbWriter: CryptomatorDatabase.shared.dbPool))
+		          vaultCache: VaultDBCache())
 	}
 
 	init(domain: NSFileProviderDomain, wrongBiometricalPassword: Bool, fileProviderConnector: FileProviderConnector, passwordManager: VaultPasswordManager, vaultAccountManager: VaultAccountManager, providerManager: CloudProviderManager, vaultCache: VaultCache) {


### PR DESCRIPTION
## Motivation
Currently we inject most of the dependencies via the initializer relying by using a singleton as the default / live value.
This pollutes the initializers as we sometimes have a lot of small components abstracted away via protocols as dependencies.
Even worse we sometimes need to first initialize the value and then set it on app / extension launch. This is cumbersome and also lead to crashes in the past… although they were pretty easy to detect as you "just" need to run every target at least once.

## Description
First proposal on how we could Improve the injection of dependencies by using the [simple-swift-dependencies](https://github.com/PhilLibs/simple-swift-dependencies) library.
In this PR I migrated the shared main database away from a pure singleton (which even got set manually on app / extension launch) implementation to a more controlled dependency with a default test value (a migrated in-memory database).
The library mentioned above does also fail the unit test if there is no test value provided and the dependency has not been mocked or it was not explicitly stated in the test case to use the live value.

If we decide to use this approach we can migrate all other database managers which use the main database easily.
Furthermore, we can eventually migrate at least every injected dependency which has a singleton as a default value to the proposed solution.