### PR TITLE
Add shortcut to clear cache

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -389,8 +389,6 @@
 		7408E6CD26779BCC00D7FAEA /* AboutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7408E6CC26779BCC00D7FAEA /* AboutViewModel.swift */; };
 		740D367E266A18DF0058744D /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D367D266A18DF0058744D /* SettingsViewController.swift */; };
 		740D3682266A19150058744D /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D3681266A19150058744D /* SettingsViewModel.swift */; };
-		74E1A1A32E02600000C0D001 /* XPCCacheController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A22E02600000C0D001 /* XPCCacheController.swift */; };
-		74E1A1A12E02500000C0D001 /* ClearCacheAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */; };
 		740D3684266A1B180058744D /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D3683266A1B180058744D /* SettingsCoordinator.swift */; };
 		742679FC26A56CF9004C61BC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 742679F926A56B33004C61BC /* Localizable.strings */; };
 		742679FD26A56CFA004C61BC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 742679F926A56B33004C61BC /* Localizable.strings */; };
@@ -440,6 +438,9 @@
 		74C2BC5626E9098500BCAA03 /* UpgradeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C2BC5526E9098500BCAA03 /* UpgradeViewModel.swift */; };
 		74C2FCED27E2197D00BB527A /* PCloudKeychainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C2FCEC27E2197D00BB527A /* PCloudKeychainTests.swift */; };
 		74D365BA268B5DB0005ECD69 /* FilesAppUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D365B9268B5DB0005ECD69 /* FilesAppUtil.swift */; };
+		74E1A1A12E02500000C0D001 /* ClearCacheAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */; };
+		74E1A1A32E02600000C0D001 /* XPCCacheController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A22E02600000C0D001 /* XPCCacheController.swift */; };
+		74E1A1A52E02700000C0D001 /* XPCCacheControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A42E02700000C0D001 /* XPCCacheControllerTests.swift */; };
 		74F5DC1C26DCD2FB00AFE989 /* StoreObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F5DC1B26DCD2FB00AFE989 /* StoreObserver.swift */; };
 		74F5DC1F26DD036D00AFE989 /* StoreManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F5DC1E26DD036D00AFE989 /* StoreManager.swift */; };
 		74FC576125ADED030003ED27 /* VaultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74FC576025ADED030003ED27 /* VaultCell.swift */; };
@@ -979,8 +980,6 @@
 		7408E6CC26779BCC00D7FAEA /* AboutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewModel.swift; sourceTree = "<group>"; };
 		740D367D266A18DF0058744D /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		740D3681266A19150058744D /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
-		74E1A1A22E02600000C0D001 /* XPCCacheController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCCacheController.swift; sourceTree = "<group>"; };
-		74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearCacheAppIntent.swift; sourceTree = "<group>"; };
 		740D3683266A1B180058744D /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		741CD1C82939080D00577FDE /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		741CD1CF2939083C00577FDE /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Intents.strings; sourceTree = "<group>"; };
@@ -1072,6 +1071,9 @@
 		74C2FCEC27E2197D00BB527A /* PCloudKeychainTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PCloudKeychainTests.swift; sourceTree = "<group>"; };
 		74D365B9268B5DB0005ECD69 /* FilesAppUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilesAppUtil.swift; sourceTree = "<group>"; };
 		74DFF9DA26DF87A0009981ED /* ro */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ro; path = ro.lproj/Localizable.strings; sourceTree = "<group>"; };
+		74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearCacheAppIntent.swift; sourceTree = "<group>"; };
+		74E1A1A22E02600000C0D001 /* XPCCacheController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCCacheController.swift; sourceTree = "<group>"; };
+		74E1A1A42E02700000C0D001 /* XPCCacheControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCCacheControllerTests.swift; sourceTree = "<group>"; };
 		74E93B742810109E0047A116 /* bn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bn; path = bn.lproj/Localizable.strings; sourceTree = "<group>"; };
 		74E93B75281010E50047A116 /* hr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hr; path = hr.lproj/Localizable.strings; sourceTree = "<group>"; };
 		74F5DC1726D928A100AFE989 /* Configuration.storekit */ = {isa = PBXFileReference; lastKnownFileType = text; path = Configuration.storekit; sourceTree = "<group>"; };
@@ -1891,6 +1893,7 @@
 				4AF45358271F38FC00CF1919 /* RenameVaultViewModelTests.swift */,
 				4A773908286D87AB0006B3C3 /* S3AuthenticationViewModelTests.swift */,
 				4A1673F0270E2E830075C724 /* SettingsViewModelTests.swift */,
+				74E1A1A42E02700000C0D001 /* XPCCacheControllerTests.swift */,
 				4A644B48267B40C3008CBB9A /* SetVaultNameViewModelTests.swift */,
 				4A707803278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift */,
 				4AF91CF325A8BB0D00ACF01E /* VaultListViewModelTests.swift */,
@@ -3042,6 +3045,7 @@
 				4A6A5204268B2915006F7368 /* OpenExistingLocalVaultViewModelTests.swift in Sources */,
 				4A4246F4275646A0005BE82D /* UpgradeViewModelTests.swift in Sources */,
 				4A1673F1270E2E830075C724 /* SettingsViewModelTests.swift in Sources */,
+				74E1A1A52E02700000C0D001 /* XPCCacheControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -389,6 +389,8 @@
 		7408E6CD26779BCC00D7FAEA /* AboutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7408E6CC26779BCC00D7FAEA /* AboutViewModel.swift */; };
 		740D367E266A18DF0058744D /* SettingsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D367D266A18DF0058744D /* SettingsViewController.swift */; };
 		740D3682266A19150058744D /* SettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D3681266A19150058744D /* SettingsViewModel.swift */; };
+		74E1A1A32E02600000C0D001 /* XPCCacheController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A22E02600000C0D001 /* XPCCacheController.swift */; };
+		74E1A1A12E02500000C0D001 /* ClearCacheAppIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */; };
 		740D3684266A1B180058744D /* SettingsCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740D3683266A1B180058744D /* SettingsCoordinator.swift */; };
 		742679FC26A56CF9004C61BC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 742679F926A56B33004C61BC /* Localizable.strings */; };
 		742679FD26A56CFA004C61BC /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 742679F926A56B33004C61BC /* Localizable.strings */; };
@@ -977,6 +979,8 @@
 		7408E6CC26779BCC00D7FAEA /* AboutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutViewModel.swift; sourceTree = "<group>"; };
 		740D367D266A18DF0058744D /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		740D3681266A19150058744D /* SettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewModel.swift; sourceTree = "<group>"; };
+		74E1A1A22E02600000C0D001 /* XPCCacheController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = XPCCacheController.swift; sourceTree = "<group>"; };
+		74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClearCacheAppIntent.swift; sourceTree = "<group>"; };
 		740D3683266A1B180058744D /* SettingsCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsCoordinator.swift; sourceTree = "<group>"; };
 		741CD1C82939080D00577FDE /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		741CD1CF2939083C00577FDE /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Intents.strings; sourceTree = "<group>"; };
@@ -2065,6 +2069,8 @@
 			isa = PBXGroup;
 			children = (
 				740D3683266A1B180058744D /* SettingsCoordinator.swift */,
+				74E1A1A22E02600000C0D001 /* XPCCacheController.swift */,
+				74E1A1A02E02500000C0D001 /* ClearCacheAppIntent.swift */,
 				740D367D266A18DF0058744D /* SettingsViewController.swift */,
 				740D3681266A19150058744D /* SettingsViewModel.swift */,
 				7408E6CB26779BC200D7FAEA /* About */,
@@ -2823,6 +2829,8 @@
 				74D365BA268B5DB0005ECD69 /* FilesAppUtil.swift in Sources */,
 				4AED9A6C286B305200352951 /* S3AuthenticationView.swift in Sources */,
 				4A644B4D267B55E4008CBB9A /* CreateNewVaultCoordinator.swift in Sources */,
+				74E1A1A32E02600000C0D001 /* XPCCacheController.swift in Sources */,
+				74E1A1A12E02500000C0D001 /* ClearCacheAppIntent.swift in Sources */,
 				740D3682266A19150058744D /* SettingsViewModel.swift in Sources */,
 				4A7B97D325B6F7520044B7FB /* AccountListViewModel.swift in Sources */,
 				4A7BC0F125ADFAD600F007B3 /* AddVaultCoordinator.swift in Sources */,

--- a/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Cryptomator.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -82,6 +82,15 @@
       }
     },
     {
+      "identity" : "combine-schedulers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/combine-schedulers",
+      "state" : {
+        "revision" : "fd16d76fd8b9a976d88bfb6cacc05ca8d19c91b6",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "cryptolib-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/cryptomator/cryptolib-swift.git",
@@ -199,12 +208,30 @@
       }
     },
     {
-      "identity" : "simple-swift-dependencies",
+      "identity" : "swift-clocks",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/PhilLibs/simple-swift-dependencies",
+      "location" : "https://github.com/pointfreeco/swift-clocks",
       "state" : {
-        "revision" : "36e2e7732b5fe2bfec76e4af78d2ef532fe09456",
-        "version" : "0.1.0"
+        "revision" : "cc46202b53476d64e824e0b6612da09d84ffde8e",
+        "version" : "1.0.6"
+      }
+    },
+    {
+      "identity" : "swift-concurrency-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
+      "state" : {
+        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
+        "version" : "1.3.2"
+      }
+    },
+    {
+      "identity" : "swift-dependencies",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-dependencies.git",
+      "state" : {
+        "revision" : "706feb7858a7f6c242879d137b8ee30926aa5b26",
+        "version" : "1.12.0"
       }
     },
     {
@@ -214,6 +241,15 @@
       "state" : {
         "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
         "version" : "1.10.1"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
       }
     },
     {

--- a/Cryptomator/Settings/ClearCacheAppIntent.swift
+++ b/Cryptomator/Settings/ClearCacheAppIntent.swift
@@ -1,0 +1,28 @@
+import AppIntents
+import Dependencies
+
+struct ClearCacheAppIntent: AppIntent {
+	static let title: LocalizedStringResource = "Clear Cache"
+	static let description = IntentDescription("Clears Cryptomator's local file cache.")
+	static let openAppWhenRun = false
+	@Dependencies.Dependency(\.cacheController) private var cacheController
+
+	func perform() async throws -> some IntentResult & ProvidesDialog {
+		try await cacheController.clearCache().getValue()
+		return .result(dialog: "Cache cleared.")
+	}
+}
+
+struct CryptomatorAppShortcutsProvider: AppShortcutsProvider {
+	static var appShortcuts: [AppShortcut] {
+		AppShortcut(
+			intent: ClearCacheAppIntent(),
+			phrases: [
+				"Clear cache in \(.applicationName)",
+				"Clear \(.applicationName) cache"
+			],
+			shortTitle: "Clear Cache",
+			systemImageName: "trash"
+		)
+	}
+}

--- a/Cryptomator/Settings/ClearCacheAppIntent.swift
+++ b/Cryptomator/Settings/ClearCacheAppIntent.swift
@@ -2,14 +2,14 @@ import AppIntents
 import Dependencies
 
 struct ClearCacheAppIntent: AppIntent {
-	static let title: LocalizedStringResource = "Clear Cache"
-	static let description = IntentDescription("Clears Cryptomator's local file cache.")
+	static let title = LocalizedStringResource("settings.clearCache", defaultValue: "Clear Cache")
+	static let description = IntentDescription(LocalizedStringResource("intents.clearCache.description", defaultValue: "Clears Cryptomator's local file cache."))
 	static let openAppWhenRun = false
 	@Dependencies.Dependency(\.cacheController) private var cacheController
 
 	func perform() async throws -> some IntentResult & ProvidesDialog {
 		try await cacheController.clearCache().getValue()
-		return .result(dialog: "Cache cleared.")
+		return .result(dialog: IntentDialog(LocalizedStringResource("intents.clearCache.cacheCleared", defaultValue: "Cache cleared.")))
 	}
 }
 
@@ -21,7 +21,7 @@ struct CryptomatorAppShortcutsProvider: AppShortcutsProvider {
 				"Clear cache in \(.applicationName)",
 				"Clear \(.applicationName) cache"
 			],
-			shortTitle: "Clear Cache",
+			shortTitle: LocalizedStringResource("settings.clearCache", defaultValue: "Clear Cache"),
 			systemImageName: "trash"
 		)
 	}

--- a/Cryptomator/Settings/SettingsViewModel.swift
+++ b/Cryptomator/Settings/SettingsViewModel.swift
@@ -128,6 +128,7 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 	}()
 
 	@Dependency(\.fileProviderConnector) private var fileProviderConnector
+	@Dependency(\.cacheController) private var cacheController
 
 	private var subscribers = Set<AnyCancellable>()
 	private lazy var showDebugModeWarningPublisher = PassthroughSubject<Void, Never>()
@@ -144,11 +145,7 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 				self.clearCacheButtonCellViewModel.isEnabled.value = false
 			}
 		}
-		let getXPCPromise: Promise<XPC<CacheManaging>> = fileProviderConnector.getXPC(serviceName: .cacheManaging, domain: nil)
-		return getXPCPromise.then { xpc in
-			xpc.proxy.getLocalCacheSizeInBytes()
-		}.then { receivedCacheSizeInBytes -> Void in
-			let totalCacheSizeInBytes = receivedCacheSizeInBytes?.intValue ?? 0
+		return cacheController.getLocalCacheSizeInBytes().then { totalCacheSizeInBytes -> Void in
 			loading = false
 			self.cacheSizeCellViewModel.isLoading.value = false
 			self.clearCacheButtonCellViewModel.isEnabled.value = totalCacheSizeInBytes > 0
@@ -158,10 +155,7 @@ class SettingsViewModel: TableViewModel<SettingsSection> {
 	}
 
 	func clearCache() -> Promise<Void> {
-		let getXPCPromise: Promise<XPC<CacheManaging>> = fileProviderConnector.getXPC(serviceName: .cacheManaging, domain: nil)
-		return getXPCPromise.then { xpc in
-			xpc.proxy.clearCache()
-		}.then {
+		return cacheController.clearCache().then {
 			self.refreshCacheSize()
 		}
 	}

--- a/Cryptomator/Settings/XPCCacheController.swift
+++ b/Cryptomator/Settings/XPCCacheController.swift
@@ -1,0 +1,56 @@
+import CryptomatorCommonCore
+import Dependencies
+import Promises
+
+protocol CacheControlling {
+	/**
+	 Returns the current total local cache size in bytes reported by the File
+	 Provider cache service.
+
+	 The reported size reflects only entries counted by that service.
+	 */
+	func getLocalCacheSizeInBytes() -> Promise<Int>
+
+	/**
+	 Clears the local cache through the File Provider cache service.
+
+	 Entries that the underlying service cannot currently evict may remain cached.
+	 */
+	func clearCache() -> Promise<Void>
+}
+
+struct XPCCacheController: CacheControlling {
+	@Dependency(\.fileProviderConnector) private var fileProviderConnector
+
+	func getLocalCacheSizeInBytes() -> Promise<Int> {
+		let getXPCPromise: Promise<XPC<CryptomatorCommonCore.CacheManaging>> = fileProviderConnector.getXPC(serviceName: .cacheManaging, domain: nil)
+		return getXPCPromise.then { xpc in
+			xpc.proxy.getLocalCacheSizeInBytes()
+		}.then {
+			$0?.intValue ?? 0
+		}.always {
+			self.fileProviderConnector.invalidateXPC(getXPCPromise)
+		}
+	}
+
+	func clearCache() -> Promise<Void> {
+		let getXPCPromise: Promise<XPC<CryptomatorCommonCore.CacheManaging>> = fileProviderConnector.getXPC(serviceName: .cacheManaging, domain: nil)
+		return getXPCPromise.then { xpc in
+			xpc.proxy.clearCache()
+		}.always {
+			self.fileProviderConnector.invalidateXPC(getXPCPromise)
+		}
+	}
+}
+
+private enum CacheControllerKey: DependencyKey {
+    static let testValue: any CacheControlling = XPCCacheController()
+	static let liveValue: any CacheControlling = XPCCacheController()
+}
+
+extension DependencyValues {
+	var cacheController: any CacheControlling {
+		get { self[CacheControllerKey.self] }
+		set { self[CacheControllerKey.self] = newValue }
+	}
+}

--- a/Cryptomator/Settings/XPCCacheController.swift
+++ b/Cryptomator/Settings/XPCCacheController.swift
@@ -44,7 +44,7 @@ struct XPCCacheController: CacheControlling {
 }
 
 private enum CacheControllerKey: DependencyKey {
-    static let testValue: any CacheControlling = XPCCacheController()
+	static let testValue: any CacheControlling = XPCCacheController()
 	static let liveValue: any CacheControlling = XPCCacheController()
 }
 

--- a/Cryptomator/Settings/XPCCacheController.swift
+++ b/Cryptomator/Settings/XPCCacheController.swift
@@ -44,8 +44,13 @@ struct XPCCacheController: CacheControlling {
 }
 
 private enum CacheControllerKey: DependencyKey {
-	static let testValue: any CacheControlling = XPCCacheController()
-	static let liveValue: any CacheControlling = XPCCacheController()
+	static var liveValue: any CacheControlling {
+		XPCCacheController()
+	}
+
+	#if DEBUG
+	static var testValue: any CacheControlling = UnimplementedCacheController()
+	#endif
 }
 
 extension DependencyValues {
@@ -54,3 +59,17 @@ extension DependencyValues {
 		set { self[CacheControllerKey.self] = newValue }
 	}
 }
+
+#if DEBUG
+private struct UnimplementedCacheController: CacheControlling {
+	func getLocalCacheSizeInBytes() -> Promise<Int> {
+		unimplemented("\(Self.self).getLocalCacheSizeInBytes() not implemented", placeholder: Promise(UnimplementedError()))
+	}
+
+	func clearCache() -> Promise<Void> {
+		unimplemented("\(Self.self).clearCache() not implemented", placeholder: Promise(UnimplementedError()))
+	}
+
+	private struct UnimplementedError: Error {}
+}
+#endif

--- a/CryptomatorCommon/Package.swift
+++ b/CryptomatorCommon/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
 	dependencies: [
 		.package(url: "https://github.com/cryptomator/cloud-access-swift.git", .upToNextMinor(from: "3.0.0")),
 		.package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack.git", .upToNextMinor(from: "3.9.0")),
-		.package(url: "https://github.com/PhilLibs/simple-swift-dependencies", .upToNextMajor(from: "0.1.0")),
+		.package(url: "https://github.com/pointfreeco/swift-dependencies.git", .upToNextMajor(from: "1.12.0")),
 		.package(url: "https://github.com/leif-ibsen/SwiftECC", .upToNextMinor(from: "5.5.0"))
 	],
 	targets: [
@@ -44,7 +44,7 @@ let package = Package(
 			dependencies: [
 				.product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
 				.product(name: "CryptomatorCloudAccessCore", package: "cloud-access-swift"),
-				.product(name: "Dependencies", package: "simple-swift-dependencies"),
+				.product(name: "Dependencies", package: "swift-dependencies"),
 				.product(name: "SwiftECC", package: "SwiftECC")
 			]
 		),

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
@@ -11,56 +11,85 @@ import XCTest
 
 class FullVersionCheckerTests: XCTestCase {
 	var settingsMock: CryptomatorSettingsMock!
-	var fullVersionChecker: FullVersionChecker!
 
 	override func setUpWithError() throws {
 		settingsMock = CryptomatorSettingsMock()
-		DependencyValues.mockDependency(\.cryptomatorSettings, with: settingsMock)
 		settingsMock.fullVersionUnlocked = false
 		settingsMock.hasRunningSubscription = false
 		settingsMock.trialExpirationDate = nil
-		fullVersionChecker = UserDefaultsFullVersionChecker()
 	}
 
 	// MARK: Is Full Version
 
 	func testIsFullVersionWithLifetime() {
 		settingsMock.fullVersionUnlocked = true
-		XCTAssert(fullVersionChecker.isFullVersion)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssert(UserDefaultsFullVersionChecker().isFullVersion)
+		}
 	}
 
 	func testIsFullVersionWithRunningSubscription() {
 		settingsMock.fullVersionUnlocked = true
-		XCTAssert(fullVersionChecker.isFullVersion)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssert(UserDefaultsFullVersionChecker().isFullVersion)
+		}
 	}
 
 	func testIsFullVersionWithTrialExpirationDateInTheFuture() {
 		settingsMock.trialExpirationDate = .distantFuture
-		XCTAssert(fullVersionChecker.isFullVersion)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssert(UserDefaultsFullVersionChecker().isFullVersion)
+		}
 	}
 
 	func testIsNotFullVersionWithTrialExpirationDateInThePast() {
 		settingsMock.trialExpirationDate = .distantPast
-		XCTAssertFalse(fullVersionChecker.isFullVersion)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssertFalse(UserDefaultsFullVersionChecker().isFullVersion)
+		}
 	}
 
 	func testIsNotFullVersionWithNothingSet() {
-		XCTAssertFalse(fullVersionChecker.isFullVersion)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssertFalse(UserDefaultsFullVersionChecker().isFullVersion)
+		}
 	}
 
 	// MARK: Has Expired Trial
 
 	func testHasExpiredTrialWithTrialExpirationDateNotSet() {
-		XCTAssertFalse(fullVersionChecker.hasExpiredTrial)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssertFalse(UserDefaultsFullVersionChecker().hasExpiredTrial)
+		}
 	}
 
 	func testHasExpiredTrialWithExpirationDateInTheFuture() {
 		settingsMock.trialExpirationDate = .distantFuture
-		XCTAssertFalse(fullVersionChecker.hasExpiredTrial)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssertFalse(UserDefaultsFullVersionChecker().hasExpiredTrial)
+		}
 	}
 
 	func testHasExpiredTrialWithExpirationDateInThePast() {
 		settingsMock.trialExpirationDate = .distantPast
-		XCTAssert(fullVersionChecker.hasExpiredTrial)
+		withDependencies {
+			$0.cryptomatorSettings = settingsMock
+		} operation: {
+			XCTAssert(UserDefaultsFullVersionChecker().hasExpiredTrial)
+		}
 	}
 }

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/FullVersionCheckerTests.swift
@@ -5,9 +5,9 @@
 //  Created by Philipp Schmid on 21.02.22.
 //
 
