### PR TITLE
CI Update: Use macOS 14 runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
           restore-keys: |
             ${{ runner.os }}-spm-
+      - name: Install SwiftLint
+        run: brew install swiftlint
       - name: Run process.sh script
         run: |
           ./Scripts/process.sh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,17 +6,17 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: macos-13
+    runs-on: macos-14
     env:
       DERIVED_DATA_PATH: 'DerivedData'
-      DEVICE: 'iPhone 14 Pro'
+      DEVICE: 'iPhone 15 Pro'
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
         config: ['freemium', 'premium']
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
         with:
           path: .build
           key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') }}
@@ -30,8 +30,8 @@ jobs:
         run: |
           cd fastlane
           ./scripts/create-cloud-access-secrets.sh
-      - name: Select Xcode 15.1
-        run: sudo xcode-select -s /Applications/Xcode_15.1.app
+      - name: Select Xcode 15.2
+        run: sudo xcode-select -s /Applications/Xcode_15.2.app
       - name: Configuration for freemium
         if: ${{ matrix.config == 'freemium' }}
         run: |


### PR DESCRIPTION
On January 30, 2024, Github [introduced](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) the macOS Sonoma image and made it possible to [use M1 macOS Runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source).

As before the runner is available for free in public repositories:
> This runner is available for all plans, free in public repositories, and eligible to consume included free plan minutes in private repositories.

In addition I've did minor upgrades to the used actions:
- bumped `actions/checkout` to `v4`
- bumped `actions/cache` to `v4`

And to the used Xcode version: `15.1`-> `15.2`.

The only downside is that the new arm64 based image does not have SwiftLint pre-installed therefore I've added an additional step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI/CD workflow to improve build performance and compatibility.
		- macOS version for runs updated.
		- Device set to 'iPhone 15 Pro' for testing.
		- Updated actions for better efficiency.
		- Added SwiftLint installation for code quality checks.
		- Switched to Xcode version 15.2 for builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->