### PR TITLE
Fix typo issue at .github/SUPPORT.md

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -14,5 +14,5 @@ For _everything else_, please visit our official [Cryptomator Community](https:/
   - Discussions about the apps
 - [Development discussions](https://community.cryptomator.org/c/development)
   - General questions
-  - Discussions regarding our design decissions
+  - Discussions regarding our design decisions
   - Our roadmap


### PR DESCRIPTION
Fix typo issue at .github/SUPPORT.md from `decissions` to `decisions`