+import Dependencies
 import XCTest
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class FullVersionCheckerTests: XCTestCase {
 	var settingsMock: CryptomatorSettingsMock!

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Hub/HubAuthenticationViewModelTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Hub/HubAuthenticationViewModelTests.swift
@@ -38,9 +38,7 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	func testContinueToAccessCheck_showsLoadingSpinnerWhileReceivingKey() async {
 		XCTAssertFalse(delegateMock.hubAuthenticationViewModelWantsToShowLoadingIndicatorCalled)
 		XCTAssertFalse(delegateMock.hubAuthenticationViewModelWantsToHideLoadingIndicatorCalled)
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let hubKeyProviderMock = CryptomatorHubKeyProviderMock()
-		DependencyValues.mockDependency(\.cryptomatorHubKeyProvider, with: hubKeyProviderMock)
 		hubKeyProviderMock.getPrivateKeyReturnValue = P384.KeyAgreement.PrivateKey(compactRepresentable: false)
 
 		let calledReceiveKey = XCTestExpectation()
@@ -61,7 +59,12 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+			$0.cryptomatorHubKeyProvider = hubKeyProviderMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the loading indicator should be displayed while receiving the key
@@ -71,7 +74,6 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	func testContinueToAccessCheck_showsLoadingSpinnerWhileReceivingKeyHidesIfFailed() async {
 		XCTAssertFalse(delegateMock.hubAuthenticationViewModelWantsToShowLoadingIndicatorCalled)
 		XCTAssertFalse(delegateMock.hubAuthenticationViewModelWantsToHideLoadingIndicatorCalled)
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let calledReceiveKey = XCTestExpectation()
 		hubKeyServiceMock.receiveKeyAuthStateVaultConfigClosure = { _, _ in
 			calledReceiveKey.fulfill()
@@ -90,7 +92,11 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the loading indicator should be displayed while receiving the key and gets hidden even if the operation fails
@@ -98,9 +104,7 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_success_hubSubscriptionStateIsActive() async throws {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let hubKeyProviderMock = CryptomatorHubKeyProviderMock()
-		DependencyValues.mockDependency(\.cryptomatorHubKeyProvider, with: hubKeyProviderMock)
 
 		// GIVEN
 		// the hub key service returns success with an active Cryptomator Hub subscription state
@@ -113,7 +117,12 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+			$0.cryptomatorHubKeyProvider = hubKeyProviderMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the unlock handler gets informed about the successful remote unlock with an active Cryptomator Hub subscription state
@@ -123,9 +132,7 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_success_hubSubscriptionStateIsInactive() async throws {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let hubKeyProviderMock = CryptomatorHubKeyProviderMock()
-		DependencyValues.mockDependency(\.cryptomatorHubKeyProvider, with: hubKeyProviderMock)
 
 		// GIVEN
 		// the hub key service returns success with an active Cryptomator Hub subscription state
@@ -138,7 +145,12 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+			$0.cryptomatorHubKeyProvider = hubKeyProviderMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the unlock handler gets informed about the successful remote unlock with an inactive Cryptomator Hub subscription state
@@ -148,9 +160,7 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_success_hubSubscriptionStateIsUnknown() async throws {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let hubKeyProviderMock = CryptomatorHubKeyProviderMock()
-		DependencyValues.mockDependency(\.cryptomatorHubKeyProvider, with: hubKeyProviderMock)
 
 		// GIVEN
 		// the hub key service returns success with an unknown Cryptomator Hub subscription state
@@ -163,7 +173,12 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+			$0.cryptomatorHubKeyProvider = hubKeyProviderMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the unlock handler gets informed about the successful remote unlock with an inactive Cryptomator Hub subscription state (unknown defaults to inactive)
@@ -173,9 +188,7 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_success_hubSubscriptionStateMissing() async throws {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
 		let hubKeyProviderMock = CryptomatorHubKeyProviderMock()
-		DependencyValues.mockDependency(\.cryptomatorHubKeyProvider, with: hubKeyProviderMock)
 
 		// GIVEN
 		// the hub key service returns success without a Hub-Subscription-State header
@@ -188,7 +201,12 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+			$0.cryptomatorHubKeyProvider = hubKeyProviderMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the unlock handler gets informed about the successful remote unlock with an inactive Cryptomator Hub subscription state (missing defaults to inactive)
@@ -198,15 +216,17 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_accessNotGranted() async {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
-
 		// GIVEN
 		// the hub key service returns access not granted
 		hubKeyServiceMock.receiveKeyAuthStateVaultConfigReturnValue = .accessNotGranted
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the authentication flow state is set to accessNotGranted
@@ -214,15 +234,17 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_needsDeviceRegistration() async {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
-
 		// GIVEN
 		// the hub key service returns needs device registration
 		hubKeyServiceMock.receiveKeyAuthStateVaultConfigReturnValue = .needsDeviceRegistration
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the authentication flow state is set to needsDeviceRegistration where the user needs to set the device name
@@ -230,15 +252,17 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 	}
 
 	func testContinueToAccessCheck_licenseExceeded() async {
-		DependencyValues.mockDependency(\.hubKeyService, with: hubKeyServiceMock)
-
 		// GIVEN
 		// the hub key service returns that the Cryptomator Hub License is exceeded
 		hubKeyServiceMock.receiveKeyAuthStateVaultConfigReturnValue = .licenseExceeded
 
 		// WHEN
 		// continue the access check
-		await viewModel.continueToAccessCheck()
+		await withDependencies({
+			$0.hubKeyService = hubKeyServiceMock
+		}, operation: {
+			await self.viewModel.continueToAccessCheck()
+		})
 
 		// THEN
 		// the authentication flow state is set to licenseExceeded
@@ -249,7 +273,6 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 	func testRegister_registersDevice_withName() async {
 		let deviceRegisteringMock = HubDeviceRegisteringMock()
-		DependencyValues.mockDependency(\.hubDeviceRegisteringService, with: deviceRegisteringMock)
 
 		// GIVEN
 		// a name has been set by the user
@@ -257,7 +280,11 @@ final class HubAuthenticationViewModelTests: XCTestCase {
 
 		// WHEN
 		// the user taps on register
-		await viewModel.register()
+		await withDependencies({
+			$0.hubDeviceRegisteringService = deviceRegisteringMock
+		}, operation: {
+			await self.viewModel.register()
+		})
 
 		// THEN
 		// the registerDevice got called on the device registering servie

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Hub/HubAuthenticationViewModelTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Hub/HubAuthenticationViewModelTests.swift
@@ -7,12 +7,12 @@
 
 import AppAuthCore
 import CryptoKit
+import Dependencies
 import JOSESwift
 import XCTest
 @testable import CryptomatorCloudAccessCore
 @testable import CryptomatorCommonCore
 @testable import CryptomatorCryptoLib
-@testable import Dependencies
 
 final class HubAuthenticationViewModelTests: XCTestCase {
 	private var unlockHandlerMock: HubVaultUnlockHandlerMock!

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderAccountManagerTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/Manager/CloudProviderAccountManagerTests.swift
@@ -6,11 +6,11 @@
 //  Copyright © 2020 Skymatic GmbH. All rights reserved.
 //
 
+import Dependencies
 import Foundation
 import GRDB
 import XCTest
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class CloudProviderAccountManagerTests: XCTestCase {
 	var accountManager: CloudProviderAccountDBManager!

--- a/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
@@ -30,14 +30,17 @@ class FileImportingServiceSourceTests: XCTestCase {
 		adapterProvidingMock = FileProviderAdapterProvidingMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
-		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 		taskRegistratorMock = SessionTaskRegistratorMock()
-		serviceSource = FileImportingServiceSource(domain: domain,
-		                                           notificator: notificatorMock,
-		                                           dbPath: dbPath,
-		                                           delegate: urlProviderMock,
-		                                           adapterManager: adapterProvidingMock,
-		                                           taskRegistrator: taskRegistratorMock)
+		serviceSource = withDependencies {
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			FileImportingServiceSource(domain: domain,
+			                           notificator: notificatorMock,
+			                           dbPath: dbPath,
+			                           delegate: urlProviderMock,
+			                           adapterManager: adapterProvidingMock,
+			                           taskRegistrator: taskRegistratorMock)
+		}
 	}
 
 	func testGetItemIdentifier() throws {

--- a/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/FileImportingServiceSourceTests.swift
@@ -7,10 +7,10 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 @testable import Promises
 
 class FileImportingServiceSourceTests: XCTestCase {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
@@ -36,17 +36,20 @@ class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 		try metadataManagerMock.cacheMetadata(child)
 
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 
-		adapter.enumerateItems(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), withPageToken: nil).then { itemList in
-			XCTAssertEqual(1, itemList.items.count)
-			XCTAssertEqual("CachedFile", itemList.items[0].metadata.name)
-			XCTAssertNil(itemList.nextPageToken)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+			adapter.enumerateItems(for: NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2), withPageToken: nil).then { itemList in
+				XCTAssertEqual(1, itemList.items.count)
+				XCTAssertEqual("CachedFile", itemList.items[0].metadata.name)
+				XCTAssertNil(itemList.nextPageToken)
+			}.catch { error in
+				XCTFail("Error in promise: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 	}
@@ -60,16 +63,19 @@ class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 		]
 		metadataManagerMock.workingSetMetadata = mockMetadata
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 		let expectation = XCTestExpectation()
-		adapter.enumerateItems(for: .workingSet, withPageToken: nil).then { itemList in
-			XCTAssertEqual(mockMetadata.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }, itemList.items)
-			XCTAssertNil(itemList.nextPageToken)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			adapter.enumerateItems(for: .workingSet, withPageToken: nil).then { itemList in
+				XCTAssertEqual(mockMetadata, itemList.items.map(\.metadata))
+				XCTAssertNil(itemList.nextPageToken)
+			}.catch { error in
+				XCTFail("Error in promise: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 	}

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterEnumerateItemTests.swift
@@ -7,9 +7,9 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import XCTest
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderAdapterEnumerateItemTests: FileProviderAdapterTestCase {
 	override func setUpWithError() throws {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
@@ -28,37 +28,34 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 
 	func testLocalItemImport() throws {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
-		let fileURL = tmpDirectory.appendingPathComponent("ItemToBeImported.txt", isDirectory: false)
-		let fileContent = "TestContent"
-		try fileContent.write(to: fileURL, atomically: true, encoding: .utf8)
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			let fileURL = tmpDirectory.appendingPathComponent("ItemToBeImported.txt", isDirectory: false)
+			let fileContent = "TestContent"
+			try fileContent.write(to: fileURL, atomically: true, encoding: .utf8)
+			let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
+			try metadataManagerMock.cacheMetadata(rootItemMetadata)
 
-		let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
+			let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
 
-		// Check that file was copied to the url provided by the localURLProvider
-		XCTAssert(FileManager.default.fileExists(atPath: expectedFileURL.path))
-		let contentOfCopiedFile = try String(data: Data(contentsOf: expectedFileURL), encoding: .utf8)
-		XCTAssertEqual(fileContent, contentOfCopiedFile)
-		// Check that the original file was not altered
-		XCTAssert(FileManager.default.contentsEqual(atPath: fileURL.path, andPath: expectedFileURL.path))
+			XCTAssert(FileManager.default.fileExists(atPath: expectedFileURL.path))
+			let contentOfCopiedFile = try String(data: Data(contentsOf: expectedFileURL), encoding: .utf8)
+			XCTAssertEqual(fileContent, contentOfCopiedFile)
+			XCTAssert(FileManager.default.contentsEqual(atPath: fileURL.path, andPath: expectedFileURL.path))
+			XCTAssertEqual([itemID], uploadTaskManagerMock.createNewTaskRecordForReceivedInvocations.map { $0.id! })
+			XCTAssertEqual(1, cachedFileManagerMock.cachedLocalFileInfo.count)
+			guard let localCachedFileInfo = cachedFileManagerMock.cachedLocalFileInfo[itemID] else {
+				XCTFail("LocalCachedFileInfo is nil")
+				return
+			}
+			XCTAssertEqual(itemID, localCachedFileInfo.correspondingItem)
+			XCTAssertEqual(expectedFileURL, localCachedFileInfo.localURL)
 
-		// Check that the correct uploadTask was created
-		XCTAssertEqual([itemID], uploadTaskManagerMock.createNewTaskRecordForReceivedInvocations.map { $0.id! })
-
-		// Check that the file was cached
-		XCTAssertEqual(1, cachedFileManagerMock.cachedLocalFileInfo.count)
-		guard let localCachedFileInfo = cachedFileManagerMock.cachedLocalFileInfo[itemID] else {
-			XCTFail("LocalCachedFileInfo is nil")
-			return
+			try assertAllExpectedPropertiesSet(for: result.item)
+			assertLocalURLProviderCalledWithItemID()
 		}
-		XCTAssertEqual(itemID, localCachedFileInfo.correspondingItem)
-		XCTAssertEqual(expectedFileURL, localCachedFileInfo.localURL)
-
-		try assertAllExpectedPropertiesSet(for: result.item)
-		assertLocalURLProviderCalledWithItemID()
 	}
 
 	func testLocalItemImportFailsWhenNoLocalURLIsProvided() throws {
@@ -272,30 +269,30 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 
 	func testLocalItemImportNormalizesNFDFilenameToNFC() throws {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+		try withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 
-		// Create a file with an NFD filename (decomposed Unicode: o + combining diaeresis)
-		let nfdName = "Erh\u{006F}\u{0308}hung.pdf"
-		let nfcName = "Erhöhung.pdf"
-		// Sanity check: NFD and NFC are different byte sequences but equal in Swift
-		XCTAssertEqual(nfdName, nfcName)
-		XCTAssertNotEqual(Array(nfdName.utf8), Array(nfcName.utf8))
+			let nfdName = "Erh\u{006F}\u{0308}hung.pdf"
+			let nfcName = "Erhöhung.pdf"
+			XCTAssertEqual(nfdName, nfcName)
+			XCTAssertNotEqual(Array(nfdName.utf8), Array(nfcName.utf8))
 
-		let fileURL = tmpDirectory.appendingPathComponent(nfdName, isDirectory: false)
-		try "test".write(to: fileURL, atomically: true, encoding: .utf8)
+			let fileURL = tmpDirectory.appendingPathComponent(nfdName, isDirectory: false)
+			try "test".write(to: fileURL, atomically: true, encoding: .utf8)
 
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+			let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
+			try metadataManagerMock.cacheMetadata(rootItemMetadata)
 
-		let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
+			let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
 
-		// The stored name and cloudPath must use NFC (precomposed), not NFD
-		let storedName = result.item.filename
-		XCTAssertEqual(Array(storedName.utf8), Array(nfcName.utf8), "Filename should be stored in NFC form")
+			let storedName = result.item.filename
+			XCTAssertEqual(Array(storedName.utf8), Array(nfcName.utf8), "Filename should be stored in NFC form")
 
-		let storedCloudPath = result.item.metadata.cloudPath.path
-		XCTAssertEqual(Array(storedCloudPath.utf8), Array("/\(nfcName)".utf8), "CloudPath should be stored in NFC form")
+			let storedCloudPath = result.item.metadata.cloudPath.path
+			XCTAssertEqual(Array(storedCloudPath.utf8), Array("/\(nfcName)".utf8), "CloudPath should be stored in NFC form")
+		}
 	}
 
 	private func assertLocalURLProviderCalledWithItemID() {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
@@ -7,12 +7,12 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import Foundation
 import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 	let itemID: Int64 = 2

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterRecoverUploadsTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterRecoverUploadsTests.swift
@@ -7,12 +7,12 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import Foundation
 import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderAdapterRecoverUploadsTests: FileProviderAdapterTestCase {
 	let itemID: Int64 = 2

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Dependencies
 import Foundation
 import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	let fileCoordinator = NSFileCoordinator()

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -28,22 +28,25 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		fileProviderItemUpdateDelegateMock = FileProviderItemUpdateDelegateMock()
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		fullVersionCheckerMock.isFullVersion = true
-		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
 		taskRegistratorMock = SessionTaskRegistratorMock()
-		adapter = FileProviderAdapter(domainIdentifier: .test,
-		                              uploadTaskManager: uploadTaskManagerMock,
-		                              cachedFileManager: cachedFileManagerMock,
-		                              itemMetadataManager: metadataManagerMock,
-		                              reparentTaskManager: reparentTaskManagerMock,
-		                              deletionTaskManager: deletionTaskManagerMock,
-		                              itemEnumerationTaskManager: itemEnumerationTaskManagerMock,
-		                              downloadTaskManager: downloadTaskManagerMock,
-		                              scheduler: WorkflowScheduler(maxParallelUploads: 1, maxParallelDownloads: 1),
-		                              provider: cloudProviderMock,
-		                              coordinator: fileCoordinator,
-		                              notificator: fileProviderItemUpdateDelegateMock,
-		                              localURLProvider: localURLProviderMock,
-		                              taskRegistrator: taskRegistratorMock)
+		adapter = withDependencies {
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			FileProviderAdapter(domainIdentifier: .test,
+			                    uploadTaskManager: uploadTaskManagerMock,
+			                    cachedFileManager: cachedFileManagerMock,
+			                    itemMetadataManager: metadataManagerMock,
+			                    reparentTaskManager: reparentTaskManagerMock,
+			                    deletionTaskManager: deletionTaskManagerMock,
+			                    itemEnumerationTaskManager: itemEnumerationTaskManagerMock,
+			                    downloadTaskManager: downloadTaskManagerMock,
+			                    scheduler: WorkflowScheduler(maxParallelUploads: 1, maxParallelDownloads: 1),
+			                    provider: cloudProviderMock,
+			                    coordinator: fileCoordinator,
+			                    notificator: fileProviderItemUpdateDelegateMock,
+			                    localURLProvider: localURLProviderMock,
+			                    taskRegistrator: taskRegistratorMock)
+		}
 		uploadTaskManagerMock.createNewTaskRecordForClosure = {
 			return UploadTaskRecord(correspondingItem: $0.id!, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil, uploadStartedAt: Date())
 		}
@@ -65,7 +68,11 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 	}
 
 	func createFullyMockedAdapter() -> FileProviderAdapter {
-		return FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, coordinator: fileCoordinator, localURLProvider: localURLProviderMock, taskRegistrator: taskRegistratorMock)
+		return withDependencies {
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: WorkflowSchedulerMock(), provider: cloudProviderMock, coordinator: fileCoordinator, localURLProvider: localURLProviderMock, taskRegistrator: taskRegistratorMock)
+		}
 	}
 }
 

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -8,12 +8,12 @@
 
 import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
+import Dependencies
 import FileProvider
 import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderEnumeratorTestCase: XCTestCase {
 	var enumerationObserverMock: NSFileProviderEnumerationObserverMock!

--- a/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderEnumeratorTests.swift
@@ -52,13 +52,16 @@ class FileProviderEnumeratorTestCase: XCTestCase {
 
 	func assertChangeObserverUpdated(deletedItems: [NSFileProviderItemIdentifier], updatedItems: [FileProviderItem], currentSyncAnchor: NSFileProviderSyncAnchor) {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 
-		XCTAssertEqual([deletedItems], changeObserverMock.didDeleteItemsWithIdentifiersReceivedInvocations)
-		let receivedUpdatedItems = changeObserverMock.didUpdateReceivedInvocations as? [[FileProviderItem]]
-		XCTAssertEqual([updatedItems], receivedUpdatedItems)
-		XCTAssertFalse(changeObserverMock.finishEnumeratingWithErrorCalled)
+			XCTAssertEqual([deletedItems], changeObserverMock.didDeleteItemsWithIdentifiersReceivedInvocations)
+			let receivedUpdatedItems = changeObserverMock.didUpdateReceivedInvocations as? [[FileProviderItem]]
+			XCTAssertEqual([updatedItems], receivedUpdatedItems)
+			XCTAssertFalse(changeObserverMock.finishEnumeratingWithErrorCalled)
+		}
 	}
 }
 
@@ -185,13 +188,16 @@ class FileProviderEnumeratorTests: FileProviderEnumeratorTestCase {
 
 	private func assertEnumerateItemObserverSucceeded(itemList: FileProviderItemList) {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 
-		XCTAssertEqual([itemList.nextPageToken], enumerationObserverMock.finishEnumeratingUpToReceivedInvocations)
-		let receivedInvocations = enumerationObserverMock.didEnumerateReceivedInvocations as? [[FileProviderItem]]
-		XCTAssertEqual([items], receivedInvocations)
-		XCTAssertFalse(enumerationObserverMock.finishEnumeratingWithErrorCalled)
+			XCTAssertEqual([itemList.nextPageToken], enumerationObserverMock.finishEnumeratingUpToReceivedInvocations)
+			let receivedInvocations = enumerationObserverMock.didEnumerateReceivedInvocations as? [[FileProviderItem]]
+			XCTAssertEqual([items], receivedInvocations)
+			XCTAssertFalse(enumerationObserverMock.finishEnumeratingWithErrorCalled)
+		}
 	}
 
 	private func assertEnumerateItemsObserverFailed(with error: CloudProviderError) {

--- a/CryptomatorFileProviderTests/FileProviderItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderItemTests.swift
@@ -7,11 +7,11 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import MobileCoreServices
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderItemTests: XCTestCase {
 	func testRootItem() {

--- a/CryptomatorFileProviderTests/FileProviderItemTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderItemTests.swift
@@ -110,16 +110,18 @@ class FileProviderItemTests: XCTestCase {
 
 	func testCapabilitiesArePassedThroughFromPermissionProvider() {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
+			let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let item = FileProviderItem(metadata: metadata, domainIdentifier: .test)
-
-		let capabilities: [NSFileProviderItemCapabilities] = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsDeleting, .allowsReading, .allowsReparenting, .allowsWriting]
-		for capability in capabilities {
-			permissionProviderMock.getPermissionsForAtReturnValue = capability
-			XCTAssertEqual(capability, item.capabilities)
+			let capabilities: [NSFileProviderItemCapabilities] = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsDeleting, .allowsReading, .allowsReparenting, .allowsWriting]
+			for capability in capabilities {
+				permissionProviderMock.getPermissionsForAtReturnValue = capability
+				XCTAssertEqual(capability, item.capabilities)
+			}
 		}
 	}
 

--- a/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
@@ -99,10 +99,12 @@ class FileProviderNotificatorTests: XCTestCase {
 		let actualItems = notificator.popUpdateContainerItems() as? [FileProviderItem]
 
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
-
-		XCTAssertEqual([updatedItem], actualItems?.sorted())
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			XCTAssertEqual([updatedItem], actualItems?.sorted())
+		}
 		XCTAssert(notificator.popUpdateWorkingSetItems().isEmpty)
 		XCTAssert(notificator.getItemIdentifiersToDeleteFromWorkingSet().isEmpty)
 
@@ -115,10 +117,13 @@ class FileProviderNotificatorTests: XCTestCase {
 
 	private func assertUpdateWorkingSetHasUpdatedItems() {
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 		let actualItems = notificator.popUpdateWorkingSetItems() as? [FileProviderItem]
-		XCTAssertEqual(updatedItems.sorted(), actualItems?.sorted())
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			XCTAssertEqual(updatedItems.sorted(), actualItems?.sorted())
+		}
 	}
 
 	private func getCurrentSyncAnchorDate() throws -> Date {

--- a/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderNotificatorTests.swift
@@ -7,9 +7,9 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import XCTest
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class FileProviderNotificatorTests: XCTestCase {
 	var notificator: FileProviderNotificator!

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
@@ -202,10 +202,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 
 	// MARK: Folder
 
-	// swiftlint:disable:next function_body_length
-	func testFolderEnumeration() throws {
-		let expectation = XCTestExpectation(description: "Folder Enumeration")
-
+	func testFolderEnumeration() async throws {
 		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(rootItemMetadata)
 
@@ -218,110 +215,92 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		                                            ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false),
 		                                            ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false)]
 
-		let expectedRootFolderFileProviderItems = expectedItemMetadataInsideRootFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
 		let expectedItemMetadataInsideSubFolder = [ItemMetadata(id: 7, name: "Directory 2", type: .folder, size: 0, parentID: 2, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/Directory 2"), isPlaceholderItem: false),
 		                                           ItemMetadata(id: 8, name: "File 5", type: .file, size: 14, parentID: 2, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/File 5"), isPlaceholderItem: false)]
-		let expectedSubFolderFileProviderItems = expectedItemMetadataInsideSubFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
 
 		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 		let permissionProviderMock = PermissionProviderMock()
-		withDependencies {
+		try await withDependencies({
 			$0.permissionProvider = permissionProviderMock
-		} operation: {
+		}, operation: {
 			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			let expectedRootFolderFileProviderItems = expectedItemMetadataInsideRootFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
+			let expectedSubFolderFileProviderItems = expectedItemMetadataInsideSubFolder.map { FileProviderItem(metadata: $0, domainIdentifier: .test) }
 
-			taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> FileProviderItem in
-				XCTAssertEqual(5, fileProviderItemList.items.count)
-				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
-				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
-				XCTAssertEqual(6, self.metadataManagerMock.cachedMetadata.count)
+			let rootFolderItemList = try await taskExecutor.execute(task: enumerationTask).getValue()
+			XCTAssertEqual(5, rootFolderItemList.items.count)
+			XCTAssertEqual(expectedRootFolderFileProviderItems, rootFolderItemList.items)
+			XCTAssertEqual(6, self.metadataManagerMock.cachedMetadata.count)
 
-				let expectedItemMetadata = [rootItemMetadata] + expectedItemMetadataInsideRootFolder
-				XCTAssert(expectedItemMetadata.allSatisfy { expectedMetadata in
-					self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
-						key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
-					})
+			// Check cached metadata equals expected metadata, except the last modified date
+			let expectedItemMetadata = [rootItemMetadata] + expectedItemMetadataInsideRootFolder
+			XCTAssert(expectedItemMetadata.allSatisfy { expectedMetadata in
+				self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
+					key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
 				})
-				XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-				XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
-				return fileProviderItemList.items[0]
-			}.then { folderFileProviderItem -> Promise<FileProviderItemList> in
-				let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
-				let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: folderFileProviderItem.metadata)
-				return taskExecutor.execute(task: enumerationTask)
-			}.then { fileProviderItemList in
-				XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			})
+			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
 
-				XCTAssertEqual(2, fileProviderItemList.items.count)
-				XCTAssertEqual(expectedSubFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
-				XCTAssertEqual(expectedSubFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
-				XCTAssertEqual(8, self.metadataManagerMock.cachedMetadata.count)
+			let subfolderEnumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
+			let subfolderEnumerationTask = ItemEnumerationTask(taskRecord: subfolderEnumerationTaskRecord, itemMetadata: rootFolderItemList.items[0].metadata)
+			let subfolderItemList = try await taskExecutor.execute(task: subfolderEnumerationTask).getValue()
 
-				XCTAssert(expectedItemMetadataInsideSubFolder.allSatisfy { expectedMetadata in
-					self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
-						key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
-					})
+			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssertEqual(2, subfolderItemList.items.count)
+			XCTAssertEqual(expectedSubFolderFileProviderItems, subfolderItemList.items)
+			XCTAssertEqual(8, self.metadataManagerMock.cachedMetadata.count)
+
+			// Check cached metadata equals expected metadata, except the last modified date
+			XCTAssert(expectedItemMetadataInsideSubFolder.allSatisfy { expectedMetadata in
+				self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
+					key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
 				})
-			}.catch { error in
-				XCTFail("Error in promise: \(error)")
-			}.always {
-				expectation.fulfill()
-			}
-		}
-		wait(for: [expectation], timeout: 5.0)
+			})
+		})
 	}
 
-	func testFolderEnumerationSameFolderTwice() throws {
-		let expectation = XCTestExpectation(description: "Folder Enumeration")
-
+	func testFolderEnumerationSameFolderTwice() async throws {
 		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/"), isPlaceholderItem: false)
 		try metadataManagerMock.cacheMetadata(rootItemMetadata)
 
 		let enumerationTaskRecord = try ItemEnumerationTaskRecord(correspondingItem: XCTUnwrap(rootItemMetadata.id), pageToken: nil)
 		let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
 
-		let expectedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 3, name: "File 1", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 1"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                           FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test)]
-		let expectedChangedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test),
-		                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false), domainIdentifier: .test)]
-
 		let permissionProviderMock = PermissionProviderMock()
 		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
-		withDependencies {
+		try await withDependencies({
 			$0.permissionProvider = permissionProviderMock
-		} operation: {
+		}, operation: {
 			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			let expectedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                           FileProviderItem(metadata: ItemMetadata(id: 3, name: "File 1", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 1"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                           FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                           FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test)]
+			let expectedChangedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                                  FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                                  FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false), domainIdentifier: .test)]
 
-			taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
-				XCTAssertEqual(5, fileProviderItemList.items.count)
-				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
-				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
-				XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-				XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
-				self.cloudProviderMock.files["/File 1"] = nil
-				self.cloudProviderMock.files["/NewFileFromCloud"] = Data("NewFileFromCloud content".utf8)
-				let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
-				let secondEnumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
-				return taskExecutor.execute(task: secondEnumerationTask)
-			}.then { fileProviderItemList in
-				XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-				XCTAssertEqual(5, fileProviderItemList.items.count)
-				XCTAssertEqual(expectedChangedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
-				XCTAssertEqual(expectedChangedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
-			}.catch { error in
-				XCTFail("Error in promise: \(error)")
-			}.always {
-				expectation.fulfill()
-			}
-		}
-		wait(for: [expectation], timeout: 5.0)
+			let firstEnumerationItemList = try await taskExecutor.execute(task: enumerationTask).getValue()
+			XCTAssertEqual(5, firstEnumerationItemList.items.count)
+			XCTAssertEqual(expectedRootFolderFileProviderItems, firstEnumerationItemList.items)
+			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
+
+			self.cloudProviderMock.files["/File 1"] = nil
+			self.cloudProviderMock.files["/NewFileFromCloud"] = Data("NewFileFromCloud content".utf8)
+			let secondEnumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
+			let secondEnumerationTask = ItemEnumerationTask(taskRecord: secondEnumerationTaskRecord, itemMetadata: rootItemMetadata)
+			let secondEnumerationItemList = try await taskExecutor.execute(task: secondEnumerationTask).getValue()
+
+			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssertEqual(5, secondEnumerationItemList.items.count)
+			XCTAssertEqual(expectedChangedRootFolderFileProviderItems, secondEnumerationItemList.items)
+		})
 	}
 
 	func testFolderEnumerationPreservesUploadError() throws {

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
@@ -225,45 +225,48 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 
 		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 
-		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> FileProviderItem in
-			XCTAssertEqual(5, fileProviderItemList.items.count)
-			XCTAssertEqual(expectedRootFolderFileProviderItems, fileProviderItemList.items)
-			XCTAssertEqual(6, self.metadataManagerMock.cachedMetadata.count)
+			taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> FileProviderItem in
+				XCTAssertEqual(5, fileProviderItemList.items.count)
+				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
+				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
+				XCTAssertEqual(6, self.metadataManagerMock.cachedMetadata.count)
 
-			// Check cached metadata equals expected metadata, except the last modified date
-			let expectedItemMetadata = [rootItemMetadata] + expectedItemMetadataInsideRootFolder
-			XCTAssert(expectedItemMetadata.allSatisfy { expectedMetadata in
-				self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
-					key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
+				let expectedItemMetadata = [rootItemMetadata] + expectedItemMetadataInsideRootFolder
+				XCTAssert(expectedItemMetadata.allSatisfy { expectedMetadata in
+					self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
+						key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
+					})
 				})
-			})
-			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
-			return fileProviderItemList.items[0]
-		}.then { folderFileProviderItem -> Promise<FileProviderItemList> in
-			let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
-			let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: folderFileProviderItem.metadata)
-			return taskExecutor.execute(task: enumerationTask)
-		}.then { fileProviderItemList in
-			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+				XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+				XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
+				return fileProviderItemList.items[0]
+			}.then { folderFileProviderItem -> Promise<FileProviderItemList> in
+				let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
+				let enumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: folderFileProviderItem.metadata)
+				return taskExecutor.execute(task: enumerationTask)
+			}.then { fileProviderItemList in
+				XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
 
-			XCTAssertEqual(2, fileProviderItemList.items.count)
-			XCTAssertEqual(expectedSubFolderFileProviderItems, fileProviderItemList.items)
-			XCTAssertEqual(8, self.metadataManagerMock.cachedMetadata.count)
+				XCTAssertEqual(2, fileProviderItemList.items.count)
+				XCTAssertEqual(expectedSubFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
+				XCTAssertEqual(expectedSubFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
+				XCTAssertEqual(8, self.metadataManagerMock.cachedMetadata.count)
 
-			// Check cached metadata equals expected metadata, except the last modified date
-			XCTAssert(expectedItemMetadataInsideSubFolder.allSatisfy { expectedMetadata in
-				self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
-					key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
+				XCTAssert(expectedItemMetadataInsideSubFolder.allSatisfy { expectedMetadata in
+					self.metadataManagerMock.cachedMetadata.contains(where: { key, value in
+						key == expectedMetadata.id && value.name == expectedMetadata.name && value.type == expectedMetadata.type && value.size == expectedMetadata.size && value.parentID == expectedMetadata.parentID && value.statusCode == expectedMetadata.statusCode && value.cloudPath == expectedMetadata.cloudPath && value.isPlaceholderItem == expectedMetadata.isPlaceholderItem
+					})
 				})
-			})
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+			}.catch { error in
+				XCTFail("Error in promise: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 	}
@@ -289,29 +292,34 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 		                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false), domainIdentifier: .test)]
 
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
-
 		let taskExecutor = ItemEnumerationTaskExecutor(domainIdentifier: .test, provider: cloudProviderMock, itemMetadataManager: metadataManagerMock, cachedFileManager: cachedFileManagerMock, uploadTaskManager: uploadTaskManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, deleteItemHelper: deleteItemHelper)
 
-		taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
-			XCTAssertEqual(5, fileProviderItemList.items.count)
-			XCTAssertEqual(expectedRootFolderFileProviderItems, fileProviderItemList.items)
-			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
-			self.cloudProviderMock.files["/File 1"] = nil
-			self.cloudProviderMock.files["/NewFileFromCloud"] = Data("NewFileFromCloud content".utf8)
-			let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
-			let secondEnumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
-			return taskExecutor.execute(task: secondEnumerationTask)
-		}.then { fileProviderItemList in
-			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
-			XCTAssertEqual(5, fileProviderItemList.items.count)
-			XCTAssertEqual(expectedChangedRootFolderFileProviderItems, fileProviderItemList.items)
-		}.catch { error in
-			XCTFail("Error in promise: \(error)")
-		}.always {
-			expectation.fulfill()
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+
+			taskExecutor.execute(task: enumerationTask).then { fileProviderItemList -> Promise<FileProviderItemList> in
+				XCTAssertEqual(5, fileProviderItemList.items.count)
+				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
+				XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
+				XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+				XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
+				self.cloudProviderMock.files["/File 1"] = nil
+				self.cloudProviderMock.files["/NewFileFromCloud"] = Data("NewFileFromCloud content".utf8)
+				let enumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
+				let secondEnumerationTask = ItemEnumerationTask(taskRecord: enumerationTaskRecord, itemMetadata: rootItemMetadata)
+				return taskExecutor.execute(task: secondEnumerationTask)
+			}.then { fileProviderItemList in
+				XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+				XCTAssertEqual(5, fileProviderItemList.items.count)
+				XCTAssertEqual(expectedChangedRootFolderFileProviderItems.map(\.filename), fileProviderItemList.items.map(\.filename))
+				XCTAssertEqual(expectedChangedRootFolderFileProviderItems.map(\.parentItemIdentifier), fileProviderItemList.items.map(\.parentItemIdentifier))
+			}.catch { error in
+				XCTFail("Error in promise: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 	}

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
@@ -7,10 +7,10 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import Promises
 import XCTest
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 	override func setUpWithError() throws {

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/ItemEnumerationTaskTests.swift
@@ -230,6 +230,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			let rootFolderItemList = try await taskExecutor.execute(task: enumerationTask).getValue()
 			XCTAssertEqual(5, rootFolderItemList.items.count)
 			XCTAssertEqual(expectedRootFolderFileProviderItems, rootFolderItemList.items)
+			XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.metadata.cloudPath), rootFolderItemList.items.map(\.metadata.cloudPath))
 			XCTAssertEqual(6, self.metadataManagerMock.cachedMetadata.count)
 
 			// Check cached metadata equals expected metadata, except the last modified date
@@ -242,13 +243,16 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
 			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
 
-			let subfolderEnumerationTaskRecord = ItemEnumerationTaskRecord(correspondingItem: rootItemMetadata.id!, pageToken: nil)
-			let subfolderEnumerationTask = ItemEnumerationTask(taskRecord: subfolderEnumerationTaskRecord, itemMetadata: rootFolderItemList.items[0].metadata)
+			let subfolderMetadata = rootFolderItemList.items[0].metadata
+			let subfolderEnumerationTaskRecord = try ItemEnumerationTaskRecord(correspondingItem: XCTUnwrap(subfolderMetadata.id), pageToken: nil)
+			let subfolderEnumerationTask = ItemEnumerationTask(taskRecord: subfolderEnumerationTaskRecord, itemMetadata: subfolderMetadata)
 			let subfolderItemList = try await taskExecutor.execute(task: subfolderEnumerationTask).getValue()
 
 			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == subfolderEnumerationTaskRecord }))
 			XCTAssertEqual(2, subfolderItemList.items.count)
 			XCTAssertEqual(expectedSubFolderFileProviderItems, subfolderItemList.items)
+			XCTAssertEqual(expectedSubFolderFileProviderItems.map(\.metadata.cloudPath), subfolderItemList.items.map(\.metadata.cloudPath))
 			XCTAssertEqual(8, self.metadataManagerMock.cachedMetadata.count)
 
 			// Check cached metadata equals expected metadata, except the last modified date
@@ -276,11 +280,11 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 			let expectedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                           FileProviderItem(metadata: ItemMetadata(id: 3, name: "File 1", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 1"), isPlaceholderItem: false), domainIdentifier: .test),
-			                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                           FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 2"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                           FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                           FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test)]
 			let expectedChangedRootFolderFileProviderItems = [FileProviderItem(metadata: ItemMetadata(id: 2, name: "Directory 1", type: .folder, size: 0, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Directory 1/"), isPlaceholderItem: false), domainIdentifier: .test),
-			                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
+			                                                  FileProviderItem(metadata: ItemMetadata(id: 4, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 2"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                                  FileProviderItem(metadata: ItemMetadata(id: 5, name: "File 3", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 3"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                                  FileProviderItem(metadata: ItemMetadata(id: 6, name: "File 4", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/File 4"), isPlaceholderItem: false), domainIdentifier: .test),
 			                                                  FileProviderItem(metadata: ItemMetadata(id: 7, name: "NewFileFromCloud", type: .file, size: 24, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/NewFileFromCloud"), isPlaceholderItem: false), domainIdentifier: .test)]
@@ -288,6 +292,7 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			let firstEnumerationItemList = try await taskExecutor.execute(task: enumerationTask).getValue()
 			XCTAssertEqual(5, firstEnumerationItemList.items.count)
 			XCTAssertEqual(expectedRootFolderFileProviderItems, firstEnumerationItemList.items)
+			XCTAssertEqual(expectedRootFolderFileProviderItems.map(\.metadata.cloudPath), firstEnumerationItemList.items.map(\.metadata.cloudPath))
 			XCTAssertEqual(1, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
 			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == enumerationTaskRecord }))
 
@@ -298,8 +303,10 @@ class ItemEnumerationTaskTests: CloudTaskExecutorTestCase {
 			let secondEnumerationItemList = try await taskExecutor.execute(task: secondEnumerationTask).getValue()
 
 			XCTAssertEqual(2, self.itemEnumerationTaskManagerMock.removedTaskRecords.count)
+			XCTAssert(self.itemEnumerationTaskManagerMock.removedTaskRecords.contains(where: { $0 == secondEnumerationTaskRecord }))
 			XCTAssertEqual(5, secondEnumerationItemList.items.count)
 			XCTAssertEqual(expectedChangedRootFolderFileProviderItems, secondEnumerationItemList.items)
+			XCTAssertEqual(expectedChangedRootFolderFileProviderItems.map(\.metadata.cloudPath), secondEnumerationItemList.items.map(\.metadata.cloudPath))
 		})
 	}
 

--- a/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
+++ b/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
@@ -21,9 +21,12 @@ final class PermissionProviderImplTests: XCTestCase {
 	override func setUpWithError() throws {
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		hubRepositoryMock = HubRepositoryMock()
-		DependencyValues.mockDependency(\.hubRepository, with: hubRepositoryMock)
-		DependencyValues.mockDependency(\.fullVersionChecker, with: fullVersionCheckerMock)
-		permissionProvider = PermissionProviderImpl()
+		permissionProvider = withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			PermissionProviderImpl()
+		}
 	}
 
 	// MARK: Full Version

--- a/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
+++ b/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
@@ -7,10 +7,10 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 final class PermissionProviderImplTests: XCTestCase {
 	private static let defaultFolderCapabilities: NSFileProviderItemCapabilities = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting]

--- a/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
+++ b/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
@@ -16,125 +16,173 @@ final class PermissionProviderImplTests: XCTestCase {
 	private static let defaultFolderCapabilities: NSFileProviderItemCapabilities = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting]
 	private var fullVersionCheckerMock: FullVersionCheckerMock!
 	private var hubRepositoryMock: HubRepositoryMock!
-	private var permissionProvider: PermissionProviderImpl!
 
 	override func setUpWithError() throws {
 		fullVersionCheckerMock = FullVersionCheckerMock()
 		hubRepositoryMock = HubRepositoryMock()
-		permissionProvider = withDependencies {
-			$0.hubRepository = hubRepositoryMock
-			$0.fullVersionChecker = fullVersionCheckerMock
-		} operation: {
-			PermissionProviderImpl()
-		}
 	}
 
 	// MARK: Full Version
 
 	func testUploadingItemRestrictsCapabilityToRead() {
-		fullVersionCheckerMock.isFullVersion = true
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = true
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+		}
 	}
 
 	func testUploadingFolderDoesNotRestrictCapabilities() {
-		fullVersionCheckerMock.isFullVersion = true
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = true
 
-		let cloudPath = CloudPath("/test")
-		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+			let cloudPath = CloudPath("/test")
+			let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+		}
 	}
 
 	func testCapabilitiesForRestrictedVersion() {
-		fullVersionCheckerMock.isFullVersion = false
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+		}
 	}
 
 	func testFailedUploadItemCapabilitiesForRestrictedVersion() {
-		fullVersionCheckerMock.isFullVersion = false
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, actualCapabilities)
+		}
 	}
 
 	func testFailedUploadFolderCapabilitiesForRestrictedVersion() {
-		fullVersionCheckerMock.isFullVersion = false
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
 
-		let cloudPath = CloudPath("/test")
-		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, actualCapabilities)
+			let cloudPath = CloudPath("/test")
+			let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .uploadError, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsDeleting, actualCapabilities)
+		}
 	}
 
 	func testFullVersionNoActiveHubScriptionReturnsFullPermissionsForFile() {
-		fullVersionCheckerMock.isFullVersion = true
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .inactive)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = true
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .inactive)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual([.allowsWriting, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual([.allowsWriting, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], actualCapabilities)
+		}
 	}
 
 	// MARK: Cryptomator Hub
 
 	func testUploadingItemRestrictsCapabilityToReadWithActiveHubSubscription() {
-		fullVersionCheckerMock.isFullVersion = false
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+		}
 	}
 
 	func testNoFullVersionNoActiveHubSubscriptionRestrictsToReadOnly() {
-		fullVersionCheckerMock.isFullVersion = false
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .inactive)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .inactive)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(NSFileProviderItemCapabilities.allowsReading, actualCapabilities)
+		}
 	}
 
 	func testFolderCapabilitiesNoFullVersionActiveHubSubscription() {
-		fullVersionCheckerMock.isFullVersion = false
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .folder, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .folder, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+		}
 	}
 
 	func testUploadingFolderDoesNotRestrictCapabilitiesForActiveHubSubsription() {
-		fullVersionCheckerMock.isFullVersion = false
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
 
-		let cloudPath = CloudPath("/test")
-		let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+			let cloudPath = CloudPath("/test")
+			let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+		}
 	}
 
 	func testNoFullVersionActiveHubScriptionReturnsFullPermissionsForFile() {
-		fullVersionCheckerMock.isFullVersion = false
-		hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
+		withDependencies {
+			$0.hubRepository = hubRepositoryMock
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			self.fullVersionCheckerMock.isFullVersion = false
+			self.hubRepositoryMock.getHubVaultVaultIDReturnValue = .init(vaultUID: "12345", subscriptionState: .active)
 
-		let cloudPath = CloudPath("/test.txt")
-		let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
-		let actualCapabilities = permissionProvider.getPermissions(for: metadata, at: .test)
-		XCTAssertEqual([.allowsWriting, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], actualCapabilities)
+			let cloudPath = CloudPath("/test.txt")
+			let metadata = ItemMetadata(id: 2, name: "test.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
+			XCTAssertEqual([.allowsWriting, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting], actualCapabilities)
+		}
 	}
 }

--- a/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
@@ -59,28 +59,32 @@ class CacheManagingServiceSourceTests: XCTestCase {
 		let cacheManagerMock = CachedFileManagerMock()
 		cacheManagerFactoryMock.createCachedFileManagerForReturnValue = cacheManagerMock
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
 		let domainIdentifier = NSFileProviderDomainIdentifier("Test-Domain")
 		let itemID: Int64 = 2
 		let itemIdentifier = NSFileProviderItemIdentifier(domainIdentifier: domainIdentifier, itemID: itemID)
-		let testItem = FileProviderItem(metadata: ItemMetadata(id: itemID, name: "Test", type: .file, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false), domainIdentifier: .test)
-		serviceSource.getItem = { receivedItemIdentifier in
-			guard itemIdentifier == receivedItemIdentifier else {
-				return nil
+		var testItem: FileProviderItem?
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			testItem = FileProviderItem(metadata: ItemMetadata(id: itemID, name: "Test", type: .file, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/Test"), isPlaceholderItem: false), domainIdentifier: .test)
+			serviceSource.getItem = { receivedItemIdentifier in
+				guard itemIdentifier == receivedItemIdentifier else {
+					return nil
+				}
+				return testItem
 			}
-			return testItem
-		}
-		serviceSource.evictFileFromCache(with: itemIdentifier) { error in
-			XCTAssertNil(error)
-			expectation.fulfill()
+			serviceSource.evictFileFromCache(with: itemIdentifier) { error in
+				XCTAssertNil(error)
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 
 		XCTAssertEqual([itemID], cacheManagerMock.removeCachedFileForReceivedInvocations)
 		XCTAssertEqual([domainIdentifier], cacheManagerFactoryMock.createCachedFileManagerForReceivedInvocations.map { $0.identifier })
 		// Assert signaled an update for the evicted item
-		XCTAssertEqual([testItem], notificatorMock.signalUpdateForReceivedInvocations as? [FileProviderItem])
+		XCTAssertEqual([testItem].compactMap { $0 }, notificatorMock.signalUpdateForReceivedInvocations as? [FileProviderItem])
 	}
 
 	func testGetLocalCacheSizeInBytes() {

--- a/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
+++ b/CryptomatorFileProviderTests/ServiceSource/CacheManagingServiceSourceTests.swift
@@ -7,11 +7,11 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class CacheManagingServiceSourceTests: XCTestCase {
 	var serviceSource: CacheManagingServiceSource!
@@ -54,7 +54,7 @@ class CacheManagingServiceSourceTests: XCTestCase {
 		XCTAssertEqual(1, cacheManagerMocks[1].clearCacheCallsCount)
 	}
 
-	func testEvictFileFromCache() {
+	func testEvictFileFromCache() throws {
 		let expectation = XCTestExpectation()
 		let cacheManagerMock = CachedFileManagerMock()
 		cacheManagerFactoryMock.createCachedFileManagerForReturnValue = cacheManagerMock
@@ -84,7 +84,8 @@ class CacheManagingServiceSourceTests: XCTestCase {
 		XCTAssertEqual([itemID], cacheManagerMock.removeCachedFileForReceivedInvocations)
 		XCTAssertEqual([domainIdentifier], cacheManagerFactoryMock.createCachedFileManagerForReceivedInvocations.map { $0.identifier })
 		// Assert signaled an update for the evicted item
-		XCTAssertEqual([testItem].compactMap { $0 }, notificatorMock.signalUpdateForReceivedInvocations as? [FileProviderItem])
+		let unwrappedTestItem = try XCTUnwrap(testItem)
+		XCTAssertEqual([unwrappedTestItem], notificatorMock.signalUpdateForReceivedInvocations as? [FileProviderItem])
 	}
 
 	func testGetLocalCacheSizeInBytes() {

--- a/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
+++ b/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
@@ -33,9 +33,12 @@ class WorkingSetObserverTests: XCTestCase {
 		XCTAssertEqual(1, notificatorMock.updateWorkingSetItemsCallsCount)
 		let actualUpdatedItems = notificatorMock.updateWorkingSetItemsReceivedItems as? [FileProviderItem]
 		let permissionProviderMock = PermissionProviderMock()
-		DependencyValues.mockDependency(\.permissionProvider, with: permissionProviderMock)
-		permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
-		XCTAssertEqual(updatedItems.sorted(), actualUpdatedItems?.sorted())
+		withDependencies {
+			$0.permissionProvider = permissionProviderMock
+		} operation: {
+			permissionProviderMock.getPermissionsForAtReturnValue = .allowsReading
+			XCTAssertEqual(updatedItems.sorted(), actualUpdatedItems?.sorted())
+		}
 		XCTAssertEqual(1, notificatorMock.refreshWorkingSetCallsCount)
 	}
 

--- a/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
+++ b/CryptomatorFileProviderTests/WorkingSetObserverTests.swift
@@ -7,10 +7,10 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import GRDB
 import XCTest
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class WorkingSetObserverTests: XCTestCase {
 	var observer: WorkingSetObserver!

--- a/CryptomatorTests/ChangePasswordViewModelTests.swift
+++ b/CryptomatorTests/ChangePasswordViewModelTests.swift
@@ -10,11 +10,11 @@ import Combine
 import CryptomatorCloudAccessCore
 import CryptomatorCryptoLib
 import CryptomatorFileProvider
+import Dependencies
 import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class ChangePasswordViewModelTests: XCTestCase {
 	private var vaultManagerMock: VaultManagerMock!

--- a/CryptomatorTests/ChangePasswordViewModelTests.swift
+++ b/CryptomatorTests/ChangePasswordViewModelTests.swift
@@ -27,12 +27,6 @@ class ChangePasswordViewModelTests: XCTestCase {
 	override func setUpWithError() throws {
 		setupMocks()
 		vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let domain = NSFileProviderDomain(vaultUID: vaultAccount.vaultUID, displayName: vaultAccount.vaultName)
-		viewModel = withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			ChangePasswordViewModel(vaultAccount: vaultAccount, domain: domain, vaultManager: vaultManagerMock)
-		}
 	}
 
 	private func setupMocks() {
@@ -55,155 +49,203 @@ class ChangePasswordViewModelTests: XCTestCase {
 	}
 
 	func testChangePassword() async throws {
-		let oldPassword = "OldPassword"
-		let newPassword = "Password"
-		setOldPassword(oldPassword)
-		setNewPassword(newPassword)
-		setNewPasswordConfirmation(newPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			let oldPassword = "OldPassword"
+			let newPassword = "Password"
+			self.setOldPassword(oldPassword)
+			self.setNewPassword(newPassword)
+			self.setNewPasswordConfirmation(newPassword)
 
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
-		vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReturnValue = Promise(())
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
+			self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReturnValue = Promise(())
 
-		try await viewModel.changePassword()
+			try await self.viewModel.changePassword()
 
-		await fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
 
-		XCTAssertEqual(1, vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDCallsCount)
-		XCTAssertEqual(oldPassword, vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.oldPassphrase)
-		XCTAssertEqual(newPassword, vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.newPassphrase)
-		XCTAssertEqual(vaultAccount.vaultUID, vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.vaultUID)
+			XCTAssertEqual(1, self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDCallsCount)
+			XCTAssertEqual(oldPassword, self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.oldPassphrase)
+			XCTAssertEqual(newPassword, self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.newPassphrase)
+			XCTAssertEqual(self.vaultAccount.vaultUID, self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReceivedArguments?.vaultUID)
 
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(self.vaultAccount.vaultUID)))
+		})
 	}
 
 	func testEnableMaintenanceModeFailed() async throws {
-		let oldPassword = "OldPassword"
-		let newPassword = "Password"
-		setOldPassword(oldPassword)
-		setNewPassword(newPassword)
-		setNewPasswordConfirmation(newPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			let oldPassword = "OldPassword"
+			let newPassword = "Password"
+			self.setOldPassword(oldPassword)
+			self.setNewPassword(newPassword)
+			self.setNewPasswordConfirmation(newPassword)
 
-		// Simulate enable maintenance mode failure
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
 
-		await XCTAssertThrowsAsyncError(try await viewModel.changePassword()) { error in
-			XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
-		}
-		XCTAssertFalse(vaultManagerMock.moveVaultAccountToCalled)
-		XCTAssertFalse(maintenanceHelperMock.disableMaintenanceModeReplyCalled)
+			await XCTAssertThrowsAsyncError(try await self.viewModel.changePassword()) { error in
+				XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
+			}
+			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+			XCTAssertFalse(self.maintenanceHelperMock.disableMaintenanceModeReplyCalled)
+		})
 	}
 
 	func testDisableMaintenanceModeAfterChangePassphraseFailed() async throws {
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
 
-		// Simulate change pass phrase failure
-		vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReturnValue = Promise(MasterkeyFileError.invalidPassphrase)
+			self.vaultManagerMock.changePassphraseOldPassphraseNewPassphraseForVaultUIDReturnValue = Promise(MasterkeyFileError.invalidPassphrase)
 
-		let oldPassword = "OldPassword"
-		let newPassword = "Password"
-		setOldPassword(oldPassword)
-		setNewPassword(newPassword)
-		setNewPasswordConfirmation(newPassword)
+			let oldPassword = "OldPassword"
+			let newPassword = "Password"
+			self.setOldPassword(oldPassword)
+			self.setNewPassword(newPassword)
+			self.setNewPasswordConfirmation(newPassword)
 
-		await XCTAssertThrowsAsyncError(try await viewModel.changePassword()) { error in
-			XCTAssertEqual(.invalidOldPassword, error as? ChangePasswordViewModelError)
-		}
+			await XCTAssertThrowsAsyncError(try await self.viewModel.changePassword()) { error in
+				XCTAssertEqual(.invalidOldPassword, error as? ChangePasswordViewModelError)
+			}
 
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
-		await fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(self.vaultAccount.vaultUID)))
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	func testChangePasswordFailForEmptyOldPassword() async throws {
-		setNewPassword("Password")
-		setNewPasswordConfirmation("Password")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			self.setNewPassword("Password")
+			self.setNewPasswordConfirmation("Password")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
 
-		setOldPassword("")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+			self.setOldPassword("")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		})
 	}
 
 	func testChangePasswordFailForEmptyNewPassword() async throws {
-		setOldPassword("OldPassword")
-		setNewPasswordConfirmation("Password")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			self.setOldPassword("OldPassword")
+			self.setNewPasswordConfirmation("Password")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
 
-		setNewPassword("")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+			self.setNewPassword("")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		})
 	}
 
 	func testChangePasswordFailForEmptyNewPasswordConfirmation() async throws {
-		setOldPassword("OldPassword")
-		setNewPassword("Password")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			self.setOldPassword("OldPassword")
+			self.setNewPassword("Password")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
 
-		setNewPasswordConfirmation("")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+			self.setNewPasswordConfirmation("")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.emptyPassword)
+		})
 	}
 
 	func testChangePasswordFailForNewPasswordUnderEightChars() async throws {
-		setOldPassword("OldPassword")
-		setNewPassword("NewPass")
-		setNewPasswordConfirmation("NewPass")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.tooShortPassword)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			self.setOldPassword("OldPassword")
+			self.setNewPassword("NewPass")
+			self.setNewPasswordConfirmation("NewPass")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.tooShortPassword)
+		})
 	}
 
 	func testChangePasswordFailForNonMatchingNewPasswordConfirmation() async throws {
-		setOldPassword("OldPassword")
-		setNewPassword("Password")
-		setNewPasswordConfirmation("NewPassword1")
-		try await checkChangePasswordFail(with: ChangePasswordViewModelError.newPasswordsDoNotMatch)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel()
+			self.setOldPassword("OldPassword")
+			self.setNewPassword("Password")
+			self.setNewPasswordConfirmation("NewPassword1")
+			try await self.checkChangePasswordFail(with: ChangePasswordViewModelError.newPasswordsDoNotMatch)
+		})
 	}
 
 	// MARK: Return Button Support
 
 	func testReturnButtonSupport() {
-		guard let oldPasswordViewModel = viewModel.cells[.oldPassword]?.first as? TextFieldCellViewModel else {
-			XCTFail("oldPasswordViewModel not found")
-			return
-		}
-		guard let newPasswordViewModel = viewModel.cells[.newPassword]?.first as? TextFieldCellViewModel else {
-			XCTFail("newPasswordViewModel not found")
-			return
-		}
-		guard let newPasswordConfirmationViewModel = viewModel.cells[.newPasswordConfirmation]?.first as? TextFieldCellViewModel else {
-			XCTFail("newPasswordConfirmationViewModel not found")
-			return
-		}
-		XCTAssert(oldPasswordViewModel.isInitialFirstResponder)
-		XCTAssertFalse(newPasswordViewModel.isInitialFirstResponder)
-		XCTAssertFalse(newPasswordConfirmationViewModel.isInitialFirstResponder)
-		let lastReturnButtonPressedRecorder = viewModel.lastReturnButtonPressed.recordNext(1)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			self.viewModel = self.createViewModel()
+			guard let oldPasswordViewModel = self.viewModel.cells[.oldPassword]?.first as? TextFieldCellViewModel else {
+				XCTFail("oldPasswordViewModel not found")
+				return
+			}
+			guard let newPasswordViewModel = self.viewModel.cells[.newPassword]?.first as? TextFieldCellViewModel else {
+				XCTFail("newPasswordViewModel not found")
+				return
+			}
+			guard let newPasswordConfirmationViewModel = self.viewModel.cells[.newPasswordConfirmation]?.first as? TextFieldCellViewModel else {
+				XCTFail("newPasswordConfirmationViewModel not found")
+				return
+			}
+			XCTAssert(oldPasswordViewModel.isInitialFirstResponder)
+			XCTAssertFalse(newPasswordViewModel.isInitialFirstResponder)
+			XCTAssertFalse(newPasswordConfirmationViewModel.isInitialFirstResponder)
+			let lastReturnButtonPressedRecorder = self.viewModel.lastReturnButtonPressed.recordNext(1)
 
-		let newPWBecomeFirstResponderRecorder = newPasswordViewModel.startListeningToBecomeFirstResponder().recordNext(1)
-		let newPWConfirmationBecomeFirstResponderRecorder = newPasswordConfirmationViewModel.startListeningToBecomeFirstResponder().recordNext(1)
+			let newPWBecomeFirstResponderRecorder = newPasswordViewModel.startListeningToBecomeFirstResponder().recordNext(1)
+			let newPWConfirmationBecomeFirstResponderRecorder = newPasswordConfirmationViewModel.startListeningToBecomeFirstResponder().recordNext(1)
 
-		oldPasswordViewModel.returnButtonPressed()
-		wait(for: newPWBecomeFirstResponderRecorder)
+			oldPasswordViewModel.returnButtonPressed()
+			self.wait(for: newPWBecomeFirstResponderRecorder)
 
-		newPasswordViewModel.returnButtonPressed()
-		wait(for: newPWConfirmationBecomeFirstResponderRecorder)
-		newPasswordConfirmationViewModel.returnButtonPressed()
-		wait(for: lastReturnButtonPressedRecorder)
+			newPasswordViewModel.returnButtonPressed()
+			self.wait(for: newPWConfirmationBecomeFirstResponderRecorder)
+			newPasswordConfirmationViewModel.returnButtonPressed()
+			self.wait(for: lastReturnButtonPressedRecorder)
+		}
+	}
+
+	private func createViewModel() -> ChangePasswordViewModel {
+		let domain = NSFileProviderDomain(vaultUID: vaultAccount.vaultUID, displayName: vaultAccount.vaultName)
+		return ChangePasswordViewModel(vaultAccount: vaultAccount, domain: domain, vaultManager: vaultManagerMock)
 	}
 
 	private func checkChangePasswordFail(with expectedError: Error) async throws {

--- a/CryptomatorTests/ChangePasswordViewModelTests.swift
+++ b/CryptomatorTests/ChangePasswordViewModelTests.swift
@@ -28,8 +28,11 @@ class ChangePasswordViewModelTests: XCTestCase {
 		setupMocks()
 		vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
 		let domain = NSFileProviderDomain(vaultUID: vaultAccount.vaultUID, displayName: vaultAccount.vaultName)
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
-		viewModel = ChangePasswordViewModel(vaultAccount: vaultAccount, domain: domain, vaultManager: vaultManagerMock)
+		viewModel = withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			ChangePasswordViewModel(vaultAccount: vaultAccount, domain: domain, vaultManager: vaultManagerMock)
+		}
 	}
 
 	private func setupMocks() {

--- a/CryptomatorTests/DatabaseManagerTests.swift
+++ b/CryptomatorTests/DatabaseManagerTests.swift
@@ -16,15 +16,23 @@ import XCTest
 class DatabaseManagerTests: XCTestCase {
 	var tmpDir: URL!
 	var dbManager: DatabaseManager!
+	private var dbURL: URL!
+	private var database: DatabaseWriter!
 
 	override func setUpWithError() throws {
 		tmpDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
 		try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true, attributes: nil)
-		let dbURL = tmpDir.appendingPathComponent("db.sqlite")
-
-		DependencyValues.mockDependency(\.databaseLocation, with: dbURL)
-		DependencyValues.mockDependency(\.database, with: CryptomatorDatabase.live)
-		dbManager = DatabaseManager()
+		dbURL = tmpDir.appendingPathComponent("db.sqlite")
+		database = withDependencies {
+			$0.databaseLocation = dbURL
+		} operation: {
+			CryptomatorDatabase.live
+		}
+		dbManager = withDependencies {
+			$0.database = database
+		} operation: {
+			DatabaseManager()
+		}
 	}
 
 	override func tearDownWithError() throws {
@@ -34,9 +42,8 @@ class DatabaseManagerTests: XCTestCase {
 	// MARK: VaultListPosition
 
 	func testCreatePositionTrigger() throws {
-		@Dependency(\.database) var database
-		let cloudAccountManager = CloudProviderAccountDBManager()
-		let vaultAccountManager = VaultAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
+		let vaultAccountManager = makeVaultAccountManager()
 
 		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
@@ -61,10 +68,8 @@ class DatabaseManagerTests: XCTestCase {
 	}
 
 	func testDeleteVaultAccountUpdatesPositions() throws {
-		@Dependency(\.database) var database
-
-		let cloudAccountManager = CloudProviderAccountDBManager()
-		let vaultAccountManager = VaultAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
+		let vaultAccountManager = makeVaultAccountManager()
 
 		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
@@ -99,8 +104,8 @@ class DatabaseManagerTests: XCTestCase {
 	}
 
 	func testUpdateVaultListPositions() throws {
-		let cloudAccountManager = CloudProviderAccountDBManager()
-		let vaultAccountManager = VaultAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
+		let vaultAccountManager = makeVaultAccountManager()
 
 		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
 		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
@@ -112,7 +117,6 @@ class DatabaseManagerTests: XCTestCase {
 		try vaultAccountManager.saveNewAccount(thirdVaultAccount)
 
 		let vaults = try dbManager.getAllVaults()
-
 		let vaultListPositions = vaults.map { $0.vaultListPosition }
 		let updatedVaultListPositions: [VaultListPosition] = vaultListPositions.map {
 			var vaultListPosition = $0
@@ -132,8 +136,7 @@ class DatabaseManagerTests: XCTestCase {
 	// MARK: AccountListPosition
 
 	func testCreateAccountListPositionTrigger() throws {
-		@Dependency(\.database) var database
-		let cloudAccountManager = CloudProviderAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
 
 		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
@@ -167,8 +170,7 @@ class DatabaseManagerTests: XCTestCase {
 	}
 
 	func testDeleteCloudProviderAccountUpdatesPositions() throws {
-		@Dependency(\.database) var database
-		let cloudAccountManager = CloudProviderAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
 
 		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
@@ -212,7 +214,7 @@ class DatabaseManagerTests: XCTestCase {
 	}
 
 	func testUpdateAccountListPositions() throws {
-		let cloudAccountManager = CloudProviderAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
 
 		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
@@ -244,7 +246,7 @@ class DatabaseManagerTests: XCTestCase {
 	}
 
 	func testGetAllAccountsIsFiltered() throws {
-		let cloudAccountManager = CloudProviderAccountDBManager()
+		let cloudAccountManager = makeCloudAccountManager()
 
 		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
 		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
@@ -276,6 +278,22 @@ class DatabaseManagerTests: XCTestCase {
 
 		let googleDriveAccounts = try dbManager.getAllAccounts(for: .googleDrive)
 		XCTAssertEqual(0, googleDriveAccounts.count)
+	}
+
+	private func makeCloudAccountManager() -> CloudProviderAccountDBManager {
+		withDependencies {
+			$0.database = database
+		} operation: {
+			CloudProviderAccountDBManager()
+		}
+	}
+
+	private func makeVaultAccountManager() -> VaultAccountDBManager {
+		withDependencies {
+			$0.database = database
+		} operation: {
+			VaultAccountDBManager()
+		}
 	}
 }
 

--- a/CryptomatorTests/DatabaseManagerTests.swift
+++ b/CryptomatorTests/DatabaseManagerTests.swift
@@ -7,11 +7,11 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import GRDB
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class DatabaseManagerTests: XCTestCase {
 	var tmpDir: URL!

--- a/CryptomatorTests/DatabaseManagerTests.swift
+++ b/CryptomatorTests/DatabaseManagerTests.swift
@@ -15,7 +15,6 @@ import XCTest
 
 class DatabaseManagerTests: XCTestCase {
 	var tmpDir: URL!
-	var dbManager: DatabaseManager!
 	private var dbURL: URL!
 	private var database: DatabaseWriter!
 
@@ -28,11 +27,6 @@ class DatabaseManagerTests: XCTestCase {
 		} operation: {
 			CryptomatorDatabase.live
 		}
-		dbManager = withDependencies {
-			$0.database = database
-		} operation: {
-			DatabaseManager()
-		}
 	}
 
 	override func tearDownWithError() throws {
@@ -42,257 +36,272 @@ class DatabaseManagerTests: XCTestCase {
 	// MARK: VaultListPosition
 
 	func testCreatePositionTrigger() throws {
-		let cloudAccountManager = makeCloudAccountManager()
-		let vaultAccountManager = makeVaultAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let cloudAccountManager = CloudProviderAccountDBManager()
+			let vaultAccountManager = VaultAccountDBManager()
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
-		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
-		try vaultAccountManager.saveNewAccount(vaultAccount)
-		let firstVaultListPosition = try database.read { db in
-			try VaultListPosition.filter(Column("vaultUID") == "Vault1").fetchOne(db)
+			let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(cloudProviderAccount)
+			let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
+			try vaultAccountManager.saveNewAccount(vaultAccount)
+			let firstVaultListPosition = try database.read { db in
+				try VaultListPosition.filter(Column("vaultUID") == "Vault1").fetchOne(db)
+			}
+			XCTAssertNotNil(firstVaultListPosition)
+			XCTAssertEqual(0, firstVaultListPosition?.position)
+			XCTAssertEqual(1, firstVaultListPosition?.id)
+
+			let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
+			try vaultAccountManager.saveNewAccount(secondVaultAccount)
+
+			let secondVaultListPosition = try database.read { db in
+				try VaultListPosition.filter(Column("vaultUID") == "Vault2").fetchOne(db)
+			}
+			XCTAssertNotNil(secondVaultListPosition)
+			XCTAssertEqual(1, secondVaultListPosition?.position)
+			XCTAssertEqual(2, secondVaultListPosition?.id)
 		}
-		XCTAssertNotNil(firstVaultListPosition)
-		XCTAssertEqual(0, firstVaultListPosition?.position)
-		XCTAssertEqual(1, firstVaultListPosition?.id)
-
-		let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
-		try vaultAccountManager.saveNewAccount(secondVaultAccount)
-
-		let secondVaultListPosition = try database.read { db in
-			try VaultListPosition.filter(Column("vaultUID") == "Vault2").fetchOne(db)
-		}
-		XCTAssertNotNil(secondVaultListPosition)
-		XCTAssertEqual(1, secondVaultListPosition?.position)
-		XCTAssertEqual(2, secondVaultListPosition?.id)
 	}
 
 	func testDeleteVaultAccountUpdatesPositions() throws {
-		let cloudAccountManager = makeCloudAccountManager()
-		let vaultAccountManager = makeVaultAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let cloudAccountManager = CloudProviderAccountDBManager()
+			let vaultAccountManager = VaultAccountDBManager()
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
-		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
-		try vaultAccountManager.saveNewAccount(vaultAccount)
-		let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
-		try vaultAccountManager.saveNewAccount(secondVaultAccount)
-		let thirdVaultAccount = VaultAccount(vaultUID: "Vault3", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault3"), vaultName: "Vault3")
-		try vaultAccountManager.saveNewAccount(thirdVaultAccount)
+			let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(cloudProviderAccount)
+			let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
+			try vaultAccountManager.saveNewAccount(vaultAccount)
+			let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
+			try vaultAccountManager.saveNewAccount(secondVaultAccount)
+			let thirdVaultAccount = VaultAccount(vaultUID: "Vault3", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault3"), vaultName: "Vault3")
+			try vaultAccountManager.saveNewAccount(thirdVaultAccount)
 
-		_ = try database.write { db in
-			try vaultAccount.delete(db)
+			_ = try database.write { db in
+				try vaultAccount.delete(db)
+			}
+
+			let vaultListPositionEntryForVault1 = try database.read { db in
+				try VaultListPosition.filter(Column("vaultUID") == "Vault1").fetchOne(db)
+			}
+			XCTAssertNil(vaultListPositionEntryForVault1)
+
+			let firstVaultListPosition = try database.read { db in
+				try VaultListPosition.filter(Column("vaultUID") == "Vault2").fetchOne(db)
+			}
+			XCTAssertNotNil(firstVaultListPosition)
+
+			let secondVaultListPosition = try database.read { db in
+				try VaultListPosition.filter(Column("vaultUID") == "Vault3").fetchOne(db)
+			}
+			XCTAssertNotNil(secondVaultListPosition)
+
+			// Order is preserved: Vault2 must come before Vault3, even if positions have gaps
+			XCTAssertTrue((firstVaultListPosition?.position ?? Int.min) < (secondVaultListPosition?.position ?? Int.min))
 		}
-
-		let vaultListPositionEntryForVault1 = try database.read { db in
-			try VaultListPosition.filter(Column("vaultUID") == "Vault1").fetchOne(db)
-		}
-		XCTAssertNil(vaultListPositionEntryForVault1)
-
-		let firstVaultListPosition = try database.read { db in
-			try VaultListPosition.filter(Column("vaultUID") == "Vault2").fetchOne(db)
-		}
-		XCTAssertNotNil(firstVaultListPosition)
-
-		let secondVaultListPosition = try database.read { db in
-			try VaultListPosition.filter(Column("vaultUID") == "Vault3").fetchOne(db)
-		}
-		XCTAssertNotNil(secondVaultListPosition)
-
-		// Order is preserved: Vault2 must come before Vault3, even if positions have gaps
-		XCTAssertTrue((firstVaultListPosition?.position ?? Int.min) < (secondVaultListPosition?.position ?? Int.min))
 	}
 
 	func testUpdateVaultListPositions() throws {
-		let cloudAccountManager = makeCloudAccountManager()
-		let vaultAccountManager = makeVaultAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let dbManager = DatabaseManager()
+			let cloudAccountManager = CloudProviderAccountDBManager()
+			let vaultAccountManager = VaultAccountDBManager()
 
-		let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(cloudProviderAccount)
-		let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
-		try vaultAccountManager.saveNewAccount(vaultAccount)
-		let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
-		try vaultAccountManager.saveNewAccount(secondVaultAccount)
-		let thirdVaultAccount = VaultAccount(vaultUID: "Vault3", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault3"), vaultName: "Vault3")
-		try vaultAccountManager.saveNewAccount(thirdVaultAccount)
+			let cloudProviderAccount = CloudProviderAccount(accountUID: "1", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(cloudProviderAccount)
+			let vaultAccount = VaultAccount(vaultUID: "Vault1", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault1"), vaultName: "Vault1")
+			try vaultAccountManager.saveNewAccount(vaultAccount)
+			let secondVaultAccount = VaultAccount(vaultUID: "Vault2", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault2"), vaultName: "Vault2")
+			try vaultAccountManager.saveNewAccount(secondVaultAccount)
+			let thirdVaultAccount = VaultAccount(vaultUID: "Vault3", delegateAccountUID: cloudProviderAccount.accountUID, vaultPath: CloudPath("/Vault3"), vaultName: "Vault3")
+			try vaultAccountManager.saveNewAccount(thirdVaultAccount)
 
-		let vaults = try dbManager.getAllVaults()
-		let vaultListPositions = vaults.map { $0.vaultListPosition }
-		let updatedVaultListPositions: [VaultListPosition] = vaultListPositions.map {
-			var vaultListPosition = $0
-			vaultListPosition.position! += 1
-			return vaultListPosition
+			let vaults = try dbManager.getAllVaults()
+			let vaultListPositions = vaults.map { $0.vaultListPosition }
+			let updatedVaultListPositions: [VaultListPosition] = vaultListPositions.map {
+				var vaultListPosition = $0
+				vaultListPosition.position! += 1
+				return vaultListPosition
+			}
+			try dbManager.updateVaultListPositions(updatedVaultListPositions)
+
+			let updatedVaults = try dbManager.getAllVaults()
+			let fetchedVaultListPositions = updatedVaults.map { $0.vaultListPosition }
+
+			let sortedUpdatedVaultListPositions = updatedVaultListPositions.sorted { $0.position! < $1.position! }
+			let sortedFetchedVaultListPositions = fetchedVaultListPositions.sorted { $0.position! < $1.position! }
+			XCTAssertEqual(sortedUpdatedVaultListPositions, sortedFetchedVaultListPositions)
 		}
-		try dbManager.updateVaultListPositions(updatedVaultListPositions)
-
-		let updatedVaults = try dbManager.getAllVaults()
-		let fetchedVaultListPositions = updatedVaults.map { $0.vaultListPosition }
-
-		let sortedUpdatedVaultListPositions = updatedVaultListPositions.sorted { $0.position! < $1.position! }
-		let sortedFetchedVaultListPositions = fetchedVaultListPositions.sorted { $0.position! < $1.position! }
-		XCTAssertEqual(sortedUpdatedVaultListPositions, sortedFetchedVaultListPositions)
 	}
 
 	// MARK: AccountListPosition
 
 	func testCreateAccountListPositionTrigger() throws {
-		let cloudAccountManager = makeCloudAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let cloudAccountManager = CloudProviderAccountDBManager()
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
+			let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
+			let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
+			let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
 
-		let firstWebDAVAccountListPosition = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
+			let firstWebDAVAccountListPosition = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
+			}
+			XCTAssertNotNil(firstWebDAVAccountListPosition)
+			XCTAssertEqual(0, firstWebDAVAccountListPosition?.position)
+			XCTAssertEqual(1, firstWebDAVAccountListPosition?.id)
+
+			let secondWebDAVAccountListPosition = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
+			}
+			XCTAssertNotNil(secondWebDAVAccountListPosition)
+			XCTAssertEqual(1, secondWebDAVAccountListPosition?.position)
+			XCTAssertEqual(2, secondWebDAVAccountListPosition?.id)
+
+			let firstDropboxAccountListPosition = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.dropbox).fetchOne(db)
+			}
+			XCTAssertNotNil(firstDropboxAccountListPosition)
+			XCTAssertEqual(0, firstDropboxAccountListPosition?.position)
+			XCTAssertEqual(3, firstDropboxAccountListPosition?.id)
 		}
-		XCTAssertNotNil(firstWebDAVAccountListPosition)
-		XCTAssertEqual(0, firstWebDAVAccountListPosition?.position)
-		XCTAssertEqual(1, firstWebDAVAccountListPosition?.id)
-
-		let secondWebDAVAccountListPosition = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.webDAV(type: .custom)).fetchOne(db)
-		}
-		XCTAssertNotNil(secondWebDAVAccountListPosition)
-		XCTAssertEqual(1, secondWebDAVAccountListPosition?.position)
-		XCTAssertEqual(2, secondWebDAVAccountListPosition?.id)
-
-		let firstDropboxAccountListPosition = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount" && Column("cloudProviderType") == CloudProviderType.dropbox).fetchOne(db)
-		}
-		XCTAssertNotNil(firstDropboxAccountListPosition)
-		XCTAssertEqual(0, firstDropboxAccountListPosition?.position)
-		XCTAssertEqual(3, firstDropboxAccountListPosition?.id)
 	}
 
 	func testDeleteCloudProviderAccountUpdatesPositions() throws {
-		let cloudAccountManager = makeCloudAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let cloudAccountManager = CloudProviderAccountDBManager()
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
+			let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
+			let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
+			let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
 
-		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
+			let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
 
-		_ = try database.write { db in
-			try firstWebdavCloudProviderAccount.delete(db)
+			_ = try database.write { db in
+				try firstWebdavCloudProviderAccount.delete(db)
+			}
+
+			let accountListPositionEntryForFirstWebDAVAccount = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount").fetchOne(db)
+			}
+			XCTAssertNil(accountListPositionEntryForFirstWebDAVAccount)
+
+			let firstAccountListPositionForWebDAV = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount").fetchOne(db)
+			}
+			XCTAssertNotNil(firstAccountListPositionForWebDAV)
+
+			let secondAccountListPositionForWebDAV = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "thirdWebdavCloudProviderAccount").fetchOne(db)
+			}
+			XCTAssertNotNil(secondAccountListPositionForWebDAV)
+
+			// Order is preserved: WebDAVAccount2 must come before WebDAVAccount3, even if positions have gaps
+			XCTAssertTrue((firstAccountListPositionForWebDAV?.position ?? Int.min) < (secondAccountListPositionForWebDAV?.position ?? Int.min))
+
+			let firstAccountListPositionForDropbox = try database.read { db in
+				try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount").fetchOne(db)
+			}
+			XCTAssertNotNil(firstAccountListPositionForDropbox)
+			XCTAssertEqual(0, firstAccountListPositionForDropbox?.position)
 		}
-
-		let accountListPositionEntryForFirstWebDAVAccount = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstWebdavCloudProviderAccount").fetchOne(db)
-		}
-		XCTAssertNil(accountListPositionEntryForFirstWebDAVAccount)
-
-		let firstAccountListPositionForWebDAV = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "secondWebdavCloudProviderAccount").fetchOne(db)
-		}
-		XCTAssertNotNil(firstAccountListPositionForWebDAV)
-
-		let secondAccountListPositionForWebDAV = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "thirdWebdavCloudProviderAccount").fetchOne(db)
-		}
-		XCTAssertNotNil(secondAccountListPositionForWebDAV)
-
-		// Order is preserved: WebDAVAccount2 must come before WebDAVAccount3, even if positions have gaps
-		XCTAssertTrue((firstAccountListPositionForWebDAV?.position ?? Int.min) < (secondAccountListPositionForWebDAV?.position ?? Int.min))
-
-		let firstAccountListPositionForDropbox = try database.read { db in
-			try AccountListPosition.filter(Column("accountUID") == "firstDropboxCloudProviderAccount").fetchOne(db)
-		}
-		XCTAssertNotNil(firstAccountListPositionForDropbox)
-		XCTAssertEqual(0, firstAccountListPositionForDropbox?.position)
 	}
 
 	func testUpdateAccountListPositions() throws {
-		let cloudAccountManager = makeCloudAccountManager()
+		try withDependencies {
+			$0.database = database
+		} operation: {
+			let dbManager = DatabaseManager()
+			let cloudAccountManager = CloudProviderAccountDBManager()
 
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
+			let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
 
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
+			let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
 
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
+			let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
 
-		let accounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
+			let accounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
 
-		XCTAssertEqual(3, accounts.count)
+			XCTAssertEqual(3, accounts.count)
 
-		let accountListPositions = accounts.map { $0.accountListPosition }
-		let updatedAccountListPositions: [AccountListPosition] = accountListPositions.map {
-			var accountListPosition = $0
-			accountListPosition.position! += 1
-			return accountListPosition
+			let accountListPositions = accounts.map { $0.accountListPosition }
+			let updatedAccountListPositions: [AccountListPosition] = accountListPositions.map {
+				var accountListPosition = $0
+				accountListPosition.position! += 1
+				return accountListPosition
+			}
+			try dbManager.updateAccountListPositions(updatedAccountListPositions)
+
+			let updatedAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
+			let fetchedAccountListPositions = updatedAccounts.map { $0.accountListPosition }
+
+			let sortedUpdatedAccountListPositions = updatedAccountListPositions.sorted { $0.position! < $1.position! }
+			let sortedFetchedAccountListPositions = fetchedAccountListPositions.sorted { $0.position! < $1.position! }
+			XCTAssertEqual(sortedUpdatedAccountListPositions, sortedFetchedAccountListPositions)
 		}
-		try dbManager.updateAccountListPositions(updatedAccountListPositions)
-
-		let updatedAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
-		let fetchedAccountListPositions = updatedAccounts.map { $0.accountListPosition }
-
-		let sortedUpdatedAccountListPositions = updatedAccountListPositions.sorted { $0.position! < $1.position! }
-		let sortedFetchedAccountListPositions = fetchedAccountListPositions.sorted { $0.position! < $1.position! }
-		XCTAssertEqual(sortedUpdatedAccountListPositions, sortedFetchedAccountListPositions)
 	}
 
 	func testGetAllAccountsIsFiltered() throws {
-		let cloudAccountManager = makeCloudAccountManager()
-
-		let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
-
-		let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
-
-		let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
-		try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
-
-		let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
-		try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
-
-		let webDAVAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
-
-		let expectedWebDAVAccountListPositions = [AccountListPosition(id: 1, position: 0, accountUID: firstWebdavCloudProviderAccount.accountUID),
-		                                          AccountListPosition(id: 2, position: 1, accountUID: secondWebdavCloudProviderAccount.accountUID),
-		                                          AccountListPosition(id: 3, position: 2, accountUID: thirdWebdavCloudProviderAccount.accountUID)]
-		let expectedWebDAVCloudAccounts = [firstWebdavCloudProviderAccount, secondWebdavCloudProviderAccount, thirdWebdavCloudProviderAccount]
-		let expectedWebDAVAccounts = expectedWebDAVAccountListPositions.enumerated().map { index, accountListPosition in
-			AccountInfo(cloudProviderAccount: expectedWebDAVCloudAccounts[index], accountListPosition: accountListPosition)
-		}
-		XCTAssertEqual(expectedWebDAVAccounts, webDAVAccounts)
-
-		let dropboxAccounts = try dbManager.getAllAccounts(for: .dropbox)
-		let expectedDropboxAccounts = [AccountInfo(cloudProviderAccount: firstDropboxCloudProviderAccount,
-		                                           accountListPosition: AccountListPosition(id: 4, position: 0, accountUID: firstDropboxCloudProviderAccount.accountUID))]
-		XCTAssertEqual(expectedDropboxAccounts, dropboxAccounts)
-
-		let googleDriveAccounts = try dbManager.getAllAccounts(for: .googleDrive)
-		XCTAssertEqual(0, googleDriveAccounts.count)
-	}
-
-	private func makeCloudAccountManager() -> CloudProviderAccountDBManager {
-		withDependencies {
+		try withDependencies {
 			$0.database = database
 		} operation: {
-			CloudProviderAccountDBManager()
-		}
-	}
+			let dbManager = DatabaseManager()
+			let cloudAccountManager = CloudProviderAccountDBManager()
 
-	private func makeVaultAccountManager() -> VaultAccountDBManager {
-		withDependencies {
-			$0.database = database
-		} operation: {
-			VaultAccountDBManager()
+			let firstWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "firstWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(firstWebdavCloudProviderAccount)
+
+			let secondWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "secondWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(secondWebdavCloudProviderAccount)
+
+			let thirdWebdavCloudProviderAccount = CloudProviderAccount(accountUID: "thirdWebdavCloudProviderAccount", cloudProviderType: .webDAV(type: .custom))
+			try cloudAccountManager.saveNewAccount(thirdWebdavCloudProviderAccount)
+
+			let firstDropboxCloudProviderAccount = CloudProviderAccount(accountUID: "firstDropboxCloudProviderAccount", cloudProviderType: .dropbox)
+			try cloudAccountManager.saveNewAccount(firstDropboxCloudProviderAccount)
+
+			let webDAVAccounts = try dbManager.getAllAccounts(for: .webDAV(type: .custom))
+
+			let expectedWebDAVAccountListPositions = [AccountListPosition(id: 1, position: 0, accountUID: firstWebdavCloudProviderAccount.accountUID),
+			                                          AccountListPosition(id: 2, position: 1, accountUID: secondWebdavCloudProviderAccount.accountUID),
+			                                          AccountListPosition(id: 3, position: 2, accountUID: thirdWebdavCloudProviderAccount.accountUID)]
+			let expectedWebDAVCloudAccounts = [firstWebdavCloudProviderAccount, secondWebdavCloudProviderAccount, thirdWebdavCloudProviderAccount]
+			let expectedWebDAVAccounts = expectedWebDAVAccountListPositions.enumerated().map { index, accountListPosition in
+				AccountInfo(cloudProviderAccount: expectedWebDAVCloudAccounts[index], accountListPosition: accountListPosition)
+			}
+			XCTAssertEqual(expectedWebDAVAccounts, webDAVAccounts)
+
+			let dropboxAccounts = try dbManager.getAllAccounts(for: .dropbox)
+			let expectedDropboxAccounts = [AccountInfo(cloudProviderAccount: firstDropboxCloudProviderAccount,
+			                                           accountListPosition: AccountListPosition(id: 4, position: 0, accountUID: firstDropboxCloudProviderAccount.accountUID))]
+			XCTAssertEqual(expectedDropboxAccounts, dropboxAccounts)
+
+			let googleDriveAccounts = try dbManager.getAllAccounts(for: .googleDrive)
+			XCTAssertEqual(0, googleDriveAccounts.count)
 		}
 	}
 }

--- a/CryptomatorTests/MoveVaultViewModelTests.swift
+++ b/CryptomatorTests/MoveVaultViewModelTests.swift
@@ -27,7 +27,6 @@ class MoveVaultViewModelTests: XCTestCase {
 	override func setUpWithError() throws {
 		setupMocks()
 		vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 	}
 
 	private func setupMocks() {
@@ -51,118 +50,145 @@ class MoveVaultViewModelTests: XCTestCase {
 	}
 
 	func testMoveVault() async throws {
-		let targetCloudPath = CloudPath("Baz")
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			let targetCloudPath = CloudPath("Baz")
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
 
-		vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
+			self.vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
 
-		try await viewModel.moveVault(to: targetCloudPath)
-		XCTAssertEqual(1, vaultManagerMock.moveVaultAccountToCallsCount)
-		XCTAssertEqual(targetCloudPath, vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
+			try await self.viewModel.moveVault(to: targetCloudPath)
+			XCTAssertEqual(1, self.vaultManagerMock.moveVaultAccountToCallsCount)
+			XCTAssertEqual(targetCloudPath, self.vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
 
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(self.vaultAccount.vaultUID)))
 
-		await fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	func testRejectVaultsInTheLocalFileSystem() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
-		await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("Baz")), "") { error in
-			XCTAssertEqual(.vaultNotEligibleForMove, error as? MoveVaultViewModelError)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
+			await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("Baz")), "") { error in
+				XCTAssertEqual(.vaultNotEligibleForMove, error as? MoveVaultViewModelError)
 
-			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
-		}
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+			}
+		})
 	}
 
 	func testRejectMoveRootVault() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Foo")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
-		await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("Bar")), "") { error in
-			XCTAssertEqual(.vaultNotEligibleForMove, error as? MoveVaultViewModelError)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Foo")
+			let viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+			await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("Bar")), "") { error in
+				XCTAssertEqual(.vaultNotEligibleForMove, error as? MoveVaultViewModelError)
 
-			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
-		}
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+			}
+		})
 	}
 
 	func testRejectMoveVaultIntoItself() async throws {
-		let targetCloudPath = vaultAccount.vaultPath.appendingPathComponent("Test")
-		await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: targetCloudPath), "") { error in
-			XCTAssertEqual(.moveVaultInsideItselfNotAllowed, error as? MoveVaultViewModelError)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			let targetCloudPath = self.vaultAccount.vaultPath.appendingPathComponent("Test")
+			await XCTAssertThrowsAsyncError(try await self.viewModel.moveVault(to: targetCloudPath), "") { error in
+				XCTAssertEqual(.moveVaultInsideItselfNotAllowed, error as? MoveVaultViewModelError)
 
-			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainCalled)
-			XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
-		}
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+				XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+			}
+		})
 	}
 
 	func testEnableMaintenanceModeFailed() async throws {
-		// Simulate enable maintenance mode failure
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			self.viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
 
-		await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("/Test")), "") { error in
-			XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
+			await XCTAssertThrowsAsyncError(try await self.viewModel.moveVault(to: CloudPath("/Test")), "") { error in
+				XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
 
-			XCTAssertFalse(vaultManagerMock.moveVaultAccountToCalled)
-			XCTAssertEqual(1, maintenanceHelperMock.enableMaintenanceModeReplyCallsCount)
-			XCTAssertFalse(maintenanceHelperMock.disableMaintenanceModeReplyCalled)
-		}
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+				XCTAssertEqual(1, self.maintenanceHelperMock.enableMaintenanceModeReplyCallsCount)
+				XCTAssertFalse(self.maintenanceHelperMock.disableMaintenanceModeReplyCalled)
+			}
+		})
 	}
 
 	func testDisableMaintenanceModeAfterVaultMoveFailure() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
