### PR TITLE
Remove change password section for Hub Vaults

### DIFF
--- a/Cryptomator/VaultDetail/VaultDetailViewModel.swift
+++ b/Cryptomator/VaultDetail/VaultDetailViewModel.swift
@@ -85,11 +85,20 @@ class VaultDetailViewModel: VaultDetailViewModelProtocol {
 	private var subscribers = Set<AnyCancellable>()
 
 	private lazy var sections: [VaultDetailSection] = {
+		var sections: [VaultDetailSection] = [.vaultInfoSection, .lockingSection]
+
 		if vaultIsEligibleToMove() {
-			return [.vaultInfoSection, .lockingSection, .moveVaultSection, .changeVaultPasswordSection, .removeVaultSection]
-		} else {
-			return [.vaultInfoSection, .lockingSection, .changeVaultPasswordSection, .removeVaultSection]
+			sections.append(.moveVaultSection)
 		}
+
+		if vaultInfo.vaultConfigType != .hub {
+			sections.append(.changeVaultPasswordSection)
+		}
+
+		// Ensure removeVaultSection is always the last element
+		sections.append(.removeVaultSection)
+
+		return sections
 	}()
 
 	private lazy var lockButton: ButtonCellViewModel<VaultDetailButtonAction> = {

--- a/Cryptomator/VaultList/VaultInfo.swift
+++ b/Cryptomator/VaultList/VaultInfo.swift
@@ -57,6 +57,16 @@ public class VaultInfo: Decodable, FetchableRecord {
 			vaultListPosition.position = newValue
 		}
 	}
+
+	var vaultConfigType: VaultConfigType {
+		if let cachedVault = try? VaultDBCache().getCachedVault(withVaultUID: vaultUID),
+		   let vaultConfigToken = cachedVault.vaultConfigToken,
+		   let unverifiedVaultConfig = try? UnverifiedVaultConfig(token: vaultConfigToken) {
+			return VaultConfigHelper.getType(for: unverifiedVaultConfig)
+		} else {
+			return .unknown
+		}
+	}
 }
 
 extension VaultInfo: Equatable {


### PR DESCRIPTION
Fixes issue #360 where the "Change password" option is shown despite Hub not relying on passwords for key derivation.