### PR TITLE
Investigation: Hardcoded CloudPath

### DIFF
--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterMoveItemTests.swift
@@ -128,6 +128,51 @@ class FileProviderAdapterMoveItemTests: FileProviderAdapterTestCase {
 		XCTAssertEqual(targetCloudPath, reparentTaskRecord.targetCloudPath)
 	}
 
+	func testMoveFolderLocallyUpdatesDescendantCloudPaths() throws {
+		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+
+		let sourceParentID: Int64 = 2
+		let movedFolderID: Int64 = 3
+		let childFileID: Int64 = 4
+		let targetParentID: Int64 = 5
+
+		// Initial tree:
+		// /
+		// |- A/
+		// |  |- B/
+		// |     |- C.txt
+		// |- Target/
+		let sourceParent = ItemMetadata(id: sourceParentID, name: "A", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/A/"), isPlaceholderItem: false)
+		let movedFolder = ItemMetadata(id: movedFolderID, name: "B", type: .folder, size: nil, parentID: sourceParentID, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/A/B/"), isPlaceholderItem: false)
+		let childFile = ItemMetadata(id: childFileID, name: "C.txt", type: .file, size: 100, parentID: movedFolderID, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/A/B/C.txt"), isPlaceholderItem: false)
+		let targetParent = ItemMetadata(id: targetParentID, name: "Target", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Target/"), isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata([sourceParent, movedFolder, childFile, targetParent])
+
+		let movedFolderIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: movedFolderID)
+		let targetParentIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: targetParentID)
+
+		// Move B from /A/B/ to /Target/B/.
+		// The important part is that descendants must follow that move as well in the database.
+		_ = try adapter.moveItemLocally(withIdentifier: movedFolderIdentifier, toParentItemWithIdentifier: targetParentIdentifier, newName: nil)
+
+		// Sanity check for the folder row itself.
+		XCTAssertEqual(CloudPath("/Target/B/"), movedFolder.cloudPath)
+		XCTAssertEqual(targetParentID, movedFolder.parentID)
+
+		// Regression check:
+		// If cloudPath is effectively hardcoded per row and only the moved folder row is updated,
+		// the child would incorrectly stay at /A/B/C.txt even though its parent is now /Target/B/.
+		// We expect the descendant path prefix to be rewritten to keep parentID and cloudPath in sync.
+		// Otherwise path-based metadata lookups, subtree queries, enumeration, deletion bookkeeping,
+		// and follow-up remote operations can use the stale location.
+		// This does not directly corrupt the local cached-file table because that is keyed by item id/local URL.
+		let updatedChild = try XCTUnwrap(metadataManagerMock.getCachedMetadata(for: childFileID))
+		XCTAssertEqual(CloudPath("/Target/B/C.txt"), updatedChild.cloudPath)
+		XCTAssertEqual(movedFolderID, updatedChild.parentID)
+		XCTAssertNil(try metadataManagerMock.getCachedMetadata(for: CloudPath("/A/B/C.txt")))
+	}
+
 	func testRenameItem() throws {
 		let expectation = XCTestExpectation()
 


### PR DESCRIPTION
This PR adds a regression test around a suspected File Provider metadata inconsistency when moving folders with descendants.

The current schema stores `cloudPath` redundantly on each `itemMetadata` row. When a folder is moved locally, the moved folder row is updated, but descendants may keep their previous `cloudPath`. That would leave `parentID` and `cloudPath` out of sync for children. In practice, this could affect path-based metadata lookups, subtree queries, enumeration/reconciliation, deletion bookkeeping, and later remote operations on descendants.

The new test documents the expected behavior for a tree like `A -> B -> C.txt`: after moving `B`, descendant paths should also be rewritten in the metadata layer. This PR does not fix the issue yet; it is intended to make the suspected failure mode explicit so we can investigate the actual runtime behavior and choose the right remediation.

⚠️ This does not yet add a fix since we should first evaluate if this makes a real difference. In case we come to the conclusion a fix would be to derived the path by walking the item graph