-		// Simulate vault move failure
-		vaultManagerMock.moveVaultAccountToReturnValue = Promise(CloudProviderError.itemAlreadyExists)
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
+			self.vaultManagerMock.moveVaultAccountToReturnValue = Promise(CloudProviderError.itemAlreadyExists)
 
-		await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("/Test")), "") { error in
-			XCTAssertEqual(.itemAlreadyExists, error as? CloudProviderError)
+			await XCTAssertThrowsAsyncError(try await viewModel.moveVault(to: CloudPath("/Test")), "") { error in
+				XCTAssertEqual(.itemAlreadyExists, error as? CloudProviderError)
 
-			XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-			XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+				XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+				XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
 
-			XCTAssertEqual(1, self.vaultManagerMock.moveVaultAccountToCallsCount)
-		}
+				XCTAssertEqual(1, self.vaultManagerMock.moveVaultAccountToCallsCount)
+			}
 
-		wait(for: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	func testIsAllowedToMove() {
-		let moveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Test"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
-		XCTAssert(moveVaultViewModel.isAllowedToMove())
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let moveVaultViewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/Test"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			XCTAssert(moveVaultViewModel.isAllowedToMove())
 
-		// allowed to move for root path
-		let rootMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
-		XCTAssert(rootMoveVaultViewModel.isAllowedToMove())
+			let rootMoveVaultViewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			XCTAssert(rootMoveVaultViewModel.isAllowedToMove())
 
-		// not allowed to move for same location
-		let sameLocationMoveVaultViewModel = createViewModel(currentFolderChoosingCloudPath: CloudPath("/Foo"), vaultAccount: vaultAccount, cloudProviderType: .dropbox)
-		XCTAssertFalse(sameLocationMoveVaultViewModel.isAllowedToMove())
+			let sameLocationMoveVaultViewModel = self.createViewModel(currentFolderChoosingCloudPath: CloudPath("/Foo"), vaultAccount: self.vaultAccount, cloudProviderType: .dropbox)
+			XCTAssertFalse(sameLocationMoveVaultViewModel.isAllowedToMove())
+		}
 	}
 
 	private func createViewModel(currentFolderChoosingCloudPath: CloudPath, vaultAccount: VaultAccount, cloudProviderType: CloudProviderType) -> MoveVaultViewModel {
@@ -170,14 +196,10 @@ class MoveVaultViewModelTests: XCTestCase {
 		let vaultListPosition = VaultListPosition(id: 1, position: 1, vaultUID: vaultAccount.vaultUID)
 		let vaultInfo = VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
 		let domain = NSFileProviderDomain(vaultUID: vaultInfo.vaultUID, displayName: vaultInfo.vaultName)
-		return withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			MoveVaultViewModel(provider: cloudProviderMock,
-			                   currentFolderChoosingCloudPath: currentFolderChoosingCloudPath,
-			                   vaultInfo: vaultInfo,
-			                   domain: domain,
-			                   vaultManager: vaultManagerMock)
-		}
+		return MoveVaultViewModel(provider: cloudProviderMock,
+		                          currentFolderChoosingCloudPath: currentFolderChoosingCloudPath,
+		                          vaultInfo: vaultInfo,
+		                          domain: domain,
+		                          vaultManager: vaultManagerMock)
 	}
 }

