### PR TITLE
Run build & test also for Premium configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,14 +2,14 @@ name: Build
 
 on:
   [push]
-env:
-  DERIVED_DATA_PATH: 'DerivedData'
-  DEVICE: 'iPhone 12 Pro'
 
 jobs:
   build:
     name: Build and test
     runs-on: macos-12
+    env:
+      DERIVED_DATA_PATH: 'DerivedData'
+      DEVICE: 'iPhone 12 Pro'
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        version: ['Freemium', 'Premium']
+        config: ['freemium', 'premium']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -30,12 +30,12 @@ jobs:
         run: |
           cd fastlane
           ./scripts/create-cloud-access-secrets.sh
-      - name: Configuration for Freemium
-        if: ${{ matrix.version == 'Freemium' }}
+      - name: Configuration for freemium
+        if: ${{ matrix.config == 'freemium' }}
         run: |
           echo "BUILD_CMD=-enableCodeCoverage YES" >> $GITHUB_ENV
-      - name: Configuration for Premium
-        if: ${{ matrix.version == 'Premium' }}
+      - name: Configuration for premium
+        if: ${{ matrix.config == 'premium' }}
         run: |
           echo "BUILD_CMD=SWIFT_ACTIVE_COMPILATION_CONDITIONS='\$(inherited) ALWAYS_PREMIUM'" >> $GITHUB_ENV
       - name: Build
@@ -43,7 +43,7 @@ jobs:
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -xctestrun $(find . -type f -name "*.xctestrun") -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH | xcpretty
       - name: Upload code coverage report
-        if: ${{ matrix.version == 'Freemium' }}
+        if: ${{ matrix.config == 'freemium' }}
         run: |
           gem install slather
           slather coverage -x  --build-directory $DERIVED_DATA_PATH --ignore "$DERIVED_DATA_PATH/SourcePackages/*" --scheme AllTests Cryptomator.xcodeproj
@@ -51,4 +51,3 @@ jobs:
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         continue-on-error: true
-  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,15 +2,18 @@ name: Build
 
 on:
   [push]
+env:
+  DERIVED_DATA_PATH: 'DerivedData'
+  DEVICE: 'iPhone 14 Pro'
 
 jobs:
   build:
     name: Build and test
-    runs-on: macos-12
-    env:
-      DERIVED_DATA_PATH: 'DerivedData'
-      DEVICE: 'iPhone 12 Pro'
+    runs-on: macos-13
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    strategy:
+      matrix:
+        version: ['Freemium', 'Premium']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3
@@ -27,11 +30,20 @@ jobs:
         run: |
           cd fastlane
           ./scripts/create-cloud-access-secrets.sh
+      - name: Configuration for Freemium
+        if: ${{ matrix.version == 'Freemium' }}
+        run: |
+          echo "BUILD_CMD=-enableCodeCoverage YES" >> $GITHUB_ENV
+      - name: Configuration for Premium
+        if: ${{ matrix.version == 'Premium' }}
+        run: |
+          echo "BUILD_CMD=SWIFT_ACTIVE_COMPILATION_CONDITIONS='\$(inherited) ALWAYS_PREMIUM'" >> $GITHUB_ENV
       - name: Build
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'AllTests' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH -enableCodeCoverage YES | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'AllTests' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH -enableCodeCoverage YES ${{ env.BUILD_CMD }} | xcpretty
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -xctestrun $(find . -type f -name "*.xctestrun") -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH | xcpretty
       - name: Upload code coverage report
+        if: ${{ matrix.version == 'Freemium' }}
         run: |
           gem install slather
           slather coverage -x  --build-directory $DERIVED_DATA_PATH --ignore "$DERIVED_DATA_PATH/SourcePackages/*" --scheme AllTests Cryptomator.xcodeproj
@@ -39,3 +51,4 @@ jobs:
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
         continue-on-error: true
+  

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,12 @@ on:
   [push]
 env:
   DERIVED_DATA_PATH: 'DerivedData'
-  DEVICE: 'iPhone 14 Pro'
+  DEVICE: 'iPhone 12 Pro'
 
 jobs:
   build:
     name: Build and test
-    runs-on: macos-13
+    runs-on: macos-12
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: |
           echo "BUILD_CMD=SWIFT_ACTIVE_COMPILATION_CONDITIONS='\$(inherited) ALWAYS_PREMIUM'" >> $GITHUB_ENV
       - name: Build
-        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'AllTests' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH -enableCodeCoverage YES ${{ env.BUILD_CMD }} | xcpretty
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild clean build-for-testing -scheme 'AllTests' -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH ${{ env.BUILD_CMD }} | xcpretty
       - name: Test
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild test-without-building -xctestrun $(find . -type f -name "*.xctestrun") -destination "name=$DEVICE" -derivedDataPath $DERIVED_DATA_PATH | xcpretty
       - name: Upload code coverage report


### PR DESCRIPTION
Due to the recent issues where it was forgotten to update some code related to the `ALWAYS_PREMIUM `compilation condition in #323, I thought it might make sense to also run the build & test steps for the Premium version as well.
This would allow us to catch compilation issues related the premium version earlier. 
Also those jobs run in parallel so the additional overhead should be minimal.
