### PR TITLE
Fix background URLSession identifier collisions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,8 +31,8 @@ jobs:
         run: |
           cd fastlane
           ./scripts/create-cloud-access-secrets.sh
-      - name: Select Xcode 15.2
-        run: sudo xcode-select -s /Applications/Xcode_15.2.app
+      - name: Select Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app
       - name: Configuration for freemium
         if: ${{ matrix.config == 'freemium' }}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,11 +6,10 @@ on:
 jobs:
   build:
     name: Build and test
-    runs-on: macos-14
+    runs-on: [self-hosted, macOS, ARM64]
     env:
       DERIVED_DATA_PATH: 'DerivedData'
       DEVICE: 'iPhone 15 Pro'
-    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
         config: ['freemium', 'premium']

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cryptomator/cloud-access-swift.git",
       "state" : {
-        "revision" : "bb9cc1c300be890f3a47efa0ac0808ee7c42146d",
-        "version" : "1.9.2"
+        "branch" : "feature/unique-identifier-bg-session",
+        "revision" : "c00d647ea80801eee8e9cc7e7c4222e4dec17151"
       }
     },
     {

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cryptomator/cloud-access-swift.git",
       "state" : {
-        "branch" : "feature/unique-identifier-bg-session",
-        "revision" : "c00d647ea80801eee8e9cc7e7c4222e4dec17151"
+        "revision" : "cd7a18abcaf09349f066363c7524b738f4f4ad79",
+        "version" : "1.10.1"
       }
     },
     {

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -40,13 +40,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		// Set up cloud storage services
 		DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: nil, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: true)
 		GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: nil)
-		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
-		oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
 		do {
-			OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
+			oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
+			let oneDriveClientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			OneDriveSetup.constants = OneDriveSetup(clientApplication: oneDriveClientApplication, sharedContainerIdentifier: nil)
 		} catch {
 			DDLogError("Setting up OneDrive failed with error: \(error)")
 		}
+		PCloudSetup.constants = PCloudSetup(appKey: CloudAccessSecrets.pCloudAppKey, sharedContainerIdentifier: nil)
 
 		// Set up payment queue
 		SKPaymentQueue.default().add(StoreObserver.shared)

--- a/Cryptomator/AppDelegate.swift
+++ b/Cryptomator/AppDelegate.swift
@@ -38,7 +38,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 		cleanup()
 
 		// Set up cloud storage services
-		CloudProviderDBManager.shared.useBackgroundSession = false
 		DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: nil, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: true)
 		GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: nil)
 		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)

--- a/Cryptomator/Common/CloudAuthenticator.swift
+++ b/Cryptomator/Common/CloudAuthenticator.swift
@@ -52,8 +52,7 @@ class CloudAuthenticator {
 	}
 
 	func authenticatePCloud(from viewController: UIViewController) -> Promise<CloudProviderAccount> {
-		let authenticator = PCloudAuthenticator(appKey: CloudAccessSecrets.pCloudAppKey)
-		return authenticator.authenticate(from: viewController).then { credential -> CloudProviderAccount in
+		return PCloudAuthenticator.authenticate(from: viewController).then { credential -> CloudProviderAccount in
 			try credential.saveToKeychain()
 			let account = CloudProviderAccount(accountUID: credential.userID, cloudProviderType: .pCloud)
 			try self.accountManager.saveNewAccount(account)

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", branch: "feature/unique-identifier-bg-session"),
+		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.10.0")),
 		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.8.0")),
 		.package(url: "https://github.com/PhilLibs/simple-swift-dependencies", .upToNextMajor(from: "0.1.0")),
 		.package(url: "https://github.com/siteline/SwiftUI-Introspect.git", .upToNextMajor(from: "0.3.0")),

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
 		)
 	],
 	dependencies: [
-		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "1.9.0")),
+		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", branch: "feature/unique-identifier-bg-session"),
 		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.8.0")),
 		.package(url: "https://github.com/PhilLibs/simple-swift-dependencies", .upToNextMajor(from: "0.1.0")),
 		.package(url: "https://github.com/siteline/SwiftUI-Introspect.git", .upToNextMajor(from: "0.3.0")),

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
@@ -98,14 +98,12 @@ public class CloudProviderDBManager: CloudProviderManager, CloudProviderUpdating
 		return provider
 	}
 
-	// swiftlint:disable:next orphaned_doc_comment
 	/**
 	 Creates and returns a cloud provider for the given `accountUID` using a background URLSession with the given `sessionIdentifier`.
 
 	 The number of returned items from a `fetchItemList(forFolderAt:pageToken:)` call is limited to 500.
 	 This is necessary because otherwise memory limit problems can occur with folders with many items in the `FileProviderExtension` where a background `URLSession` is used.
 	 */