--- a/CryptomatorTests/MoveVaultViewModelTests.swift
+++ b/CryptomatorTests/MoveVaultViewModelTests.swift
@@ -37,8 +37,6 @@ class MoveVaultViewModelTests: XCTestCase {
 		maintenanceHelperMock = MaintenanceModeHelperMock()
 		vaultLockingMock = VaultLockingMock()
 
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
-
 		fileProviderConnectorMock.getXPCServiceNameDomainClosure = { serviceName, _ in
 			switch serviceName {
 			case .maintenanceModeHelper:
@@ -172,10 +170,14 @@ class MoveVaultViewModelTests: XCTestCase {
 		let vaultListPosition = VaultListPosition(id: 1, position: 1, vaultUID: vaultAccount.vaultUID)
 		let vaultInfo = VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
 		let domain = NSFileProviderDomain(vaultUID: vaultInfo.vaultUID, displayName: vaultInfo.vaultName)
-		return MoveVaultViewModel(provider: cloudProviderMock,
-		                          currentFolderChoosingCloudPath: currentFolderChoosingCloudPath,
-		                          vaultInfo: vaultInfo,
-		                          domain: domain,
-		                          vaultManager: vaultManagerMock)
+		return withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			MoveVaultViewModel(provider: cloudProviderMock,
+			                   currentFolderChoosingCloudPath: currentFolderChoosingCloudPath,
+			                   vaultInfo: vaultInfo,
+			                   domain: domain,
+			                   vaultManager: vaultManagerMock)
+		}
 	}
 }

--- a/CryptomatorTests/MoveVaultViewModelTests.swift
+++ b/CryptomatorTests/MoveVaultViewModelTests.swift
@@ -8,12 +8,12 @@
 
 import CryptomatorCloudAccessCore
 import CryptomatorFileProvider
+import Dependencies
 import GRDB
 import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class MoveVaultViewModelTests: XCTestCase {
 	private var vaultManagerMock: VaultManagerMock!

--- a/CryptomatorTests/RenameVaultViewModelTests.swift
+++ b/CryptomatorTests/RenameVaultViewModelTests.swift
@@ -33,8 +33,6 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 		maintenanceHelperMock = MaintenanceModeHelperMock()
 		vaultLockingMock = VaultLockingMock()
 
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
-
 		fileProviderConnectorMock.getXPCServiceNameDomainClosure = { serviceName, _ in
 			switch serviceName {
 			case .maintenanceModeHelper:
@@ -202,7 +200,11 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 		let vaultListPosition = VaultListPosition(id: 1, position: 1, vaultUID: vaultAccount.vaultUID)
 		let vaultInfo = VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
 		let domain = NSFileProviderDomain(vaultUID: vaultInfo.vaultUID, displayName: vaultInfo.vaultName)
-		return RenameVaultViewModel(provider: CloudProviderMock(), vaultInfo: vaultInfo, domain: domain, vaultManager: vaultManagerMock)
+		return withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			RenameVaultViewModel(provider: CloudProviderMock(), vaultInfo: vaultInfo, domain: domain, vaultManager: vaultManagerMock)
+		}
 	}
 
 	private func checkMaintenanceModeEnabledThenDisabled() {

--- a/CryptomatorTests/RenameVaultViewModelTests.swift
+++ b/CryptomatorTests/RenameVaultViewModelTests.swift
@@ -8,12 +8,12 @@
 
 import CryptomatorCloudAccessCore
 import CryptomatorFileProvider
+import Dependencies
 import GRDB
 import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	private var vaultManagerMock: VaultManagerMock!

--- a/CryptomatorTests/RenameVaultViewModelTests.swift
+++ b/CryptomatorTests/RenameVaultViewModelTests.swift
@@ -23,8 +23,12 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 
 	override func setUpWithError() throws {
 		setupMocks()
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			self.viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		})
 	}
 
 	private func setupMocks() {
@@ -47,152 +51,178 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 	}
 
 	func testRejectsVaultsInTheLocalFileSystem() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .localFileSystem(type: .custom))
 
