### PR TITLE
Fix copy-paste error for files with non-ASCII names (NFC normalization)

### DIFF
--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -547,7 +547,8 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		let name: String
 		if let newName = newName {
 			try validateItemName(newName)
-			name = newName
+			// Normalize to NFC — iOS URLs use NFD, and SQLite compares bytes, not Unicode equivalence.
+			name = newName.precomposedStringWithCanonicalMapping
 		} else {
 			name = itemMetadata.name
 		}
@@ -824,9 +825,12 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		if typeFile == FileAttributeType.typeDirectory {
 			throw FileProviderAdapterError.folderUploadNotSupported
 		}
-		let cloudPath = try getCloudPathForPlaceholderItem(withName: localURL.lastPathComponent, in: parentID, type: .file)
+		// Normalize to NFC so the collision check matches cloud-fetched (NFC) entries in the DB.
+		// iOS file URLs use NFD, and SQLite compares bytes — without this, non-ASCII names bypass the collision check.
+		let name = localURL.lastPathComponent.precomposedStringWithCanonicalMapping
+		let cloudPath = try getCloudPathForPlaceholderItem(withName: name, in: parentID, type: .file)
 		try checkLocalItemCollision(for: cloudPath)
-		let placeholderMetadata = ItemMetadata(name: localURL.lastPathComponent, type: .file, size: size, parentID: parentID, lastModifiedDate: lastModifiedDate, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true)
+		let placeholderMetadata = ItemMetadata(name: name, type: .file, size: size, parentID: parentID, lastModifiedDate: lastModifiedDate, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true)
 		try itemMetadataManager.cacheMetadata(placeholderMetadata)
 		return placeholderMetadata
 	}
@@ -840,9 +844,12 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	 */
 	func createPlaceholderItemForFolder(withName name: String, in parentIdentifier: NSFileProviderItemIdentifier) throws -> FileProviderItem {
 		let parentID = try convertFileProviderItemIdentifierToInt64(parentIdentifier)
-		let cloudPath = try getCloudPathForPlaceholderItem(withName: name, in: parentID, type: .folder)
+		// Normalize to NFC so the collision check matches cloud-fetched (NFC) entries in the DB.
+		// iOS file URLs use NFD, and SQLite compares bytes — without this, non-ASCII names bypass the collision check.
+		let normalizedName = name.precomposedStringWithCanonicalMapping
+		let cloudPath = try getCloudPathForPlaceholderItem(withName: normalizedName, in: parentID, type: .folder)
 		try checkLocalItemCollision(for: cloudPath)
-		let placeholderMetadata = ItemMetadata(name: name, type: .folder, size: nil, parentID: parentID, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true)
+		let placeholderMetadata = ItemMetadata(name: normalizedName, type: .folder, size: nil, parentID: parentID, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: true)
 		try itemMetadataManager.cacheMetadata(placeholderMetadata)
 		return FileProviderItem(metadata: placeholderMetadata, domainIdentifier: domainIdentifier, newestVersionLocallyCached: true)
 	}

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
@@ -268,6 +268,36 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 		assertLocalURLProviderCalledWithItemID()
 	}
 
+	// MARK: Unicode Normalization
+
+	func testLocalItemImportNormalizesNFDFilenameToNFC() throws {
+		let permissionProviderMock = PermissionProviderMock()
+		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
+		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+
+		// Create a file with an NFD filename (decomposed Unicode: o + combining diaeresis)
+		let nfdName = "Erh\u{006F}\u{0308}hung.pdf"
+		let nfcName = "Erhöhung.pdf"
+		// Sanity check: NFD and NFC are different byte sequences but equal in Swift
+		XCTAssertEqual(nfdName, nfcName)
+		XCTAssertNotEqual(Array(nfdName.utf8), Array(nfcName.utf8))
+
+		let fileURL = tmpDirectory.appendingPathComponent(nfdName, isDirectory: false)
+		try "test".write(to: fileURL, atomically: true, encoding: .utf8)
+
+		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+
+		let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
+
+		// The stored name and cloudPath must use NFC (precomposed), not NFD
+		let storedName = result.item.filename
+		XCTAssertEqual(Array(storedName.utf8), Array(nfcName.utf8), "Filename should be stored in NFC form")
+
+		let storedCloudPath = result.item.metadata.cloudPath.path
+		XCTAssertEqual(Array(storedCloudPath.utf8), Array("/\(nfcName)".utf8), "CloudPath should be stored in NFC form")
+	}
+
 	private func assertLocalURLProviderCalledWithItemID() {
 		XCTAssertEqual([NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: itemID)], localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReceivedInvocations)
 	}


### PR DESCRIPTION
When copy-pasting a file with non-ASCII characters (e.g., German umlauts) within the same vault folder, the first paste showed an "Error" file. A second paste succeeded with a " 2" suffix. The root cause: iOS file URLs use NFD (decomposed) Unicode, while cloud-fetched metadata stored in SQLite uses NFC (precomposed). Since SQLite compares strings as raw bytes — not Unicode canonical equivalence — the collision check in `checkLocalItemCollision` failed to match the existing NFC entry against the incoming NFD name. This caused a duplicate DB row and a broken upload state.

The fix normalizes filenames to NFC (`precomposedStringWithCanonicalMapping`) at the three entry points where external names enter the metadata layer: file import, folder creation, and rename/reparent. This mirrors the approach used by Java `cryptofs`, which normalizes at the path factory level.