-	// swiftlint:disable:next function_body_length
 	func createBackgroundSessionProvider(for accountUID: String, sessionIdentifier: String) throws -> CloudProvider {
 		let cloudProviderType = try accountManager.getCloudProviderType(for: accountUID)
 		let provider: CloudProvider
@@ -116,32 +114,17 @@ public class CloudProviderDBManager: CloudProviderManager, CloudProviderUpdating
 			provider = DropboxCloudProvider(credential: credential, maxPageSize: maxPageSizeForFileProvider)
 		case .googleDrive:
 			let credential = GoogleDriveCredential(userID: accountUID)
-			provider = try GoogleDriveCloudProvider.withBackgroundSession(
-				credential: credential,
-				maxPageSize: maxPageSizeForFileProvider,
-				sessionIdentifier: sessionIdentifier
-			)
+			provider = try GoogleDriveCloudProvider.withBackgroundSession(credential: credential, maxPageSize: maxPageSizeForFileProvider, sessionIdentifier: sessionIdentifier)
 		case .oneDrive:
 			let credential = try OneDriveCredential(with: accountUID)
-			provider = try OneDriveCloudProvider.withBackgroundSession(
-				credential: credential,
-				maxPageSize: maxPageSizeForFileProvider,
-				sessionIdentifier: sessionIdentifier
-			)
+			provider = try OneDriveCloudProvider.withBackgroundSession(credential: credential, maxPageSize: maxPageSizeForFileProvider, sessionIdentifier: sessionIdentifier)
 		case .pCloud:
 			let credential = try PCloudCredential(userID: accountUID)
-			let client = PCloud.createBackgroundClient(
-				with: credential.user,
-				sessionIdentifier: sessionIdentifier
-			)
+			let client = PCloud.createBackgroundClient(with: credential.user, sessionIdentifier: sessionIdentifier)
 			provider = try PCloudCloudProvider(client: client)
 		case .webDAV:
 			let credential = try getWebDAVCredential(for: accountUID)
-			let client = WebDAVClient.withBackgroundSession(
-				credential: credential,
-				sessionIdentifier: sessionIdentifier,
-				sharedContainerIdentifier: CryptomatorConstants.appGroupName
-			)
+			let client = WebDAVClient.withBackgroundSession(credential: credential, sessionIdentifier: sessionIdentifier, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
 			provider = try WebDAVProvider(with: client, maxPageSize: maxPageSizeForFileProvider)
 		case .localFileSystem:
 			guard let rootURL = try LocalFileSystemBookmarkManager.getBookmarkedRootURL(for: accountUID) else {

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
@@ -119,22 +119,20 @@ public class CloudProviderDBManager: CloudProviderManager, CloudProviderUpdating
 			provider = try GoogleDriveCloudProvider.withBackgroundSession(
 				credential: credential,
 				maxPageSize: maxPageSizeForFileProvider,
-				sessionIdentifier: sessionIdentifier,
-				sharedContainerIdentifier: CryptomatorConstants.appGroupName
+				sessionIdentifier: sessionIdentifier
 			)
 		case .oneDrive:
 			let credential = try OneDriveCredential(with: accountUID)
 			provider = try OneDriveCloudProvider.withBackgroundSession(
 				credential: credential,
 				maxPageSize: maxPageSizeForFileProvider,
-				identifier: sessionIdentifier
+				sessionIdentifier: sessionIdentifier
 			)
 		case .pCloud:
 			let credential = try PCloudCredential(userID: accountUID)
 			let client = PCloud.createBackgroundClient(
 				with: credential.user,
-				sessionIdentifier: sessionIdentifier,
-				sharedContainerIdentifier: CryptomatorConstants.appGroupName
+				sessionIdentifier: sessionIdentifier
 			)
 			provider = try PCloudCloudProvider(client: client)
 		case .webDAV:

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/CloudProviderDBManager.swift
@@ -52,7 +52,7 @@ public class CloudProviderDBManager: CloudProviderManager, CloudProviderUpdating
 		}) {
 			return entry.provider
 		}
-		return try createProvider(for: accountUID)
+		return try createBackgroundSessionProvider(for: accountUID, sessionIdentifier: sessionIdentifier)
 	}
 
 	/**

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBManager.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/Manager/VaultDBManager.swift
@@ -483,7 +483,8 @@ public class VaultDBManager: VaultManager {
 	private func createVaultProvider(cachedVault: CachedVault, masterkey: Masterkey, masterkeyFile: MasterkeyFile) throws -> CloudProvider {
 		let vaultUID = cachedVault.vaultUID
 		let vaultAccount = try vaultAccountManager.getAccount(with: vaultUID)
-		let provider = try providerManager.getProvider(with: vaultAccount.delegateAccountUID)
+		// it's important to use the vaultUID as background URLSession identifier to avoid identifier collisions
+		let provider = try providerManager.getBackgroundSessionProvider(with: vaultAccount.delegateAccountUID, sessionIdentifier: vaultUID)
 		let decorator: CloudProvider
 		if let vaultConfigToken = cachedVault.vaultConfigToken {
 			let unverifiedVaultConfig = try UnverifiedVaultConfig(token: vaultConfigToken)

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderManagerTests.swift
@@ -25,12 +25,12 @@ class CloudProviderManagerTests: XCTestCase {
 		DropboxSetup.constants = DropboxSetup(appKey: "", sharedContainerIdentifier: nil, keychainService: nil, forceForegroundSession: false)
 		let account = CloudProviderAccount(accountUID: UUID().uuidString, cloudProviderType: .dropbox)
 		try accountManager.saveNewAccount(account)
-		XCTAssertNil(CloudProviderDBManager.cachedProvider[account.accountUID])
+		XCTAssert(CloudProviderDBManager.cachedProvider.isEmpty)
 		let provider = try manager.getProvider(with: account.accountUID)
 		guard provider is DropboxCloudProvider else {
 			XCTFail("Provider has wrong type")
 			return
 		}
-		XCTAssertNotNil(CloudProviderDBManager.cachedProvider[account.accountUID])
+		XCTAssertEqual(CloudProviderDBManager.cachedProvider.filter { $0.accountUID == account.accountUID }.count, 1)
 	}
 }

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -210,7 +210,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 					}
 					return completionHandler(nil, NSFileProviderError(.noSuchItem))
 				}
-				let localImportHandler: Error? -> Void = { error in
+				let localImportHandler: (Error?) -> Void = { error in
 					if let error = error {
 						completionHandler(nil, error)
 					} else {

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -210,7 +210,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 					}
 					return completionHandler(nil, NSFileProviderError(.noSuchItem))
 				}
-				let localImportHandler: (Error?) -> Void = { error in
+				let localImportHandler: Error? -> Void = { error in
 					if let error = error {
 						completionHandler(nil, error)
 					} else {

--- a/FileProviderExtension/FileProviderExtension.swift
+++ b/FileProviderExtension/FileProviderExtension.swift
@@ -30,10 +30,11 @@ class FileProviderExtension: NSFileProviderExtension {
 				FileProviderExtension.sharedDatabaseInitialized = true
 				DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: CryptomatorConstants.appGroupName, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: false)
 				GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
-				OneDriveSetup.sharedContainerIdentifier = CryptomatorConstants.appGroupName
 				let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
 				oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
-				OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+				let oneDriveClientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+				OneDriveSetup.constants = OneDriveSetup(clientApplication: oneDriveClientApplication, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
+				PCloudSetup.constants = PCloudSetup(appKey: CloudAccessSecrets.pCloudAppKey, sharedContainerIdentifier: CryptomatorConstants.appGroupName)
 			} catch {
 				// MARK: Handle error
 

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -61,7 +61,6 @@ class RootViewController: FPUIActionExtensionViewController {
 		LoggerSetup.oneTimeSetup()
 
 		// Set up cloud storage services
-		CloudProviderDBManager.shared.useBackgroundSession = false
 		DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: nil, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: true)
 		GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: nil)
 		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)

--- a/FileProviderExtensionUI/RootViewController.swift
+++ b/FileProviderExtensionUI/RootViewController.swift
@@ -63,13 +63,15 @@ class RootViewController: FPUIActionExtensionViewController {
 		// Set up cloud storage services
 		DropboxSetup.constants = DropboxSetup(appKey: CloudAccessSecrets.dropboxAppKey, sharedContainerIdentifier: nil, keychainService: CryptomatorConstants.mainAppBundleId, forceForegroundSession: true)
 		GoogleDriveSetup.constants = GoogleDriveSetup(clientId: CloudAccessSecrets.googleDriveClientId, redirectURL: CloudAccessSecrets.googleDriveRedirectURL!, sharedContainerIdentifier: nil)
-		let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
-		oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
 		do {
-			OneDriveSetup.clientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			let oneDriveConfiguration = MSALPublicClientApplicationConfig(clientId: CloudAccessSecrets.oneDriveClientId, redirectUri: CloudAccessSecrets.oneDriveRedirectURI, authority: nil)
+			oneDriveConfiguration.cacheConfig.keychainSharingGroup = CryptomatorConstants.mainAppBundleId
+			let oneDriveClientApplication = try MSALPublicClientApplication(configuration: oneDriveConfiguration)
+			OneDriveSetup.constants = OneDriveSetup(clientApplication: oneDriveClientApplication, sharedContainerIdentifier: nil)
 		} catch {
 			DDLogError("Setting up OneDrive failed with error: \(error)")
 		}
+		PCloudSetup.constants = PCloudSetup(appKey: CloudAccessSecrets.pCloudAppKey, sharedContainerIdentifier: nil)
 		return {}
 	}()
 


### PR DESCRIPTION
This PR fixes #345.
It currently relies on the `cloud-access-swift` branch and can be used right now to test the PR: https://github.com/cryptomator/cloud-access-swift/pull/33

Those changes are needed since issues appeared in the `FileProviderExtension` where we tried to use the same credential, which we usually used to make the identifier unique, for multiple vaults. Therefore, it was possible that more than one background `URLSession` gets created with the same identifier which then results in a failing `URLSession`.

Previously we could workaround this issue by just cache each `CloudProvider` but it seems like iOS creates now a own process for each domain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Improved background session handling in CloudProviderDBManager for enhanced performance.
  - Enhanced vault provider creation in VaultDBManager for better session management.

- **Improvements**
  - Updated methods for creating cloud providers to optimize performance.
  - Streamlined background session provider retrieval for improved efficiency.

- **Bug Fixes**
  - Addressed potential collisions in background URLSession identifiers to prevent issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->