-		let newVaultName = "Baz"
-		setVaultName(newVaultName, viewModel: viewModel)
-		await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
-			XCTAssertEqual(.vaultNotEligibleForRename, error as? RenameVaultViewModelError)
-			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-		}
-		XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
-		XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+			let newVaultName = "Baz"
+			self.setVaultName(newVaultName, viewModel: viewModel)
+			await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
+				XCTAssertEqual(.vaultNotEligibleForRename, error as? RenameVaultViewModelError)
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+			}
+			XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+			XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+		})
 	}
 
 	func testRejectsRootVault() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let newVaultName = "Baz"
-		setVaultName(newVaultName, viewModel: viewModel)
-		await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
-			XCTAssertEqual(.vaultNotEligibleForRename, error as? RenameVaultViewModelError)
-			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-			self.checkMaintenanceModeNeitherEnabledNorDisabled()
-		}
+			let newVaultName = "Baz"
+			self.setVaultName(newVaultName, viewModel: viewModel)
+			await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
+				XCTAssertEqual(.vaultNotEligibleForRename, error as? RenameVaultViewModelError)
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+				self.checkMaintenanceModeNeitherEnabledNorDisabled()
+			}
+		})
 	}
 
 	func testRenameVault() async throws {
-		let oldVaultName = "Bar"
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: oldVaultName)
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let oldVaultName = "Bar"
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: oldVaultName)
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
 
