### PR TITLE
Inject FullVersionChecker with new DI framework

### DIFF
--- a/Cryptomator/AddVault/AddVaultCoordinator.swift
+++ b/Cryptomator/AddVault/AddVaultCoordinator.swift
@@ -7,12 +7,14 @@
 //
 
 import CryptomatorCommonCore
+import Dependencies
 import Foundation
 import UIKit
 
 class AddVaultCoordinator: Coordinator {
 	var childCoordinators = [Coordinator]()
 	var navigationController: UINavigationController
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 	weak var parentCoordinator: MainCoordinator?
 
 	init(navigationController: UINavigationController) {
@@ -76,7 +78,7 @@ class AddVaultCoordinator: Coordinator {
 	}
 
 	private func isAllowedToCreateNewVault() -> Bool {
-		return GlobalFullVersionChecker.default.isFullVersion
+		fullVersionChecker.isFullVersion
 	}
 }
 

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -145,8 +145,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension FullVersionCheckerKey: DependencyKey {
 	public static var liveValue: FullVersionChecker {
 		#if ALWAYS_PREMIUM
-		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
-		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
+		return AlwaysActivatedPremium.default
 		#else
 		return UserDefaultsFullVersionChecker.default
 		#endif

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -11,6 +11,7 @@ import CryptomatorCloudAccess
 import CryptomatorCloudAccessCore
 import CryptomatorCommon
 import CryptomatorCommonCore
+import Dependencies
 import MSAL
 import ObjectiveDropboxOfficial
 import StoreKit
@@ -130,11 +131,24 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 	private func setupIAP() {
 		#if ALWAYS_PREMIUM
 		DDLogDebug("Always activated premium")
-		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
 		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
 		#else
 		DDLogDebug("Freemium version")
-		GlobalFullVersionChecker.default = UserDefaultsFullVersionChecker.default
+		#endif
+	}
+}
+
+/**
+ Define the liveValue in the main target since compilation flags do not work on Swift Package Manager level.
+ Be aware that it is needed to set the default value once per app launch (+ also when launching the FileProviderExtension).
+ */
+extension FullVersionCheckerKey: DependencyKey {
+	public static var liveValue: FullVersionChecker {
+		#if ALWAYS_PREMIUM
+		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
+		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
+		#else
+		return UserDefaultsFullVersionChecker.default
 		#endif
 	}
 }

--- a/Cryptomator/Onboarding/OnboardingCoordinator.swift
+++ b/Cryptomator/Onboarding/OnboardingCoordinator.swift
@@ -7,12 +7,14 @@
 //
 
 import CryptomatorCommonCore
+import Dependencies
 import Foundation
 import UIKit
 
 class OnboardingCoordinator: Coordinator {
 	var childCoordinators = [Coordinator]()
 	var navigationController: UINavigationController
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 
 	init(navigationController: UINavigationController) {
 		self.navigationController = navigationController
@@ -25,7 +27,7 @@ class OnboardingCoordinator: Coordinator {
 	}
 
 	func showIAP() {
-		guard !GlobalFullVersionChecker.default.isFullVersion else {
+		guard !fullVersionChecker.isFullVersion else {
 			navigationController.dismiss(animated: true)
 			return
 		}

--- a/Cryptomator/VaultList/VaultListViewController.swift
+++ b/Cryptomator/VaultList/VaultListViewController.swift
@@ -9,6 +9,7 @@
 import CocoaLumberjackSwift
 import Combine
 import CryptomatorCommonCore
+import Dependencies
 import Foundation
 import UIKit
 
@@ -17,6 +18,7 @@ class VaultListViewController: ListViewController<VaultCellViewModel> {
 
 	private let viewModel: VaultListViewModelProtocol
 	private var observer: NSObjectProtocol?
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 
 	init(with viewModel: VaultListViewModelProtocol) {
 		self.viewModel = viewModel
@@ -60,7 +62,7 @@ class VaultListViewController: ListViewController<VaultCellViewModel> {
 		super.viewDidAppear(animated)
 		if CryptomatorUserDefaults.shared.showOnboardingAtStartup {
 			coordinator?.showOnboarding()
-		} else if GlobalFullVersionChecker.default.hasExpiredTrial, !CryptomatorUserDefaults.shared.showedTrialExpiredAtStartup {
+		} else if fullVersionChecker.hasExpiredTrial, !CryptomatorUserDefaults.shared.showedTrialExpiredAtStartup {
 			coordinator?.showTrialExpired()
 		}
 	}

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/CryptomatorUserDefaults.swift
@@ -7,6 +7,7 @@
 //
 
 import CocoaLumberjackSwift
+import Dependencies
 import Foundation
 
 public protocol CryptomatorSettings {
@@ -14,6 +15,20 @@ public protocol CryptomatorSettings {
 	var trialExpirationDate: Date? { get set }
 	var fullVersionUnlocked: Bool { get set }
 	var hasRunningSubscription: Bool { get set }
+}
+
+private enum CryptomatorSettingsKey: DependencyKey {
+	#if DEBUG
+	static let testValue: CryptomatorSettings = CryptomatorSettingsMock()
+	#endif
+	static let liveValue: CryptomatorSettings = CryptomatorUserDefaults.shared
+}
+
+public extension DependencyValues {
+	var cryptomatorSettings: CryptomatorSettings {
+		get { self[CryptomatorSettingsKey.self] }
+		set { self[CryptomatorSettingsKey.self] = newValue }
+	}
 }
 
 public class CryptomatorUserDefaults {

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Mocks/FullVersionCheckerMock.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Mocks/FullVersionCheckerMock.swift
@@ -6,11 +6,9 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
-#if DEBUG
 import Foundation
 
 final class FullVersionCheckerMock: FullVersionChecker {
 	var isFullVersion: Bool = false
 	var hasExpiredTrial: Bool = false
 }
-#endif

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
@@ -7,6 +7,7 @@
 
 import XCTest
 @testable import CryptomatorCommonCore
+@testable import Dependencies
 
 class FullVersionCheckerTests: XCTestCase {
 	var settingsMock: CryptomatorSettingsMock!
@@ -14,10 +15,11 @@ class FullVersionCheckerTests: XCTestCase {
 
 	override func setUpWithError() throws {
 		settingsMock = CryptomatorSettingsMock()
+		DependencyValues.mockDependency(\.cryptomatorSettings, with: settingsMock)
 		settingsMock.fullVersionUnlocked = false
 		settingsMock.hasRunningSubscription = false
 		settingsMock.trialExpirationDate = nil
-		fullVersionChecker = UserDefaultsFullVersionChecker(cryptomatorSettings: settingsMock)
+		fullVersionChecker = UserDefaultsFullVersionChecker()
 	}
 
 	// MARK: Is Full Version

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -9,6 +9,7 @@
 import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
+import Dependencies
 import FileProvider
 import Foundation
 import Promises
@@ -68,7 +69,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	private let provider: CloudProvider
 	private let localURLProvider: LocalURLProviderType
 	private let notificator: FileProviderItemUpdateDelegate?
-	private let fullVersionChecker: FullVersionChecker
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 	private let workflowFactory: WorkflowFactoryLocking
 	private let domainIdentifier: NSFileProviderDomainIdentifier
 	private let fileCoordinator: NSFileCoordinator
@@ -87,7 +88,6 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	     coordinator: NSFileCoordinator,
 	     notificator: FileProviderItemUpdateDelegate? = nil,
 	     localURLProvider: LocalURLProviderType,
-	     fullVersionChecker: FullVersionChecker = GlobalFullVersionChecker.default,
 	     taskRegistrator: SessionTaskRegistrator) {
 		self.lastUnlockedDate = Date()
 		self.domainIdentifier = domainIdentifier
@@ -112,7 +112,6 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		self.provider = provider
 		self.notificator = notificator
 		self.localURLProvider = localURLProvider
-		self.fullVersionChecker = fullVersionChecker
 		self.fileCoordinator = coordinator
 		self.taskRegistrator = taskRegistrator
 	}

--- a/CryptomatorFileProvider/FileProviderItem.swift
+++ b/CryptomatorFileProvider/FileProviderItem.swift
@@ -8,6 +8,7 @@
 
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
+import Dependencies
 import FileProvider
 import Foundation
 import MobileCoreServices
@@ -22,15 +23,14 @@ public class FileProviderItem: NSObject, NSFileProviderItem {
 	let newestVersionLocallyCached: Bool
 	let localURL: URL?
 	let domainIdentifier: NSFileProviderDomainIdentifier
-	private let fullVersionChecker: FullVersionChecker
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 
-	init(metadata: ItemMetadata, domainIdentifier: NSFileProviderDomainIdentifier, newestVersionLocallyCached: Bool = false, localURL: URL? = nil, error: Error? = nil, fullVersionChecker: FullVersionChecker = GlobalFullVersionChecker.default) {
+	init(metadata: ItemMetadata, domainIdentifier: NSFileProviderDomainIdentifier, newestVersionLocallyCached: Bool = false, localURL: URL? = nil, error: Error? = nil) {
 		self.metadata = metadata
 		self.domainIdentifier = domainIdentifier
 		self.error = error
 		self.newestVersionLocallyCached = newestVersionLocallyCached
 		self.localURL = localURL
-		self.fullVersionChecker = fullVersionChecker
 	}
 
 	public var itemIdentifier: NSFileProviderItemIdentifier {

--- a/CryptomatorFileProvider/RootFileProviderItem.swift
+++ b/CryptomatorFileProvider/RootFileProviderItem.swift
@@ -7,6 +7,7 @@
 //
 
 import CryptomatorCommonCore
+import Dependencies
 import FileProvider
 import Foundation
 import MobileCoreServices
@@ -25,12 +26,5 @@ public class RootFileProviderItem: NSObject, NSFileProviderItem {
 		}
 	}
 
-	private let fullVersionChecker: FullVersionChecker
-	override public convenience init() {
-		self.init(fullVersionChecker: GlobalFullVersionChecker.default)
-	}
-
-	init(fullVersionChecker: FullVersionChecker) {
-		self.fullVersionChecker = fullVersionChecker
-	}
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 }

--- a/CryptomatorFileProvider/ServiceSource/FileImportingServiceSource.swift
+++ b/CryptomatorFileProvider/ServiceSource/FileImportingServiceSource.swift
@@ -8,6 +8,7 @@
 
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
+import Dependencies
 import FileProvider
 import Foundation
 
@@ -17,7 +18,7 @@ public class FileImportingServiceSource: ServiceSource, FileImporting {
 	private let dbPath: URL
 	private let localURLProvider: LocalURLProviderType
 	private let adapterManager: FileProviderAdapterProviding
-	private let fullVersionChecker: FullVersionChecker
+	@Dependency(\.fullVersionChecker) private var fullVersionChecker
 	private let taskRegistrator: SessionTaskRegistrator
 
 	public convenience init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType, dbPath: URL, delegate: LocalURLProviderType, taskRegistrator: SessionTaskRegistrator) {
@@ -26,17 +27,15 @@ public class FileImportingServiceSource: ServiceSource, FileImporting {
 		          dbPath: dbPath,
 		          delegate: delegate,
 		          adapterManager: FileProviderAdapterManager.shared,
-		          fullVersionChecker: GlobalFullVersionChecker.default,
 		          taskRegistrator: taskRegistrator)
 	}
 
-	init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType, dbPath: URL, delegate: LocalURLProviderType, adapterManager: FileProviderAdapterProviding, fullVersionChecker: FullVersionChecker, taskRegistrator: SessionTaskRegistrator) {
+	init(domain: NSFileProviderDomain, notificator: FileProviderNotificatorType, dbPath: URL, delegate: LocalURLProviderType, adapterManager: FileProviderAdapterProviding, taskRegistrator: SessionTaskRegistrator) {
 		self.domain = domain
 		self.notificator = notificator
 		self.dbPath = dbPath
 		self.localURLProvider = delegate
 		self.adapterManager = adapterManager
-		self.fullVersionChecker = fullVersionChecker
 		self.taskRegistrator = taskRegistrator
 		super.init(serviceName: .fileImporting, exportedInterface: NSXPCInterface(with: FileImporting.self))
 	}

--- a/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
@@ -10,6 +10,7 @@ import CryptomatorCloudAccessCore
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
+@testable import Dependencies
 @testable import Promises
 
 class FileImportingServiceSourceTests: XCTestCase {
@@ -21,7 +22,7 @@ class FileImportingServiceSourceTests: XCTestCase {
 	var taskRegistratorMock: SessionTaskRegistratorMock!
 	let dbPath = FileManager.default.temporaryDirectory
 	let domain = NSFileProviderDomain(identifier: .test, displayName: "Foo", pathRelativeToDocumentStorage: "/")
-	let itemStub = FileProviderItem(metadata: .init(name: "Foo", type: .file, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: CloudPath("/foo"), isPlaceholderItem: false), domainIdentifier: .test, fullVersionChecker: FullVersionCheckerMock())
+	let itemStub = FileProviderItem(metadata: .init(name: "Foo", type: .file, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: CloudPath("/foo"), isPlaceholderItem: false), domainIdentifier: .test)
 
 	override func setUpWithError() throws {
 		notificatorMock = FileProviderNotificatorTypeMock()
@@ -29,13 +30,13 @@ class FileImportingServiceSourceTests: XCTestCase {
 		adapterProvidingMock = FileProviderAdapterProvidingMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 		taskRegistratorMock = SessionTaskRegistratorMock()
 		serviceSource = FileImportingServiceSource(domain: domain,
 		                                           notificator: notificatorMock,
 		                                           dbPath: dbPath,
 		                                           delegate: urlProviderMock,
 		                                           adapterManager: adapterProvidingMock,
-		                                           fullVersionChecker: fullVersionCheckerMock,
 		                                           taskRegistrator: taskRegistratorMock)
 	}
 

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -11,6 +11,7 @@ import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
+@testable import Dependencies
 
 class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	let fileCoordinator = NSFileCoordinator()
@@ -27,6 +28,7 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		fileProviderItemUpdateDelegateMock = FileProviderItemUpdateDelegateMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 		taskRegistratorMock = SessionTaskRegistratorMock()
 		adapter = FileProviderAdapter(domainIdentifier: .test,
 		                              uploadTaskManager: uploadTaskManagerMock,
@@ -41,7 +43,6 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		                              coordinator: fileCoordinator,
 		                              notificator: fileProviderItemUpdateDelegateMock,
 		                              localURLProvider: localURLProviderMock,
-		                              fullVersionChecker: fullVersionCheckerMock,
 		                              taskRegistrator: taskRegistratorMock)
 		uploadTaskManagerMock.createNewTaskRecordForClosure = {
 			return UploadTaskRecord(correspondingItem: $0.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil)

--- a/CryptomatorFileProviderTests/FileProviderAdapterManagerTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapterManagerTests.swift
@@ -34,10 +34,6 @@ class FileProviderAdapterManagerTests: XCTestCase {
 		case test
 	}
 
-	override class func setUp() {
-		GlobalFullVersionChecker.default = FullVersionCheckerMock()
-	}
-
 	#warning("TODO: Replace unlockMonitor with mock")
 	override func setUpWithError() throws {
 		masterkeyCacheManagerMock = MasterkeyCacheManagerMock()

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -25,8 +25,8 @@ class FileProviderEnumeratorTestCase: XCTestCase {
 	let dbPath = FileManager.default.temporaryDirectory
 	let domain = NSFileProviderDomain(vaultUID: "VaultUID-12345", displayName: "Test Vault")
 	let items: [FileProviderItem] = [
-		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false), domainIdentifier: .test, fullVersionChecker: FullVersionCheckerMock()),
-		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false), domainIdentifier: .test, fullVersionChecker: FullVersionCheckerMock())
+		.init(metadata: ItemMetadata(id: 2, name: "Test.txt", type: .file, size: 100, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test.txt"), isPlaceholderItem: false), domainIdentifier: .test),
+		.init(metadata: ItemMetadata(id: 3, name: "TestFolder", type: .folder, size: nil, parentID: 1, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/TestFolder"), isPlaceholderItem: false), domainIdentifier: .test)
 	]
 	let deleteItemIdentifiers = [1, 2, 3].map { NSFileProviderItemIdentifier("\($0)") }
 

--- a/CryptomatorFileProviderTests/FileProviderItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderItemTests.swift
@@ -11,6 +11,7 @@ import MobileCoreServices
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
+@testable import Dependencies
 
 class FileProviderItemTests: XCTestCase {
 	func testRootItem() {
@@ -110,50 +111,55 @@ class FileProviderItemTests: XCTestCase {
 	func testUploadingItemRestrictsCapabilityToRead() {
 		let fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, item.capabilities)
 	}
 
 	func testUploadingFolderDoesNotRestrictCapabilities() {
 		let fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 
 		let cloudPath = CloudPath("/test")
 		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual([.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], item.capabilities)
 	}
 
 	func testCapabilitiesForRestrictedVersion() {
 		let fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = false
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, item.capabilities)
 	}
 
 	func testFailedUploadItemCapabilitiesForRestrictedVersion() {
 		let fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = false
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 
 		let cloudPath = CloudPath("/test.txt")
 		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, item.capabilities)
 	}
 
 	func testFailedUploadFolderCapabilitiesForRestrictedVersion() {
 		let fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = false
+		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 
 		let cloudPath = CloudPath("/test")
 		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test, fullVersionChecker: fullVersionCheckerMock)
+		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, item.capabilities)
 	}
 

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
@@ -24,10 +24,6 @@ class CloudTaskExecutorTestCase: XCTestCase {
 	var deleteItemHelper: DeleteItemHelper!
 	var tmpDirectory: URL!
 
-	override class func setUp() {
-		GlobalFullVersionChecker.default = FullVersionCheckerMock()
-	}
-
 	override func setUpWithError() throws {
 		cloudProviderMock = CustomCloudProviderMock()
 		metadataManagerMock = MetadataManagerMock()

--- a/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
@@ -20,10 +20,6 @@ class CacheManagingServiceSourceTests: XCTestCase {
 	let domains = [NSFileProviderDomain(identifier: NSFileProviderDomainIdentifier("1")),
 	               NSFileProviderDomain(identifier: NSFileProviderDomainIdentifier("2"))]
 
-	override class func setUp() {
-		GlobalFullVersionChecker.default = FullVersionCheckerMock()
-	}
-
 	override func setUpWithError() throws {
 		cacheManagerFactoryMock = CachedFileManagerFactoryMock()
 		domainProviderMock = NSFileProviderDomainProviderMock()

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -309,6 +309,7 @@ class FileProviderExtension: NSFileProviderExtension {
 	static var setupIAP: () -> Void = {
 		#if ALWAYS_PREMIUM
 		DDLogDebug("Always activated premium")
+		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
 		#else
 		DDLogDebug("Freemium version")
 		#endif
@@ -323,8 +324,7 @@ class FileProviderExtension: NSFileProviderExtension {
 extension FullVersionCheckerKey: DependencyKey {
 	public static var liveValue: FullVersionChecker {
 		#if ALWAYS_PREMIUM
-		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
-		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
+		return AlwaysActivatedPremium.default
 		#else
 		return UserDefaultsFullVersionChecker.default
 		#endif

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -10,6 +10,7 @@ import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
 import CryptomatorCommonCore
 import CryptomatorFileProvider
+import Dependencies
 import FileProvider
 import MSAL
 
@@ -308,13 +309,26 @@ class FileProviderExtension: NSFileProviderExtension {
 	static var setupIAP: () -> Void = {
 		#if ALWAYS_PREMIUM
 		DDLogDebug("Always activated premium")
-		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
 		#else
 		DDLogDebug("Freemium version")
-		GlobalFullVersionChecker.default = UserDefaultsFullVersionChecker.default
 		#endif
 		return {}
 	}()
+}
+
+/**
+ Define the liveValue in the main target since compilation flags do not work on Swift Package Manager level.
+ Be aware that it is needed to set the default value once per app launch (+ also when launching the FileProviderExtension).
+ */
+extension FullVersionCheckerKey: DependencyKey {
+	public static var liveValue: FullVersionChecker {
+		#if ALWAYS_PREMIUM
+		GlobalFullVersionChecker.default = AlwaysActivatedPremium.default
+		CryptomatorUserDefaults.shared.fullVersionUnlocked = true
+		#else
+		return UserDefaultsFullVersionChecker.default
+		#endif
+	}
 }
 
 enum FileProviderDecoratorSetupError: Error {


### PR DESCRIPTION
Updates `CryptomatorSettings` and the `FullVersionChecker` to use the recently introduced dependency injection framework.

Please test:
- existing full version via IAP gets still correctly recognized (Main App & FileProvider)
- debug mode can be enabled / disabled and internally works
- the always premium version works as expected