-		vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
+			self.vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
 
-		XCTAssertEqual("Bar", viewModel.title)
-		let newVaultName = "Baz"
-		setVaultName(newVaultName, viewModel: viewModel)
-		XCTAssertEqual("Bar", viewModel.title)
-		try await viewModel.renameVault()
-		XCTAssertEqual(1, vaultManagerMock.moveVaultAccountToCallsCount)
-		XCTAssertEqual(CloudPath("/Foo/Baz"), vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
+			XCTAssertEqual("Bar", viewModel.title)
+			let newVaultName = "Baz"
+			self.setVaultName(newVaultName, viewModel: viewModel)
+			XCTAssertEqual("Bar", viewModel.title)
+			try await viewModel.renameVault()
+			XCTAssertEqual(1, self.vaultManagerMock.moveVaultAccountToCallsCount)
+			XCTAssertEqual(CloudPath("/Foo/Baz"), self.vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
 
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
 
-		await fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	func testRenameVaultWithOldNameAsSubstring() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
 
-		vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
+			self.vaultManagerMock.moveVaultAccountToReturnValue = Promise(())
 
-		let newVaultName = "Bar1"
-		setVaultName(newVaultName, viewModel: viewModel)
-		try await viewModel.renameVault()
-		XCTAssertEqual(1, vaultManagerMock.moveVaultAccountToCallsCount)
-		XCTAssertEqual(CloudPath("/Foo/Bar1"), vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
+			let newVaultName = "Bar1"
+			self.setVaultName(newVaultName, viewModel: viewModel)
+			try await viewModel.renameVault()
+			XCTAssertEqual(1, self.vaultManagerMock.moveVaultAccountToCallsCount)
+			XCTAssertEqual(CloudPath("/Foo/Bar1"), self.vaultManagerMock.moveVaultAccountToReceivedArguments?.targetVaultPath)
 
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
 
-		wait(for: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	func testRenameVaultWithSameName() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		setVaultName(vaultAccount.vaultName, viewModel: viewModel)
-		try await viewModel.renameVault()
-		XCTAssertFalse(vaultManagerMock.moveVaultAccountToCalled)
+			self.setVaultName(vaultAccount.vaultName, viewModel: viewModel)
+			try await viewModel.renameVault()
+			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
 
-		XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainCalled)
-		XCTAssertFalse(fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+			XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainCalled)
+			XCTAssertFalse(self.fileProviderConnectorMock.getXPCServiceNameDomainIdentifierCalled)
+		})
 	}
 
 	func testEnableMaintenanceModeFailed() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let newVaultName = "Baz"
-		setVaultName(newVaultName, viewModel: viewModel)
+			let newVaultName = "Baz"
+			self.setVaultName(newVaultName, viewModel: viewModel)
 
-		// Simulate enable maintenance mode failure
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = { $0(MaintenanceModeError.runningCloudTask as NSError) }
 
-		await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
-			XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
+			await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
+				XCTAssertEqual(.runningCloudTask, error as? MaintenanceModeError)
+				XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+			}
+			XCTAssert(self.vaultLockingMock.lockedVaults.isEmpty)
 			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
-		}
-		XCTAssert(vaultLockingMock.lockedVaults.isEmpty)
-		XCTAssertFalse(vaultManagerMock.moveVaultAccountToCalled)
-		XCTAssertFalse(maintenanceHelperMock.disableMaintenanceModeReplyCalled)
+			XCTAssertFalse(self.maintenanceHelperMock.disableMaintenanceModeReplyCalled)
+		})
 	}
 
 	func testDisableMaintenanceModeAfterVaultMoveFailure() async throws {
-		let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
-		let viewModel = createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
+		try await withDependencies({
+			$0.fileProviderConnector = fileProviderConnectorMock
+		}, operation: {
+			let vaultAccount = VaultAccount(vaultUID: UUID().uuidString, delegateAccountUID: UUID().uuidString, vaultPath: CloudPath("/Foo/Bar"), vaultName: "Bar")
+			let viewModel = self.createViewModel(vaultAccount: vaultAccount, cloudProviderType: .dropbox)
 
-		let newVaultName = "Baz"
-		setVaultName(newVaultName, viewModel: viewModel)
+			let newVaultName = "Baz"
+			self.setVaultName(newVaultName, viewModel: viewModel)
 
-		let maintenanceModeEnabled = XCTestExpectation()
-		let maintenanceModeDisabled = XCTestExpectation()
-		maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
-			maintenanceModeEnabled.fulfill()
-			$0(nil)
-		}
-		maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
-			maintenanceModeDisabled.fulfill()
-			$0(nil)
-		}
+			let maintenanceModeEnabled = XCTestExpectation()
+			let maintenanceModeDisabled = XCTestExpectation()
+			self.maintenanceHelperMock.enableMaintenanceModeReplyClosure = {
+				maintenanceModeEnabled.fulfill()
+				$0(nil)
+			}
+			self.maintenanceHelperMock.disableMaintenanceModeReplyClosure = {
+				maintenanceModeDisabled.fulfill()
+				$0(nil)
+			}
 
-		// Simulate vault move failure
-		vaultManagerMock.moveVaultAccountToThrowableError = CloudProviderError.itemAlreadyExists
+			self.vaultManagerMock.moveVaultAccountToThrowableError = CloudProviderError.itemAlreadyExists
 
-		await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
-			XCTAssertEqual(.itemAlreadyExists, error as? CloudProviderError)
-		}
-		XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-		XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
-		XCTAssertFalse(vaultManagerMock.moveVaultAccountToCalled)
-		await fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+			await XCTAssertThrowsAsyncError(try await viewModel.renameVault()) { error in
+				XCTAssertEqual(.itemAlreadyExists, error as? CloudProviderError)
+			}
+			XCTAssertEqual(1, self.vaultLockingMock.lockedVaults.count)
+			XCTAssertTrue(self.vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier(vaultAccount.vaultUID)))
+			XCTAssertFalse(self.vaultManagerMock.moveVaultAccountToCalled)
+			await self.fulfillment(of: [maintenanceModeEnabled, maintenanceModeDisabled], timeout: 5.0, enforceOrder: true)
+		})
 	}
 
 	private func createViewModel(vaultAccount: VaultAccount, cloudProviderType: CloudProviderType, viewControllerTitle: String? = nil) -> RenameVaultViewModel {
@@ -200,11 +230,7 @@ class RenameVaultViewModelTests: SetVaultNameViewModelTests {
 		let vaultListPosition = VaultListPosition(id: 1, position: 1, vaultUID: vaultAccount.vaultUID)
 		let vaultInfo = VaultInfo(vaultAccount: vaultAccount, cloudProviderAccount: cloudProviderAccount, vaultListPosition: vaultListPosition)
 		let domain = NSFileProviderDomain(vaultUID: vaultInfo.vaultUID, displayName: vaultInfo.vaultName)
-		return withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			RenameVaultViewModel(provider: CloudProviderMock(), vaultInfo: vaultInfo, domain: domain, vaultManager: vaultManagerMock)
-		}
+		return RenameVaultViewModel(provider: CloudProviderMock(), vaultInfo: vaultInfo, domain: domain, vaultManager: vaultManagerMock)
 	}
 
 	private func checkMaintenanceModeEnabledThenDisabled() {

--- a/CryptomatorTests/SettingsViewModelTests.swift
+++ b/CryptomatorTests/SettingsViewModelTests.swift
@@ -17,16 +17,14 @@ class SettingsViewModelTests: XCTestCase {
 	private var cryptomatorSettingsMock: CryptomatorSettingsMock!
 	private var fileProviderConnectorMock: FileProviderConnectorMock!
 	var settingsViewModel: SettingsViewModel!
-	var cacheManagerMock: CacheManagingMock!
+	private var cacheControllerMock: CacheControllerMock!
 
 	override func setUpWithError() throws {
-		cacheManagerMock = CacheManagingMock()
-		cacheManagerMock.clearCacheReplyClosure = { reply in
-			reply(nil)
-		}
+		cacheControllerMock = CacheControllerMock()
 		cryptomatorSettingsMock = CryptomatorSettingsMock()
 		fileProviderConnectorMock = FileProviderConnectorMock()
 		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
+		DependencyValues.mockDependency(\.cacheController, with: cacheControllerMock)
 		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
 	}
 
@@ -116,7 +114,7 @@ class SettingsViewModelTests: XCTestCase {
 	func testRefreshCacheSize() {
 		let expectation = XCTestExpectation()
 		let cacheSizeInBytes = 1024 * 1024
-		setCacheManagingResponse(to: cacheSizeInBytes)
+		setCacheControllerResponse(to: cacheSizeInBytes)
 		settingsViewModel.refreshCacheSize().always {
 			expectation.fulfill()
 		}
@@ -143,7 +141,7 @@ class SettingsViewModelTests: XCTestCase {
 
 	func testRefreshCacheSizeForEmptyCache() {
 		let expectation = XCTestExpectation()
-		setCacheManagingResponse(to: 0)
+		setCacheControllerResponse(to: 0)
 		settingsViewModel.refreshCacheSize().always {
 			expectation.fulfill()
 		}
@@ -155,13 +153,13 @@ class SettingsViewModelTests: XCTestCase {
 	func testClearCache() {
 		let expectation = XCTestExpectation()
 		let cacheSizeInBytes = 0
-		setCacheManagingResponse(to: cacheSizeInBytes)
+		setCacheControllerResponse(to: cacheSizeInBytes)
 		settingsViewModel.clearCache().always {
 			expectation.fulfill()
 		}
 		wait(for: [expectation], timeout: 5.0)
 
-		XCTAssertEqual(1, cacheManagerMock.clearCacheReplyCallsCount)
+		XCTAssertEqual(1, cacheControllerMock.clearCacheCallsCount)
 		checkEmptyCacheBehaviour()
 	}
 
@@ -319,11 +317,25 @@ class SettingsViewModelTests: XCTestCase {
 		return settingsViewModel.sections.filter({ $0.id == identifier }).first
 	}
 
-	private func setCacheManagingResponse(to totalCacheSizeInBytes: Int) {
-		cacheManagerMock.getLocalCacheSizeInBytesReplyClosure = { reply in
-			reply(totalCacheSizeInBytes as NSNumber, nil)
-		}
-		fileProviderConnectorMock.proxy = cacheManagerMock
+	private func setCacheControllerResponse(to totalCacheSizeInBytes: Int) {
+		cacheControllerMock.getLocalCacheSizeInBytesReturnValue = Promise(totalCacheSizeInBytes)
+	}
+}
+
+private final class CacheControllerMock: CacheControlling {
+	var getLocalCacheSizeInBytesCallsCount = 0
+	var getLocalCacheSizeInBytesReturnValue = Promise(0)
+	var clearCacheCallsCount = 0
+	var clearCacheReturnValue = Promise(())
+
+	func getLocalCacheSizeInBytes() -> Promise<Int> {
+		getLocalCacheSizeInBytesCallsCount += 1
+		return getLocalCacheSizeInBytesReturnValue
+	}
+
+	func clearCache() -> Promise<Void> {
+		clearCacheCallsCount += 1
+		return clearCacheReturnValue
 	}
 }
 

--- a/CryptomatorTests/SettingsViewModelTests.swift
+++ b/CryptomatorTests/SettingsViewModelTests.swift
@@ -23,9 +23,7 @@ class SettingsViewModelTests: XCTestCase {
 		cacheControllerMock = CacheControllerMock()
 		cryptomatorSettingsMock = CryptomatorSettingsMock()
 		fileProviderConnectorMock = FileProviderConnectorMock()
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
-		DependencyValues.mockDependency(\.cacheController, with: cacheControllerMock)
-		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		settingsViewModel = createSettingsViewModel()
 	}
 
 	// - MARK: Unlock Full Version / Upgrade to Lifetime
@@ -33,7 +31,7 @@ class SettingsViewModelTests: XCTestCase {
 	func testNonPayingUserSeesUnlockFullVersion() {
 		cryptomatorSettingsMock.hasRunningSubscription = false
 		cryptomatorSettingsMock.fullVersionUnlocked = false
-		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		settingsViewModel = createSettingsViewModel()
 		guard let section = getSection(for: .unlockFullVersionSection) else {
 			XCTFail("Missing unlockFullVersionSection")
 			return
@@ -48,7 +46,7 @@ class SettingsViewModelTests: XCTestCase {
 	func testSubscriberSeesUpgradeToLifetimeInAboutSection() {
 		cryptomatorSettingsMock.hasRunningSubscription = true
 		cryptomatorSettingsMock.fullVersionUnlocked = false
-		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		settingsViewModel = createSettingsViewModel()
 		let unlockSection = getSection(for: .unlockFullVersionSection)
 		XCTAssertNil(unlockSection, "Subscriber should not see unlockFullVersionSection")
 		guard let aboutSection = getSection(for: .aboutSection) else {
@@ -62,7 +60,7 @@ class SettingsViewModelTests: XCTestCase {
 	func testLifetimeOwnerSeesNoUpgradeToLifetime() {
 		cryptomatorSettingsMock.hasRunningSubscription = false
 		cryptomatorSettingsMock.fullVersionUnlocked = true
-		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		settingsViewModel = createSettingsViewModel()
 		let unlockSection = getSection(for: .unlockFullVersionSection)
 		XCTAssertNil(unlockSection)
 		guard let aboutSection = getSection(for: .aboutSection) else {
@@ -76,7 +74,7 @@ class SettingsViewModelTests: XCTestCase {
 	func testSubscriberWithLifetimeSeesNoUpgradeToLifetime() {
 		cryptomatorSettingsMock.hasRunningSubscription = true
 		cryptomatorSettingsMock.fullVersionUnlocked = true
-		settingsViewModel = SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		settingsViewModel = createSettingsViewModel()
 		guard let aboutSection = getSection(for: .aboutSection) else {
 			XCTFail("Missing aboutSection")
 			return
@@ -220,6 +218,7 @@ class SettingsViewModelTests: XCTestCase {
 			invalidationExpectation.fulfill()
 		}
 		cryptomatorSettingsMock.debugModeEnabled = true
+		settingsViewModel = createSettingsViewModel()
 		guard let debugSection = getSection(for: .debugSection) else {
 			XCTFail("Missing debugSection")
 			return
@@ -319,6 +318,15 @@ class SettingsViewModelTests: XCTestCase {
 
 	private func setCacheControllerResponse(to totalCacheSizeInBytes: Int) {
 		cacheControllerMock.getLocalCacheSizeInBytesReturnValue = Promise(totalCacheSizeInBytes)
+	}
+
+	private func createSettingsViewModel() -> SettingsViewModel {
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
+		}
 	}
 }
 

--- a/CryptomatorTests/SettingsViewModelTests.swift
+++ b/CryptomatorTests/SettingsViewModelTests.swift
@@ -23,142 +23,185 @@ class SettingsViewModelTests: XCTestCase {
 		cacheControllerMock = CacheControllerMock()
 		cryptomatorSettingsMock = CryptomatorSettingsMock()
 		fileProviderConnectorMock = FileProviderConnectorMock()
-		settingsViewModel = createSettingsViewModel()
 	}
 
 	// - MARK: Unlock Full Version / Upgrade to Lifetime
 
 	func testNonPayingUserSeesUnlockFullVersion() {
-		cryptomatorSettingsMock.hasRunningSubscription = false
-		cryptomatorSettingsMock.fullVersionUnlocked = false
-		settingsViewModel = createSettingsViewModel()
-		guard let section = getSection(for: .unlockFullVersionSection) else {
-			XCTFail("Missing unlockFullVersionSection")
-			return
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.cryptomatorSettingsMock.hasRunningSubscription = false
+			self.cryptomatorSettingsMock.fullVersionUnlocked = false
+			self.settingsViewModel = self.createSettingsViewModel()
+			guard let section = self.getSection(for: .unlockFullVersionSection) else {
+				XCTFail("Missing unlockFullVersionSection")
+				return
+			}
+			guard let cellViewModel = section.elements[0] as? ButtonCellViewModel<SettingsButtonAction> else {
+				XCTFail("Missing cellViewModel")
+				return
+			}
+			XCTAssertEqual(.showUnlockFullVersion, cellViewModel.action)
 		}
-		guard let cellViewModel = section.elements[0] as? ButtonCellViewModel<SettingsButtonAction> else {
-			XCTFail("Missing cellViewModel")
-			return
-		}
-		XCTAssertEqual(.showUnlockFullVersion, cellViewModel.action)
 	}
 
 	func testSubscriberSeesUpgradeToLifetimeInAboutSection() {
-		cryptomatorSettingsMock.hasRunningSubscription = true
-		cryptomatorSettingsMock.fullVersionUnlocked = false
-		settingsViewModel = createSettingsViewModel()
-		let unlockSection = getSection(for: .unlockFullVersionSection)
-		XCTAssertNil(unlockSection, "Subscriber should not see unlockFullVersionSection")
-		guard let aboutSection = getSection(for: .aboutSection) else {
-			XCTFail("Missing aboutSection")
-			return
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.cryptomatorSettingsMock.hasRunningSubscription = true
+			self.cryptomatorSettingsMock.fullVersionUnlocked = false
+			self.settingsViewModel = self.createSettingsViewModel()
+			let unlockSection = self.getSection(for: .unlockFullVersionSection)
+			XCTAssertNil(unlockSection, "Subscriber should not see unlockFullVersionSection")
+			guard let aboutSection = self.getSection(for: .aboutSection) else {
+				XCTFail("Missing aboutSection")
+				return
+			}
+			let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
+			XCTAssertNotNil(upgradeCell)
 		}
-		let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
-		XCTAssertNotNil(upgradeCell)
 	}
 
 	func testLifetimeOwnerSeesNoUpgradeToLifetime() {
-		cryptomatorSettingsMock.hasRunningSubscription = false
-		cryptomatorSettingsMock.fullVersionUnlocked = true
-		settingsViewModel = createSettingsViewModel()
-		let unlockSection = getSection(for: .unlockFullVersionSection)
-		XCTAssertNil(unlockSection)
-		guard let aboutSection = getSection(for: .aboutSection) else {
-			XCTFail("Missing aboutSection")
-			return
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.cryptomatorSettingsMock.hasRunningSubscription = false
+			self.cryptomatorSettingsMock.fullVersionUnlocked = true
+			self.settingsViewModel = self.createSettingsViewModel()
+			let unlockSection = self.getSection(for: .unlockFullVersionSection)
+			XCTAssertNil(unlockSection)
+			guard let aboutSection = self.getSection(for: .aboutSection) else {
+				XCTFail("Missing aboutSection")
+				return
+			}
+			let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
+			XCTAssertNil(upgradeCell)
 		}
-		let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
-		XCTAssertNil(upgradeCell)
 	}
 
 	func testSubscriberWithLifetimeSeesNoUpgradeToLifetime() {
-		cryptomatorSettingsMock.hasRunningSubscription = true
-		cryptomatorSettingsMock.fullVersionUnlocked = true
-		settingsViewModel = createSettingsViewModel()
-		guard let aboutSection = getSection(for: .aboutSection) else {
-			XCTFail("Missing aboutSection")
-			return
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.cryptomatorSettingsMock.hasRunningSubscription = true
+			self.cryptomatorSettingsMock.fullVersionUnlocked = true
+			self.settingsViewModel = self.createSettingsViewModel()
+			guard let aboutSection = self.getSection(for: .aboutSection) else {
+				XCTFail("Missing aboutSection")
+				return
+			}
+			let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
+			XCTAssertNil(upgradeCell)
 		}
-		let upgradeCell = aboutSection.elements.compactMap { $0 as? ButtonCellViewModel<SettingsButtonAction> }.first { $0.action == .showUpgradeToLifetime }
-		XCTAssertNil(upgradeCell)
 	}
 
 	// - MARK: Cache Section
 
 	func testInitialStateOfCacheSection() {
-		guard let cacheSection = getSection(for: .cacheSection) else {
-			XCTFail("Missing cacheSection")
-			return
-		}
-		guard let cacheSizeCellViewModel = cacheSection.elements[0] as? LoadingWithLabelCellViewModel else {
-			XCTFail("Missing cacheSizeCellViewModel")
-			return
-		}
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			guard let cacheSection = self.getSection(for: .cacheSection) else {
+				XCTFail("Missing cacheSection")
+				return
+			}
+			guard let cacheSizeCellViewModel = cacheSection.elements[0] as? LoadingWithLabelCellViewModel else {
+				XCTFail("Missing cacheSizeCellViewModel")
+				return
+			}
 
-		XCTAssertFalse(cacheSizeCellViewModel.isLoading.value)
-		XCTAssertEqual(LocalizedString.getValue("settings.cacheSize"), cacheSizeCellViewModel.title.value)
-		XCTAssertNil(cacheSizeCellViewModel.detailTitle.value)
+			XCTAssertFalse(cacheSizeCellViewModel.isLoading.value)
+			XCTAssertEqual(LocalizedString.getValue("settings.cacheSize"), cacheSizeCellViewModel.title.value)
+			XCTAssertNil(cacheSizeCellViewModel.detailTitle.value)
 
-		guard let clearCacheButtonCellViewModel = cacheSection.elements[1] as? ButtonCellViewModel<SettingsButtonAction> else {
-			XCTFail("Missing clearCacheButtonCellViewModel")
-			return
+			guard let clearCacheButtonCellViewModel = cacheSection.elements[1] as? ButtonCellViewModel<SettingsButtonAction> else {
+				XCTFail("Missing clearCacheButtonCellViewModel")
+				return
+			}
+			XCTAssertEqual(.clearCache, clearCacheButtonCellViewModel.action)
+			XCTAssertFalse(clearCacheButtonCellViewModel.isEnabled.value)
+			XCTAssertEqual(LocalizedString.getValue("settings.clearCache"), clearCacheButtonCellViewModel.title.value)
+			XCTAssertNil(clearCacheButtonCellViewModel.detailTitle.value)
 		}
-		XCTAssertEqual(.clearCache, clearCacheButtonCellViewModel.action)
-		XCTAssertFalse(clearCacheButtonCellViewModel.isEnabled.value)
-		XCTAssertEqual(LocalizedString.getValue("settings.clearCache"), clearCacheButtonCellViewModel.title.value)
-		XCTAssertNil(clearCacheButtonCellViewModel.detailTitle.value)
 	}
 
 	func testRefreshCacheSize() {
-		let expectation = XCTestExpectation()
-		let cacheSizeInBytes = 1024 * 1024
-		setCacheControllerResponse(to: cacheSizeInBytes)
-		settingsViewModel.refreshCacheSize().always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 5.0)
-		guard let cacheSection = getSection(for: .cacheSection) else {
-			XCTFail("Missing cacheSection")
-			return
-		}
-		guard let cacheSizeCellViewModel = cacheSection.elements[0] as? LoadingWithLabelCellViewModel else {
-			XCTFail("Missing cacheSizeCellViewModel")
-			return
-		}
-		let cacheSizeDisplayText = ByteCountFormatter().string(fromByteCount: Int64(cacheSizeInBytes))
-		XCTAssertEqual(cacheSizeDisplayText, cacheSizeCellViewModel.detailTitle.value)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			let expectation = XCTestExpectation()
+			let cacheSizeInBytes = 1024 * 1024
+			self.setCacheControllerResponse(to: cacheSizeInBytes)
+			self.settingsViewModel.refreshCacheSize().always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			guard let cacheSection = self.getSection(for: .cacheSection) else {
+				XCTFail("Missing cacheSection")
+				return
+			}
+			guard let cacheSizeCellViewModel = cacheSection.elements[0] as? LoadingWithLabelCellViewModel else {
+				XCTFail("Missing cacheSizeCellViewModel")
+				return
+			}
+			let cacheSizeDisplayText = ByteCountFormatter().string(fromByteCount: Int64(cacheSizeInBytes))
+			XCTAssertEqual(cacheSizeDisplayText, cacheSizeCellViewModel.detailTitle.value)
 
-		guard let clearCacheButtonCellViewModel = cacheSection.elements[1] as? ButtonCellViewModel<SettingsButtonAction> else {
-			XCTFail("Missing clearCacheButtonCellViewModel")
-			return
+			guard let clearCacheButtonCellViewModel = cacheSection.elements[1] as? ButtonCellViewModel<SettingsButtonAction> else {
+				XCTFail("Missing clearCacheButtonCellViewModel")
+				return
+			}
+			XCTAssertEqual(.clearCache, clearCacheButtonCellViewModel.action)
+			XCTAssertTrue(clearCacheButtonCellViewModel.isEnabled.value)
+			XCTAssertFalse(cacheSizeCellViewModel.isLoading.value)
 		}
-		XCTAssertEqual(.clearCache, clearCacheButtonCellViewModel.action)
-		XCTAssertTrue(clearCacheButtonCellViewModel.isEnabled.value)
-		XCTAssertFalse(cacheSizeCellViewModel.isLoading.value)
 	}
 
 	func testRefreshCacheSizeForEmptyCache() {
-		let expectation = XCTestExpectation()
-		setCacheControllerResponse(to: 0)
-		settingsViewModel.refreshCacheSize().always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 5.0)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			let expectation = XCTestExpectation()
+			self.setCacheControllerResponse(to: 0)
+			self.settingsViewModel.refreshCacheSize().always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
 
-		checkEmptyCacheBehaviour()
+			self.checkEmptyCacheBehaviour()
+		}
 	}
 
 	func testClearCache() {
-		let expectation = XCTestExpectation()
-		let cacheSizeInBytes = 0
-		setCacheControllerResponse(to: cacheSizeInBytes)
-		settingsViewModel.clearCache().always {
-			expectation.fulfill()
-		}
-		wait(for: [expectation], timeout: 5.0)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			let expectation = XCTestExpectation()
+			let cacheSizeInBytes = 0
+			self.setCacheControllerResponse(to: cacheSizeInBytes)
+			self.settingsViewModel.clearCache().always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
 
-		XCTAssertEqual(1, cacheControllerMock.clearCacheCallsCount)
-		checkEmptyCacheBehaviour()
+			XCTAssertEqual(1, self.cacheControllerMock.clearCacheCallsCount)
+			self.checkEmptyCacheBehaviour()
+		}
 	}
 
 	func checkEmptyCacheBehaviour() {
@@ -184,112 +227,132 @@ class SettingsViewModelTests: XCTestCase {
 	// - MARK: Debug Section
 
 	func testDisabledDebugMode() {
-		cryptomatorSettingsMock.debugModeEnabled = false
-		guard let debugSection = getSection(for: .debugSection) else {
-			XCTFail("Missing debugSection")
-			return
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.cryptomatorSettingsMock.debugModeEnabled = false
+			self.settingsViewModel = self.createSettingsViewModel()
+			guard let debugSection = self.getSection(for: .debugSection) else {
+				XCTFail("Missing debugSection")
+				return
+			}
+			guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
+				XCTFail("Missing debugModeCellViewModel")
+				return
+			}
+			XCTAssertFalse(debugModeCellViewModel.isOn.value)
+			XCTAssertTrue(debugModeCellViewModel.isEnabled.value)
+
+			self.checkSendLogFilesCellViewModel()
+
+			let showDebugModeWarningRecorder = self.settingsViewModel.showDebugModeWarning.recordNext(1)
+
+			debugModeCellViewModel.isOnButtonPublisher.send(true)
+
+			self.wait(for: showDebugModeWarningRecorder)
+
+			XCTAssertFalse(self.cryptomatorSettingsMock.debugModeEnabled)
+			self.checkSendLogFilesCellViewModel()
 		}
-		guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
-			XCTFail("Missing debugModeCellViewModel")
-			return
-		}
-		XCTAssertFalse(debugModeCellViewModel.isOn.value)
-		XCTAssertTrue(debugModeCellViewModel.isEnabled.value)
-
-		checkSendLogFilesCellViewModel()
-
-		let showDebugModeWarningRecorder = settingsViewModel.showDebugModeWarning.recordNext(1)
-
-		// Simulate Debug toggle
-		debugModeCellViewModel.isOnButtonPublisher.send(true)
-
-		// Check showDebugModeWarning fired
-		wait(for: showDebugModeWarningRecorder)
-
-		XCTAssertFalse(cryptomatorSettingsMock.debugModeEnabled)
-		checkSendLogFilesCellViewModel()
 	}
 
 	func testEnabledDebugMode() {
-		let invalidationExpectation = XCTestExpectation()
-		let logLevelUpdatingMock = LogLevelUpdatingMock()
-		fileProviderConnectorMock.proxy = logLevelUpdatingMock
-		fileProviderConnectorMock.doneHandler = {
-			invalidationExpectation.fulfill()
-		}
-		cryptomatorSettingsMock.debugModeEnabled = true
-		settingsViewModel = createSettingsViewModel()
-		guard let debugSection = getSection(for: .debugSection) else {
-			XCTFail("Missing debugSection")
-			return
-		}
-		guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
-			XCTFail("Missing debugModeCellViewModel")
-			return
-		}
-		XCTAssertTrue(debugModeCellViewModel.isOn.value)
-		XCTAssertTrue(debugModeCellViewModel.isEnabled.value)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			let invalidationExpectation = XCTestExpectation()
+			let logLevelUpdatingMock = LogLevelUpdatingMock()
+			self.fileProviderConnectorMock.proxy = logLevelUpdatingMock
+			self.fileProviderConnectorMock.doneHandler = {
+				invalidationExpectation.fulfill()
+			}
+			self.cryptomatorSettingsMock.debugModeEnabled = true
+			self.settingsViewModel = self.createSettingsViewModel()
+			guard let debugSection = self.getSection(for: .debugSection) else {
+				XCTFail("Missing debugSection")
+				return
+			}
+			guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
+				XCTFail("Missing debugModeCellViewModel")
+				return
+			}
+			XCTAssertTrue(debugModeCellViewModel.isOn.value)
+			XCTAssertTrue(debugModeCellViewModel.isEnabled.value)
 
-		checkSendLogFilesCellViewModel()
+			self.checkSendLogFilesCellViewModel()
 
-		// Simulate Debug toggle
-		let expectation = XCTestExpectation()
-		debugModeCellViewModel.isOnButtonPublisher.send(false)
-		logLevelUpdatingMock.updated.then {
-			XCTAssertFalse(self.cryptomatorSettingsMock.debugModeEnabled)
-			self.checkLogLevelUpdatingServiceSourceCall()
-			expectation.fulfill()
+			let expectation = XCTestExpectation()
+			debugModeCellViewModel.isOnButtonPublisher.send(false)
+			logLevelUpdatingMock.updated.then {
+				XCTAssertFalse(self.cryptomatorSettingsMock.debugModeEnabled)
+				self.checkLogLevelUpdatingServiceSourceCall()
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation, invalidationExpectation], timeout: 5.0)
+			self.checkSendLogFilesCellViewModel()
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		wait(for: [expectation, invalidationExpectation], timeout: 5.0)
-		checkSendLogFilesCellViewModel()
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testEnableDebugMode() {
-		let invalidationExpectation = XCTestExpectation()
-		let expectation = XCTestExpectation()
-		let logLevelUpdatingMock = LogLevelUpdatingMock()
-		fileProviderConnectorMock.proxy = logLevelUpdatingMock
-		fileProviderConnectorMock.doneHandler = {
-			invalidationExpectation.fulfill()
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			let invalidationExpectation = XCTestExpectation()
+			let expectation = XCTestExpectation()
+			let logLevelUpdatingMock = LogLevelUpdatingMock()
+			self.fileProviderConnectorMock.proxy = logLevelUpdatingMock
+			self.fileProviderConnectorMock.doneHandler = {
+				invalidationExpectation.fulfill()
+			}
+			self.settingsViewModel.enableDebugMode()
+			logLevelUpdatingMock.updated.then {
+				XCTAssertTrue(self.cryptomatorSettingsMock.debugModeEnabled)
+				self.checkLogLevelUpdatingServiceSourceCall()
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation, invalidationExpectation], timeout: 5.0)
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		settingsViewModel.enableDebugMode()
-		logLevelUpdatingMock.updated.then {
-			XCTAssertTrue(self.cryptomatorSettingsMock.debugModeEnabled)
-			self.checkLogLevelUpdatingServiceSourceCall()
-			expectation.fulfill()
-		}
-		wait(for: [expectation, invalidationExpectation], timeout: 5.0)
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testDisableDebugMode() {
-		let invalidationExpectation = XCTestExpectation()
-		let expectation = XCTestExpectation()
-		let logLevelUpdatingMock = LogLevelUpdatingMock()
-		fileProviderConnectorMock.proxy = logLevelUpdatingMock
-		fileProviderConnectorMock.doneHandler = {
-			invalidationExpectation.fulfill()
-		}
-		guard let debugSection = getSection(for: .debugSection) else {
-			XCTFail("Missing debugSection")
-			return
-		}
-		guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
-			XCTFail("Missing debugModeCellViewModel")
-			return
-		}
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+			$0.cacheController = cacheControllerMock
+		} operation: {
+			self.settingsViewModel = self.createSettingsViewModel()
+			let invalidationExpectation = XCTestExpectation()
+			let expectation = XCTestExpectation()
+			let logLevelUpdatingMock = LogLevelUpdatingMock()
+			self.fileProviderConnectorMock.proxy = logLevelUpdatingMock
+			self.fileProviderConnectorMock.doneHandler = {
+				invalidationExpectation.fulfill()
+			}
+			guard let debugSection = self.getSection(for: .debugSection) else {
+				XCTFail("Missing debugSection")
+				return
+			}
+			guard let debugModeCellViewModel = debugSection.elements[0] as? SwitchCellViewModel else {
+				XCTFail("Missing debugModeCellViewModel")
+				return
+			}
 
-		settingsViewModel.disableDebugMode()
+			self.settingsViewModel.disableDebugMode()
 
-		XCTAssertFalse(debugModeCellViewModel.isOn.value)
-		logLevelUpdatingMock.updated.then {
-			XCTAssertFalse(self.cryptomatorSettingsMock.debugModeEnabled)
-			self.checkLogLevelUpdatingServiceSourceCall()
-			expectation.fulfill()
+			XCTAssertFalse(debugModeCellViewModel.isOn.value)
+			logLevelUpdatingMock.updated.then {
+				XCTAssertFalse(self.cryptomatorSettingsMock.debugModeEnabled)
+				self.checkLogLevelUpdatingServiceSourceCall()
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation, invalidationExpectation], timeout: 5.0)
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		wait(for: [expectation, invalidationExpectation], timeout: 5.0)
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	private func checkSendLogFilesCellViewModel() {
@@ -321,12 +384,7 @@ class SettingsViewModelTests: XCTestCase {
 	}
 
 	private func createSettingsViewModel() -> SettingsViewModel {
-		withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-			$0.cacheController = cacheControllerMock
-		} operation: {
-			SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
-		}
+		SettingsViewModel(cryptomatorSettings: cryptomatorSettingsMock)
 	}
 }
 

--- a/CryptomatorTests/SettingsViewModelTests.swift
+++ b/CryptomatorTests/SettingsViewModelTests.swift
@@ -6,12 +6,12 @@
 //  Copyright © 2021 Skymatic GmbH. All rights reserved.
 //
 
+import Dependencies
 import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
-@testable import Dependencies
 
 class SettingsViewModelTests: XCTestCase {
 	private var cryptomatorSettingsMock: CryptomatorSettingsMock!

--- a/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
+++ b/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
@@ -30,185 +30,217 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 	}
 
 	func testDefaultConfiguration() throws {
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
-		XCTAssertEqual(.auto, currentKeepUnlockedDuration.value)
-		XCTAssertEqual(LocalizedString.getValue("vaultDetail.keepUnlocked.title"), viewModel.title)
+		try withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
+			XCTAssertEqual(.auto, currentKeepUnlockedDuration.value)
+			XCTAssertEqual(LocalizedString.getValue("vaultDetail.keepUnlocked.title"), viewModel.title)
 
-		let mainFooterViewModel = try XCTUnwrap(viewModel.getFooterViewModel(forSection: 0))
-		guard let attributedTextViewModel = mainFooterViewModel as? BindableAttributedTextHeaderFooterViewModel else {
-			XCTFail("mainFooterViewModel has unexpected type")
-			return
+			let mainFooterViewModel = try XCTUnwrap(viewModel.getFooterViewModel(forSection: 0))
+			guard let attributedTextViewModel = mainFooterViewModel as? BindableAttributedTextHeaderFooterViewModel else {
+				XCTFail("mainFooterViewModel has unexpected type")
+				return
+			}
+
+			let footerInfoText = LocalizedString.getValue("keepUnlocked.footer.auto")
+			let learnMoreText = LocalizedString.getValue("common.footer.learnMore")
+			let expectedFooterText = "\(footerInfoText) \(learnMoreText)"
+			XCTAssertEqual(expectedFooterText, attributedTextViewModel.attributedText.value.string)
 		}
-
-		let footerInfoText = LocalizedString.getValue("keepUnlocked.footer.auto")
-		let learnMoreText = LocalizedString.getValue("common.footer.learnMore")
-		let expectedFooterText = "\(footerInfoText) \(learnMoreText)"
-		XCTAssertEqual(expectedFooterText, attributedTextViewModel.attributedText.value.string)
 	}
 
 	func testDefaultConfigurationNotDefaultKeepUnlockedDuration() throws {
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.fiveMinutes)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .fiveMinutes, viewModel: viewModel)
-		XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
-		XCTAssertEqual(LocalizedString.getValue("vaultDetail.keepUnlocked.title"), viewModel.title)
+		try withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.fiveMinutes)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .fiveMinutes, viewModel: viewModel)
+			XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
+			XCTAssertEqual(LocalizedString.getValue("vaultDetail.keepUnlocked.title"), viewModel.title)
 
-		let mainFooterViewModel = try XCTUnwrap(viewModel.getFooterViewModel(forSection: 0))
-		guard let attributedTextViewModel = mainFooterViewModel as? BindableAttributedTextHeaderFooterViewModel else {
-			XCTFail("mainFooterViewModel has unexpected type")
-			return
+			let mainFooterViewModel = try XCTUnwrap(viewModel.getFooterViewModel(forSection: 0))
+			guard let attributedTextViewModel = mainFooterViewModel as? BindableAttributedTextHeaderFooterViewModel else {
+				XCTFail("mainFooterViewModel has unexpected type")
+				return
+			}
+
+			let footerInfoText = LocalizedString.getValue("keepUnlocked.footer.on")
+			let learnMoreText = LocalizedString.getValue("common.footer.learnMore")
+			let expectedFooterText = "\(footerInfoText) \(learnMoreText)"
+			XCTAssertEqual(expectedFooterText, attributedTextViewModel.attributedText.value.string)
 		}
-
-		let footerInfoText = LocalizedString.getValue("keepUnlocked.footer.on")
-		let learnMoreText = LocalizedString.getValue("common.footer.learnMore")
-		let expectedFooterText = "\(footerInfoText) \(learnMoreText)"
-		XCTAssertEqual(expectedFooterText, attributedTextViewModel.attributedText.value.string)
 	}
 
 	func testSetKeepUnlockedDuration() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
 
-		viewModel.setKeepUnlockedDuration(to: .tenMinutes).catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .tenMinutes).catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .tenMinutes, viewModel: viewModel)
+
+			XCTAssertEqual(.tenMinutes, currentKeepUnlockedDuration.value)
+			self.assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .tenMinutes)
+			XCTAssertFalse(self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .tenMinutes, viewModel: viewModel)
-
-		XCTAssertEqual(.tenMinutes, currentKeepUnlockedDuration.value)
-		assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .tenMinutes)
-		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 	}
 
 	func testSetKeepUnlockedDurationForUnlockedVault() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		fileProviderConnectorMock.proxy = vaultLockingMock
-		vaultLockingMock.unlockedVaults.append(NSFileProviderDomainIdentifier(vaultUID))
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.fileProviderConnectorMock.proxy = self.vaultLockingMock
+			self.vaultLockingMock.unlockedVaults.append(NSFileProviderDomainIdentifier(self.vaultUID))
 
-		viewModel.setKeepUnlockedDuration(to: .fiveMinutes).then {
-			XCTFail("Promise fulfilled")
-		}.catch { error in
-			XCTAssertEqual(.vaultIsUnlocked, error as? VaultKeepUnlockedViewModelError)
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .fiveMinutes).then {
+				XCTFail("Promise fulfilled")
+			}.catch { error in
+				XCTAssertEqual(.vaultIsUnlocked, error as? VaultKeepUnlockedViewModelError)
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertFileProviderConnectorCalled()
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
+			XCTAssertEqual(.auto, currentKeepUnlockedDuration.value)
+			XCTAssertFalse(self.vaultKeepUnlockedSettingsMock.setKeepUnlockedDurationForVaultUIDCalled)
+			XCTAssertFalse(self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertFileProviderConnectorCalled()
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
-		XCTAssertEqual(.auto, currentKeepUnlockedDuration.value)
-		XCTAssertFalse(vaultKeepUnlockedSettingsMock.setKeepUnlockedDurationForVaultUIDCalled)
-		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testSetKeepUnlockedDurationForLockedVault() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		fileProviderConnectorMock.proxy = vaultLockingMock
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.fileProviderConnectorMock.proxy = self.vaultLockingMock
 
-		viewModel.setKeepUnlockedDuration(to: .fiveMinutes).catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .fiveMinutes).catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertFileProviderConnectorCalled()
+			XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
+			self.assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .fiveMinutes)
+			XCTAssertFalse(self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertFileProviderConnectorCalled()
-		XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
-		assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .fiveMinutes)
-		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	func testSetKeepUnlockedDurationForUnlockedVaultNotAutoDuration() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.fiveMinutes)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		fileProviderConnectorMock.proxy = vaultLockingMock
-		vaultLockingMock.unlockedVaults.append(NSFileProviderDomainIdentifier(vaultUID))
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.fiveMinutes)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.fileProviderConnectorMock.proxy = self.vaultLockingMock
+			self.vaultLockingMock.unlockedVaults.append(NSFileProviderDomainIdentifier(self.vaultUID))
 
-		viewModel.setKeepUnlockedDuration(to: .tenMinutes).catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .tenMinutes).catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertFileProviderConnectorNotCalled()
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .tenMinutes, viewModel: viewModel)
+			XCTAssertEqual(.tenMinutes, currentKeepUnlockedDuration.value)
+			self.assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .tenMinutes)
+			XCTAssertFalse(self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertFileProviderConnectorNotCalled()
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .tenMinutes, viewModel: viewModel)
-		XCTAssertEqual(.tenMinutes, currentKeepUnlockedDuration.value)
-		assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .tenMinutes)
-		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 	}
 
 	func testSetKeepUnlockedDurationAlreadySelectedDuration() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
 
-		viewModel.setKeepUnlockedDuration(to: .fiveMinutes).catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .fiveMinutes).catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .fiveMinutes, viewModel: viewModel)
+
+			XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
+			self.assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .fiveMinutes)
+			XCTAssertFalse(self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .fiveMinutes, viewModel: viewModel)
-
-		XCTAssertEqual(.fiveMinutes, currentKeepUnlockedDuration.value)
-		assertVaultKeepUnlockedSettingsSetKeepUnlockedDurationCalled(with: .fiveMinutes)
-		XCTAssertFalse(masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDCalled)
 	}
 
 	func testSetKeepUnlockedDurationToAuto() {
-		let expectation = XCTestExpectation()
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(KeepUnlockedDuration.fiveMinutes)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
 
-		viewModel.setKeepUnlockedDuration(to: .auto).catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.setKeepUnlockedDuration(to: .auto).catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			self.assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
+			XCTAssertEqual([self.vaultUID], self.masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDReceivedInvocations)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		assertSectionsAreCorrect(selectedKeepUnlockedDuration: .auto, viewModel: viewModel)
-		XCTAssertEqual([vaultUID], masterkeyCacheManagerMock.removeCachedMasterkeyForVaultUIDReceivedInvocations)
 	}
 
 	func testGracefulLockVault() {
-		let expectation = XCTestExpectation()
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			let expectation = XCTestExpectation()
 
-		let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
-		let viewModel = createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
-		vaultInfo.vaultIsUnlocked.value = true
-		fileProviderConnectorMock.proxy = vaultLockingMock
+			let currentKeepUnlockedDuration = Bindable<KeepUnlockedDuration>(.auto)
+			let viewModel = self.createViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration)
+			self.vaultInfo.vaultIsUnlocked.value = true
+			self.fileProviderConnectorMock.proxy = self.vaultLockingMock
 
-		viewModel.gracefulLockVault().catch { error in
-			XCTFail("Promise rejected with error: \(error)")
-		}.always {
-			expectation.fulfill()
+			viewModel.gracefulLockVault().catch { error in
+				XCTFail("Promise rejected with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+			self.wait(for: [expectation], timeout: 5.0)
+			XCTAssertFalse(self.vaultInfo.vaultIsUnlocked.value)
+			self.assertFileProviderConnectorCalled()
+			XCTAssertEqual([NSFileProviderDomainIdentifier(self.vaultUID)], self.vaultLockingMock.lockedVaults)
+			XCTAssertEqual(1, self.fileProviderConnectorMock.xpcInvalidationCallCount)
 		}
-		wait(for: [expectation], timeout: 5.0)
-		XCTAssertFalse(vaultInfo.vaultIsUnlocked.value)
-		assertFileProviderConnectorCalled()
-		XCTAssertEqual([NSFileProviderDomainIdentifier(vaultUID)], vaultLockingMock.lockedVaults)
-		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
 	private func createViewModel(currentKeepUnlockedDuration: Bindable<KeepUnlockedDuration>) -> VaultKeepUnlockedViewModel {
-		return withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			VaultKeepUnlockedViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration,
-			                           vaultInfo: vaultInfo,
-			                           vaultKeepUnlockedSettings: vaultKeepUnlockedSettingsMock,
-			                           masterkeyCacheManager: masterkeyCacheManagerMock)
-		}
+		return VaultKeepUnlockedViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration,
+		                                  vaultInfo: vaultInfo,
+		                                  vaultKeepUnlockedSettings: vaultKeepUnlockedSettingsMock,
+		                                  masterkeyCacheManager: masterkeyCacheManagerMock)
 	}
 
 	private func assertSectionsAreCorrect(selectedKeepUnlockedDuration: KeepUnlockedDuration, viewModel: VaultKeepUnlockedViewModel) {

--- a/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
+++ b/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
@@ -7,10 +7,10 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class VaultKeepUnlockedViewModelTests: XCTestCase {
 	var vaultKeepUnlockedSettingsMock: VaultKeepUnlockedSettingsMock!

--- a/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
+++ b/CryptomatorTests/VaultKeepUnlockedViewModelTests.swift
@@ -27,7 +27,6 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 		masterkeyCacheManagerMock = MasterkeyCacheManagerMock()
 		fileProviderConnectorMock = FileProviderConnectorMock()
 		vaultLockingMock = VaultLockingMock()
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
 	}
 
 	func testDefaultConfiguration() throws {
@@ -202,10 +201,14 @@ class VaultKeepUnlockedViewModelTests: XCTestCase {
 	}
 
 	private func createViewModel(currentKeepUnlockedDuration: Bindable<KeepUnlockedDuration>) -> VaultKeepUnlockedViewModel {
-		return VaultKeepUnlockedViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration,
-		                                  vaultInfo: vaultInfo,
-		                                  vaultKeepUnlockedSettings: vaultKeepUnlockedSettingsMock,
-		                                  masterkeyCacheManager: masterkeyCacheManagerMock)
+		return withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			VaultKeepUnlockedViewModel(currentKeepUnlockedDuration: currentKeepUnlockedDuration,
+			                           vaultInfo: vaultInfo,
+			                           vaultKeepUnlockedSettings: vaultKeepUnlockedSettingsMock,
+			                           masterkeyCacheManager: masterkeyCacheManagerMock)
+		}
 	}
 
 	private func assertSectionsAreCorrect(selectedKeepUnlockedDuration: KeepUnlockedDuration, viewModel: VaultKeepUnlockedViewModel) {

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -7,13 +7,13 @@
 //
 
 import CryptomatorCloudAccessCore
+import Dependencies
 import GRDB
 import LocalAuthentication
 import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class VaultListViewModelTests: XCTestCase {
 	private var vaultManagerMock: VaultDBManagerMock!

--- a/CryptomatorTests/VaultListViewModelTests.swift
+++ b/CryptomatorTests/VaultListViewModelTests.swift
@@ -29,7 +29,6 @@ class VaultListViewModelTests: XCTestCase {
 		vaultCacheMock = VaultCacheMock()
 		vaultManagerMock = VaultDBManagerMock(providerManager: cloudProviderManager, vaultAccountManager: vaultAccountManagerMock, vaultCache: vaultCacheMock, passwordManager: passwordManagerMock, masterkeyCacheManager: MasterkeyCacheManagerMock(), masterkeyCacheHelper: MasterkeyCacheHelperMock())
 		fileProviderConnectorMock = FileProviderConnectorMock()
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
 	}
 
 	func testRefreshVaultsIsSorted() throws {
@@ -98,18 +97,22 @@ class VaultListViewModelTests: XCTestCase {
 		                          vaultListPosition: VaultListPosition(position: 1, vaultUID: "vault1"))
 		let vaultLockingMock = VaultLockingMock()
 		fileProviderConnectorMock.proxy = vaultLockingMock
-		vaultListViewModel.lockVault(vaultInfo).then {
-			XCTAssertEqual(NSFileProviderDomainIdentifier("vault1"), self.fileProviderConnectorMock.passedDomainIdentifier)
-			XCTAssertEqual(NSFileProviderServiceName("org.cryptomator.ios.vault-locking"), self.fileProviderConnectorMock.passedServiceName)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			vaultListViewModel.lockVault(vaultInfo).then {
+				XCTAssertEqual(NSFileProviderDomainIdentifier("vault1"), self.fileProviderConnectorMock.passedDomainIdentifier)
+				XCTAssertEqual(NSFileProviderServiceName("org.cryptomator.ios.vault-locking"), self.fileProviderConnectorMock.passedServiceName)
 
-			XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
-			XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier("vault1")))
+				XCTAssertEqual(1, vaultLockingMock.lockedVaults.count)
+				XCTAssertTrue(vaultLockingMock.lockedVaults.contains(NSFileProviderDomainIdentifier("vault1")))
 
-			XCTAssertEqual(0, vaultLockingMock.unlockedVaults.count)
-		}.catch { error in
-			XCTFail("Promise failed with error: \(error)")
-		}.always {
-			expectation.fulfill()
+				XCTAssertEqual(0, vaultLockingMock.unlockedVaults.count)
+			}.catch { error in
+				XCTFail("Promise failed with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
@@ -129,17 +132,21 @@ class VaultListViewModelTests: XCTestCase {
 		// Simulate an unlocked vault
 		vaultLockingMock.unlockedVaults.append(NSFileProviderDomainIdentifier("vault1"))
 
-		vaultListViewModel.refreshVaultLockStates().then {
-			XCTAssertEqual(self.fileProviderConnectorMock.passedDomainIdentifier?.rawValue, "vault1")
-			XCTAssertEqual(NSFileProviderServiceName("org.cryptomator.ios.vault-locking"), self.fileProviderConnectorMock.passedServiceName)
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			vaultListViewModel.refreshVaultLockStates().then {
+				XCTAssertEqual(self.fileProviderConnectorMock.passedDomainIdentifier?.rawValue, "vault1")
+				XCTAssertEqual(NSFileProviderServiceName("org.cryptomator.ios.vault-locking"), self.fileProviderConnectorMock.passedServiceName)
 
-			let unlockedVaults = vaultListViewModel.getVaults().filter({ $0.vaultIsUnlocked.value })
-			XCTAssertEqual(1, unlockedVaults.count)
-			XCTAssertTrue(unlockedVaults.contains(where: { $0.vaultUID == "vault1" }))
-		}.catch { error in
-			XCTFail("Promise failed with error: \(error)")
-		}.always {
-			expectation.fulfill()
+				let unlockedVaults = vaultListViewModel.getVaults().filter({ $0.vaultIsUnlocked.value })
+				XCTAssertEqual(1, unlockedVaults.count)
+				XCTAssertTrue(unlockedVaults.contains(where: { $0.vaultUID == "vault1" }))
+			}.catch { error in
+				XCTFail("Promise failed with error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 		XCTAssertEqual(2, fileProviderConnectorMock.xpcInvalidationCallCount)

--- a/CryptomatorTests/XPCCacheControllerTests.swift
+++ b/CryptomatorTests/XPCCacheControllerTests.swift
@@ -3,13 +3,16 @@
 //  CryptomatorTests
 //
 
+import Dependencies
 import FileProvider
+import Promises
 import XCTest
 @testable import Cryptomator
 @testable import CryptomatorCommonCore
-@testable import Dependencies
 
 class XPCCacheControllerTests: XCTestCase {
+	private static let serviceError = NSError(domain: "TestError", code: -42)
+
 	private var fileProviderConnectorMock: FileProviderConnectorMock!
 	private var xpcCacheManagingMock: CacheManagingMock!
 
@@ -22,17 +25,9 @@ class XPCCacheControllerTests: XCTestCase {
 	}
 
 	func testClearCacheUsesXPCServiceAndInvalidatesConnection() {
-		let expectation = XCTestExpectation()
 		fileProviderConnectorMock.proxy = xpcCacheManagingMock
 
-		withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			XPCCacheController().clearCache().always {
-				expectation.fulfill()
-			}
-		}
-		wait(for: [expectation], timeout: 5.0)
+		_ = runExpectingSuccess { $0.clearCache() }
 
 		XCTAssertEqual(1, xpcCacheManagingMock.clearCacheReplyCallsCount)
 		XCTAssertEqual(NSFileProviderServiceName.cacheManaging, fileProviderConnectorMock.passedServiceName)
@@ -40,26 +35,113 @@ class XPCCacheControllerTests: XCTestCase {
 		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
 	}
 
+	func testClearCacheRejectsWhenGetXPCFails() {
+		// Leave fileProviderConnectorMock.proxy unset so getCastedProxy rejects with typeMismatch.
+		let receivedError = runExpectingFailure { $0.clearCache() }
+
+		XCTAssertEqual(FileProviderXPCConnectorError.typeMismatch, receivedError as? FileProviderXPCConnectorError)
+		XCTAssertEqual(0, xpcCacheManagingMock.clearCacheReplyCallsCount)
+		XCTAssertEqual(0, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	func testClearCacheRejectsWhenServiceRepliesWithError() {
+		xpcCacheManagingMock.clearCacheReplyClosure = { reply in
+			reply(Self.serviceError)
+		}
+		fileProviderConnectorMock.proxy = xpcCacheManagingMock
+
+		let receivedError = runExpectingFailure { $0.clearCache() }
+
+		XCTAssertEqual(Self.serviceError, receivedError as NSError?)
+		XCTAssertEqual(1, xpcCacheManagingMock.clearCacheReplyCallsCount)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
 	func testGetLocalCacheSizeInBytesUsesXPCServiceAndInvalidatesConnection() {
-		let expectation = XCTestExpectation()
 		xpcCacheManagingMock.getLocalCacheSizeInBytesReplyClosure = { reply in
 			reply(512 as NSNumber, nil)
 		}
 		fileProviderConnectorMock.proxy = xpcCacheManagingMock
 
-		withDependencies {
-			$0.fileProviderConnector = fileProviderConnectorMock
-		} operation: {
-			XPCCacheController().getLocalCacheSizeInBytes().then { value in
-				XCTAssertEqual(512, value)
-				expectation.fulfill()
-			}
-		}
-		wait(for: [expectation], timeout: 5.0)
+		let value = runExpectingSuccess { $0.getLocalCacheSizeInBytes() }
 
+		XCTAssertEqual(512, value)
 		XCTAssertEqual(1, xpcCacheManagingMock.getLocalCacheSizeInBytesReplyCallsCount)
 		XCTAssertEqual(NSFileProviderServiceName.cacheManaging, fileProviderConnectorMock.passedServiceName)
 		XCTAssertNil(fileProviderConnectorMock.passedDomain)
 		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	func testGetLocalCacheSizeInBytesRejectsWhenGetXPCFails() {
+		// Leave fileProviderConnectorMock.proxy unset so getCastedProxy rejects with typeMismatch.
+		let receivedError = runExpectingFailure { $0.getLocalCacheSizeInBytes() }
+
+		XCTAssertEqual(FileProviderXPCConnectorError.typeMismatch, receivedError as? FileProviderXPCConnectorError)
+		XCTAssertEqual(0, xpcCacheManagingMock.getLocalCacheSizeInBytesReplyCallsCount)
+		XCTAssertEqual(0, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	func testGetLocalCacheSizeInBytesRejectsWhenServiceRepliesWithError() {
+		xpcCacheManagingMock.getLocalCacheSizeInBytesReplyClosure = { reply in
+			reply(nil, Self.serviceError)
+		}
+		fileProviderConnectorMock.proxy = xpcCacheManagingMock
+
+		let receivedError = runExpectingFailure { $0.getLocalCacheSizeInBytes() }
+
+		XCTAssertEqual(Self.serviceError, receivedError as NSError?)
+		XCTAssertEqual(1, xpcCacheManagingMock.getLocalCacheSizeInBytesReplyCallsCount)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	func testGetLocalCacheSizeInBytesReturnsZeroWhenReplyIsNil() {
+		xpcCacheManagingMock.getLocalCacheSizeInBytesReplyClosure = { reply in
+			reply(nil, nil)
+		}
+		fileProviderConnectorMock.proxy = xpcCacheManagingMock
+
+		let value = runExpectingSuccess { $0.getLocalCacheSizeInBytes() }
+
+		XCTAssertEqual(0, value)
+		XCTAssertEqual(1, xpcCacheManagingMock.getLocalCacheSizeInBytesReplyCallsCount)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	// MARK: Helpers
+
+	private func runExpectingSuccess<T>(_ operation: @escaping (XPCCacheController) -> Promise<T>) -> T? {
+		let expectation = XCTestExpectation()
+		var value: T?
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			operation(XPCCacheController()).then { v in
+				value = v
+			}.catch { error in
+				XCTFail("Unexpected error: \(error)")
+			}.always {
+				expectation.fulfill()
+			}
+		}
+		wait(for: [expectation], timeout: 5.0)
+		return value
+	}
+
+	private func runExpectingFailure<T>(_ operation: @escaping (XPCCacheController) -> Promise<T>) -> Error? {
+		let expectation = XCTestExpectation()
+		var receivedError: Error?
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			operation(XPCCacheController()).then { _ in
+				XCTFail("Expected failure")
+			}.catch { error in
+				receivedError = error
+			}.always {
+				expectation.fulfill()
+			}
+		}
+		wait(for: [expectation], timeout: 5.0)
+		return receivedError
 	}
 }

--- a/CryptomatorTests/XPCCacheControllerTests.swift
+++ b/CryptomatorTests/XPCCacheControllerTests.swift
@@ -1,0 +1,58 @@
+//
+//  XPCCacheControllerTests.swift
+//  CryptomatorTests
+//
+
+import FileProvider
+import XCTest
+@testable import Cryptomator
+@testable import CryptomatorCommonCore
+@testable import Dependencies
+
+class XPCCacheControllerTests: XCTestCase {
+	private var fileProviderConnectorMock: FileProviderConnectorMock!
+	private var xpcCacheManagingMock: CacheManagingMock!
+
+	override func setUpWithError() throws {
+		fileProviderConnectorMock = FileProviderConnectorMock()
+		xpcCacheManagingMock = CacheManagingMock()
+		xpcCacheManagingMock.clearCacheReplyClosure = { reply in
+			reply(nil)
+		}
+		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
+	}
+
+	func testClearCacheUsesXPCServiceAndInvalidatesConnection() {
+		let expectation = XCTestExpectation()
+		fileProviderConnectorMock.proxy = xpcCacheManagingMock
+
+		XPCCacheController().clearCache().always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+
+		XCTAssertEqual(1, xpcCacheManagingMock.clearCacheReplyCallsCount)
+		XCTAssertEqual(NSFileProviderServiceName.cacheManaging, fileProviderConnectorMock.passedServiceName)
+		XCTAssertNil(fileProviderConnectorMock.passedDomain)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+
+	func testGetLocalCacheSizeInBytesUsesXPCServiceAndInvalidatesConnection() {
+		let expectation = XCTestExpectation()
+		xpcCacheManagingMock.getLocalCacheSizeInBytesReplyClosure = { reply in
+			reply(512 as NSNumber, nil)
+		}
+		fileProviderConnectorMock.proxy = xpcCacheManagingMock
+
+		XPCCacheController().getLocalCacheSizeInBytes().then { value in
+			XCTAssertEqual(512, value)
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+
+		XCTAssertEqual(1, xpcCacheManagingMock.getLocalCacheSizeInBytesReplyCallsCount)
+		XCTAssertEqual(NSFileProviderServiceName.cacheManaging, fileProviderConnectorMock.passedServiceName)
+		XCTAssertNil(fileProviderConnectorMock.passedDomain)
+		XCTAssertEqual(1, fileProviderConnectorMock.xpcInvalidationCallCount)
+	}
+}

--- a/CryptomatorTests/XPCCacheControllerTests.swift
+++ b/CryptomatorTests/XPCCacheControllerTests.swift
@@ -19,15 +19,18 @@ class XPCCacheControllerTests: XCTestCase {
 		xpcCacheManagingMock.clearCacheReplyClosure = { reply in
 			reply(nil)
 		}
-		DependencyValues.mockDependency(\.fileProviderConnector, with: fileProviderConnectorMock)
 	}
 
 	func testClearCacheUsesXPCServiceAndInvalidatesConnection() {
 		let expectation = XCTestExpectation()
 		fileProviderConnectorMock.proxy = xpcCacheManagingMock
 
-		XPCCacheController().clearCache().always {
-			expectation.fulfill()
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			XPCCacheController().clearCache().always {
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 
@@ -44,9 +47,13 @@ class XPCCacheControllerTests: XCTestCase {
 		}
 		fileProviderConnectorMock.proxy = xpcCacheManagingMock
 
-		XPCCacheController().getLocalCacheSizeInBytes().then { value in
-			XCTAssertEqual(512, value)
-			expectation.fulfill()
+		withDependencies {
+			$0.fileProviderConnector = fileProviderConnectorMock
+		} operation: {
+			XPCCacheController().getLocalCacheSizeInBytes().then { value in
+				XCTAssertEqual(512, value)
+				expectation.fulfill()
+			}
 		}
 		wait(for: [expectation], timeout: 5.0)
 

--- a/SharedResources/en.lproj/Localizable.strings
+++ b/SharedResources/en.lproj/Localizable.strings
@@ -139,6 +139,9 @@
 "hubAuthentication.untrustedHost.alert.title" = "Host Not Trusted";
 "hubAuthentication.vaultArchived" = "This vault has been archived. Please ask the vault owner to unarchive it.";
 
+"intents.clearCache.description" = "Clears Cryptomator's local file cache.";
+"intents.clearCache.cacheCleared" = "Cache cleared.";
+
 "intents.saveFile.missingFile" = "The provided file is not valid.";
 "intents.saveFile.invalidFolder" = "The provided folder is not valid.";
 "intents.saveFile.missingTemporaryFolder" = "Failed to create temporary folder.";


### PR DESCRIPTION
Adds an shortcut to clear the cache by adding a new `AppIntent`.
As part of this PR I also migrated away from the dependency I introduced 1-2 years ago to the official one `swift-dependencies` as I hit a wall with the simplified version. Also it no longer hits the build time, is better supported for future Swift versions and has nice feature like automatically created mock with the `@DependencyClient` macro.
I'm already sorry for the huge diff which mainly comes from the migration to the official `swift-dependencies` package 🙈 

<img width="400" alt="Simulator Screenshot - iPhone 17 Pro - 2026-04-11 at 11 18 15" src="https://github.com/user-attachments/assets/c4191bd0-88da-456f-94d9-68b0030c30db" />

To test the feature:
1. Open the Shortcuts app
2. Check that you can see a new suggestion `Clear Cache`
3. Create a new shortcut with it
4. Open the Cryptomator app and check in settings that your cache is currently > 0MB
5. Trigger the new shortcut
6. Open the Cryptomator app and check in settings that your cache is now empty



> [!WARNING] 
> Localization for the newly added strings is still missing