### PR TITLE
Enable offline unlock in File Provider

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -456,6 +456,9 @@
 		B3C397FE2EB10FC0001280AC /* ShareVaultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C397FC2EB10FC0001280AC /* ShareVaultViewController.swift */; };
 		B3C398002EB110F9001280AC /* ShareVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3C397FF2EB110F9001280AC /* ShareVaultViewModel.swift */; };
 		B3D19A442CB937C700CD18A5 /* FileProviderCoordinatorError.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3D19A432CB937BF00CD18A5 /* FileProviderCoordinatorError.swift */; };
+		B40000000000000000E00001 /* UnlockVaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10001 /* UnlockVaultViewModelTests.swift */; };
+		B40000000000000000E00002 /* VaultUnlockingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10002 /* VaultUnlockingMock.swift */; };
+		B40000000000000000E00003 /* UnlockVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */; };
 		FB6962AFC1C60F6728A7850E /* FileProviderAdapterRecoverUploadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153B84C203850D7414DE2A66 /* FileProviderAdapterRecoverUploadsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1095,6 +1098,8 @@
 		B3C397FC2EB10FC0001280AC /* ShareVaultViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareVaultViewController.swift; sourceTree = "<group>"; };
 		B3C397FF2EB110F9001280AC /* ShareVaultViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareVaultViewModel.swift; sourceTree = "<group>"; };
 		B3D19A432CB937BF00CD18A5 /* FileProviderCoordinatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderCoordinatorError.swift; sourceTree = "<group>"; };
+		B40000000000000000E10001 /* UnlockVaultViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockVaultViewModelTests.swift; sourceTree = "<group>"; };
+		B40000000000000000E10002 /* VaultUnlockingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockingMock.swift; sourceTree = "<group>"; };
 		D4BFCEFE82DA5BB518E9DA8B /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Intents.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1896,7 +1901,9 @@
 				74E1A1A42E02700000C0D001 /* XPCCacheControllerTests.swift */,
 				4A644B48267B40C3008CBB9A /* SetVaultNameViewModelTests.swift */,
 				4A707803278DC37F00AEF4CE /* VaultKeepUnlockedViewModelTests.swift */,
+				B40000000000000000E10001 /* UnlockVaultViewModelTests.swift */,
 				4AF91CF325A8BB0D00ACF01E /* VaultListViewModelTests.swift */,
+				B40000000000000000E10002 /* VaultUnlockingMock.swift */,
 				4A587FC928BB777B00C69A1E /* WebDAVAuthenticationViewModelTests.swift */,
 				4AD9481B2909BD9C00072110 /* XCTest+Async.swift */,
 				4AFF1BB0272C337A00F41E1B /* XCTest+Combine.swift */,
@@ -3046,6 +3053,9 @@
 				4A4246F4275646A0005BE82D /* UpgradeViewModelTests.swift in Sources */,
 				4A1673F1270E2E830075C724 /* SettingsViewModelTests.swift in Sources */,
 				74E1A1A52E02700000C0D001 /* XPCCacheControllerTests.swift in Sources */,
+				B40000000000000000E00001 /* UnlockVaultViewModelTests.swift in Sources */,
+				B40000000000000000E00002 /* VaultUnlockingMock.swift in Sources */,
+				B40000000000000000E00003 /* UnlockVaultViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CryptomatorCommon/Sources/CryptomatorCommonCore/ErrorExtensions.swift
+++ b/CryptomatorCommon/Sources/CryptomatorCommonCore/ErrorExtensions.swift
@@ -1,0 +1,42 @@
+//
+//  ErrorExtensions.swift
+//  CryptomatorCommonCore
+//
+//  Created by Tobias Hagemann on 21.04.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import FileProvider
+import Foundation
+
+public extension Error {
+	var isNoInternetConnectionError: Bool {
+		if let cloudProviderError = self as? CloudProviderError, cloudProviderError == .noInternetConnection {
+			return true
+		}
+		if let localizedError = self as? LocalizedCloudProviderError, case .noInternetConnection = localizedError {
+			return true
+		}
+		if let fileProviderError = self as? NSFileProviderError, fileProviderError.code == .serverUnreachable {
+			return true
+		}
+		return false
+	}
+
+	var isTransientConnectivityError: Bool {
+		if isNoInternetConnectionError {
+			return true
+		}
+		let nsError = self as NSError
+		guard nsError.domain == NSURLErrorDomain else {
+			return false
+		}
+		return [NSURLErrorTimedOut,
+		        NSURLErrorCannotFindHost,
+		        NSURLErrorCannotConnectToHost,
+		        NSURLErrorNetworkConnectionLost,
+		        NSURLErrorDNSLookupFailed,
+		        NSURLErrorNotConnectedToInternet].contains(nsError.code)
+	}
+}

--- a/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/ErrorExtensionsTests.swift
+++ b/CryptomatorCommon/Tests/CryptomatorCommonCoreTests/ErrorExtensionsTests.swift
@@ -1,0 +1,58 @@
+//
+//  ErrorExtensionsTests.swift
+//  CryptomatorCommonCoreTests
+//
+//  Created by Tobias Hagemann on 21.04.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
+import FileProvider
+import XCTest
+
+class ErrorExtensionsTests: XCTestCase {
+	// MARK: - isNoInternetConnectionError
+
+	func testIsNoInternetConnectionErrorForCloudProviderError() {
+		XCTAssertTrue(CloudProviderError.noInternetConnection.isNoInternetConnectionError)
+	}
+
+	func testIsNoInternetConnectionErrorForLocalizedCloudProviderError() {
+		let error = LocalizedCloudProviderError.noInternetConnection
+		XCTAssertTrue(error.isNoInternetConnectionError)
+	}
+
+	func testIsNoInternetConnectionErrorForNSFileProviderError() {
+		let error = NSFileProviderError(.serverUnreachable)
+		XCTAssertTrue(error.isNoInternetConnectionError)
+	}
+
+	func testIsNoInternetConnectionErrorReturnsFalseForUnrelatedError() {
+		XCTAssertFalse(CloudProviderError.unauthorized.isNoInternetConnectionError)
+	}
+
+	// MARK: - isTransientConnectivityError
+
+	func testIsTransientConnectivityErrorIncludesNoInternetConnectionErrors() {
+		XCTAssertTrue(CloudProviderError.noInternetConnection.isTransientConnectivityError)
+		XCTAssertTrue(NSFileProviderError(.serverUnreachable).isTransientConnectivityError)
+	}
+
+	func testIsTransientConnectivityErrorForNSURLErrors() {
+		let transientCodes = [NSURLErrorTimedOut, NSURLErrorCannotFindHost, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorDNSLookupFailed, NSURLErrorNotConnectedToInternet]
+		for code in transientCodes {
+			let error = NSError(domain: NSURLErrorDomain, code: code)
+			XCTAssertTrue(error.isTransientConnectivityError, "Expected NSURLError code \(code) to be transient")
+		}
+	}
+
+	func testIsTransientConnectivityErrorReturnsFalseForNonTransientNSURLError() {
+		let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
+		XCTAssertFalse(error.isTransientConnectivityError)
+	}
+
+	func testIsTransientConnectivityErrorReturnsFalseForUnrelatedError() {
+		XCTAssertFalse(CloudProviderError.unauthorized.isTransientConnectivityError)
+	}
+}

--- a/CryptomatorFileProvider/Middleware/ErrorMapper.swift
+++ b/CryptomatorFileProvider/Middleware/ErrorMapper.swift
@@ -44,35 +44,6 @@ class ErrorMapper<T>: WorkflowMiddleware {
 }
 
 extension Error {
-	var isNoInternetConnectionError: Bool {
-		if let cloudProviderError = self as? CloudProviderError, cloudProviderError == .noInternetConnection {
-			return true
-		}
-		if let localizedError = self as? LocalizedCloudProviderError, case .noInternetConnection = localizedError {
-			return true
-		}
-		if let fileProviderError = self as? NSFileProviderError, fileProviderError.code == .serverUnreachable {
-			return true
-		}
-		return false
-	}
-
-	var isTransientConnectivityError: Bool {
-		if isNoInternetConnectionError {
-			return true
-		}
-		let nsError = self as NSError
-		guard nsError.domain == NSURLErrorDomain else {
-			return false
-		}
-		return [NSURLErrorTimedOut,
-		        NSURLErrorCannotFindHost,
-		        NSURLErrorCannotConnectToHost,
-		        NSURLErrorNetworkConnectionLost,
-		        NSURLErrorDNSLookupFailed,
-		        NSURLErrorNotConnectedToInternet].contains(nsError.code)
-	}
-
 	func toPresentableError() -> Error {
 		guard let cloudProviderError = self as? CloudProviderError else {
 			return self

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/ItemEnumerationTaskExecutor.swift
@@ -8,6 +8,7 @@
 
 import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
 import FileProvider
 import Foundation
 import GRDB

--- a/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
+++ b/CryptomatorFileProvider/Middleware/TaskExecutor/UploadTaskExecutor.swift
@@ -8,6 +8,7 @@
 
 import CocoaLumberjackSwift
 import CryptomatorCloudAccessCore
+import CryptomatorCommonCore
 import Dependencies
 import FileProvider
 import Foundation

--- a/CryptomatorFileProviderTests/Middleware/ErrorMapperTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/ErrorMapperTests.swift
@@ -48,50 +48,6 @@ class ErrorMapperTests: XCTestCase {
 		return errorMapper.execute(task: DummyTask())
 	}
 
-	// MARK: - isNoInternetConnectionError
-
-	func testIsNoInternetConnectionErrorForCloudProviderError() {
-		XCTAssertTrue(CloudProviderError.noInternetConnection.isNoInternetConnectionError)
-	}
-
-	func testIsNoInternetConnectionErrorForLocalizedCloudProviderError() {
-		let error = LocalizedCloudProviderError.noInternetConnection
-		XCTAssertTrue(error.isNoInternetConnectionError)
-	}
-
-	func testIsNoInternetConnectionErrorForNSFileProviderError() {
-		let error = NSFileProviderError(.serverUnreachable)
-		XCTAssertTrue(error.isNoInternetConnectionError)
-	}
-
-	func testIsNoInternetConnectionErrorReturnsFalseForUnrelatedError() {
-		XCTAssertFalse(CloudProviderError.unauthorized.isNoInternetConnectionError)
-	}
-
-	// MARK: - isTransientConnectivityError
-
-	func testIsTransientConnectivityErrorIncludesNoInternetConnectionErrors() {
-		XCTAssertTrue(CloudProviderError.noInternetConnection.isTransientConnectivityError)
-		XCTAssertTrue(NSFileProviderError(.serverUnreachable).isTransientConnectivityError)
-	}
-
-	func testIsTransientConnectivityErrorForNSURLErrors() {
-		let transientCodes = [NSURLErrorTimedOut, NSURLErrorCannotFindHost, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost, NSURLErrorDNSLookupFailed, NSURLErrorNotConnectedToInternet]
-		for code in transientCodes {
-			let error = NSError(domain: NSURLErrorDomain, code: code)
-			XCTAssertTrue(error.isTransientConnectivityError, "Expected NSURLError code \(code) to be transient")
-		}
-	}
-
-	func testIsTransientConnectivityErrorReturnsFalseForNonTransientNSURLError() {
-		let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorBadURL)
-		XCTAssertFalse(error.isTransientConnectivityError)
-	}
-
-	func testIsTransientConnectivityErrorReturnsFalseForUnrelatedError() {
-		XCTAssertFalse(CloudProviderError.unauthorized.isTransientConnectivityError)
-	}
-
 	// MARK: - Helpers
 
 	private struct DummyTask: CloudTask {

--- a/CryptomatorTests/UnlockVaultViewModelTests.swift
+++ b/CryptomatorTests/UnlockVaultViewModelTests.swift
@@ -1,0 +1,182 @@
+//
+//  UnlockVaultViewModelTests.swift
+//  CryptomatorTests
+//
+//  Created by Tobias Hagemann on 21.04.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import CryptomatorCryptoLib
+import Dependencies
+import FileProvider
+import Promises
+import XCTest
+@testable import CryptomatorCommonCore
+
+class UnlockVaultViewModelTests: XCTestCase {
+	private let vaultUID = "UnlockTestVault"
+	private let passphrase = "testPassword"
+	private var domain: NSFileProviderDomain!
+	private var vaultAccount: VaultAccount!
+	private var masterkeyFileData: Data!
+
+	private var vaultCacheMock: CryptomatorCommonCore.VaultCacheMock!
+	private var passwordManagerMock: CryptomatorCommonCore.VaultPasswordManagerMock!
+	private var providerManagerMock: CloudProviderManagerStub!
+	private var vaultAccountManagerMock: VaultAccountManagerStub!
+	private var fileProviderConnectorMock: FileProviderConnectorMock!
+	private var vaultUnlockingMock: VaultUnlockingMock!
+
+	override func setUpWithError() throws {
+		domain = NSFileProviderDomain(identifier: NSFileProviderDomainIdentifier(vaultUID), displayName: "Unlock Test Vault", pathRelativeToDocumentStorage: vaultUID)
+		vaultAccount = VaultAccount(vaultUID: vaultUID, delegateAccountUID: "delegate-\(vaultUID)", vaultPath: CloudPath("/Vault"), vaultName: "Unlock Test Vault")
+
+		let masterkey = Masterkey.createFromRaw(rawKey: [UInt8](repeating: 0x55, count: 64))
+		masterkeyFileData = try MasterkeyFile.lock(masterkey: masterkey, vaultVersion: 8, passphrase: passphrase, pepper: [UInt8](), scryptCostParam: 2)
+
+		vaultCacheMock = CryptomatorCommonCore.VaultCacheMock()
+		vaultCacheMock.getCachedVaultWithVaultUIDReturnValue = CachedVault(vaultUID: vaultUID, masterkeyFileData: masterkeyFileData, vaultConfigToken: nil, lastUpToDateCheck: Date(), masterkeyFileLastModifiedDate: nil, vaultConfigLastModifiedDate: nil)
+		passwordManagerMock = CryptomatorCommonCore.VaultPasswordManagerMock()
+		providerManagerMock = CloudProviderManagerStub()
+		vaultAccountManagerMock = VaultAccountManagerStub(vaultAccount: vaultAccount)
+		vaultUnlockingMock = VaultUnlockingMock()
+		fileProviderConnectorMock = FileProviderConnectorMock()
+		fileProviderConnectorMock.proxy = vaultUnlockingMock
+	}
+
+	// MARK: - Swallow-path (offline / cached-only signals)
+
+	func testUnlockSwallowsCloudProviderNoInternetConnection() throws {
+		try assertUnlockSucceeds(withRefreshError: CloudProviderError.noInternetConnection)
+	}
+
+	func testUnlockSwallowsLocalizedCloudProviderNoInternetConnection() throws {
+		try assertUnlockSucceeds(withRefreshError: LocalizedCloudProviderError.noInternetConnection)
+	}
+
+	func testUnlockSwallowsNSURLErrorTimedOut() throws {
+		try assertUnlockSucceeds(withRefreshError: NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut))
+	}
+
+	func testUnlockSwallowsNSURLErrorNotConnectedToInternet() throws {
+		try assertUnlockSucceeds(withRefreshError: NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet))
+	}
+
+	func testUnlockSwallowsNSURLErrorNetworkConnectionLost() throws {
+		try assertUnlockSucceeds(withRefreshError: NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost))
+	}
+
+	func testUnlockSwallowsLocalizedCloudProviderItemNotFound() throws {
+		try assertUnlockSucceeds(withRefreshError: LocalizedCloudProviderError.itemNotFound(cloudPath: CloudPath("/Vault/masterkey.cryptomator")))
+	}
+
+	func testUnlockSwallowsCloudProviderItemNotFound() throws {
+		try assertUnlockSucceeds(withRefreshError: CloudProviderError.itemNotFound)
+	}
+
+	// MARK: - Reject-path (should still surface)
+
+	func testUnlockRejectsLocalizedCloudProviderUnauthorized() throws {
+		try assertUnlockFails(withRefreshError: LocalizedCloudProviderError.unauthorized)
+	}
+
+	func testUnlockRejectsNonTransientNSURLError() throws {
+		try assertUnlockFails(withRefreshError: NSError(domain: NSURLErrorDomain, code: NSURLErrorUserCancelledAuthentication))
+	}
+
+	func testUnlockRejectsUnrelatedError() throws {
+		try assertUnlockFails(withRefreshError: NSError(domain: "TestDomain", code: 42))
+	}
+
+	// MARK: - Helpers
+
+	private func makeViewModel() -> UnlockVaultViewModel {
+		return withDependencies({
+			$0.fileProviderConnector = self.fileProviderConnectorMock
+		}, operation: {
+			UnlockVaultViewModel(domain: self.domain,
+			                     wrongBiometricalPassword: false,
+			                     passwordManager: self.passwordManagerMock,
+			                     vaultAccountManager: self.vaultAccountManagerMock,
+			                     providerManager: self.providerManagerMock,
+			                     vaultCache: self.vaultCacheMock)
+		})
+	}
+
+	private func assertUnlockSucceeds(withRefreshError refreshError: Error, file: StaticString = #filePath, line: UInt = #line) throws {
+		vaultCacheMock.refreshVaultCacheForWithThrowableError = refreshError
+		let viewModel = makeViewModel()
+
+		let expectation = XCTestExpectation()
+		viewModel.unlock(withPassword: passphrase, storePasswordInKeychain: false).then {
+			// Expected: swallow path resolved successfully.
+		}.catch { error in
+			XCTFail("Expected unlock to succeed when refresh failed with swallowed error \(refreshError), but got \(error)", file: file, line: line)
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+		XCTAssertEqual(1, vaultUnlockingMock.unlockVaultKekCallsCount, "XPC unlock should run after swallow", file: file, line: line)
+	}
+
+	private func assertUnlockFails(withRefreshError refreshError: Error, file: StaticString = #filePath, line: UInt = #line) throws {
+		vaultCacheMock.refreshVaultCacheForWithThrowableError = refreshError
+		let viewModel = makeViewModel()
+
+		let expectation = XCTestExpectation()
+		viewModel.unlock(withPassword: passphrase, storePasswordInKeychain: false).then {
+			XCTFail("Expected unlock to reject with refresh error \(refreshError), but it resolved", file: file, line: line)
+		}.catch { _ in
+			// Expected: reject path surfaced the error.
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+		XCTAssertEqual(0, vaultUnlockingMock.unlockVaultKekCallsCount, "XPC unlock must not run on reject path", file: file, line: line)
+	}
+}
+
+private class VaultAccountManagerStub: VaultAccountManager {
+	private let vaultAccount: VaultAccount
+
+	init(vaultAccount: VaultAccount) {
+		self.vaultAccount = vaultAccount
+	}
+
+	func getAccount(with vaultUID: String) throws -> VaultAccount {
+		return vaultAccount
+	}
+
+	func saveNewAccount(_ account: VaultAccount) throws {
+		throw MockError.notMocked
+	}
+
+	func removeAccount(with vaultUID: String) throws {
+		throw MockError.notMocked
+	}
+
+	func removeAccounts(with vaultUIDs: [String]) throws {
+		throw MockError.notMocked
+	}
+
+	func getAllAccounts() throws -> [VaultAccount] {
+		throw MockError.notMocked
+	}
+
+	func updateAccount(_ account: VaultAccount) throws {
+		throw MockError.notMocked
+	}
+}
+
+private class CloudProviderManagerStub: CloudProviderManager {
+	let provider: CloudProvider = CryptomatorCommonCore.CloudProviderMock()
+
+	func getProvider(with accountUID: String) throws -> CloudProvider {
+		return provider
+	}
+
+	func getBackgroundSessionProvider(with accountUID: String, sessionIdentifier: String) throws -> CloudProvider {
+		throw MockError.notMocked
+	}
+}

--- a/CryptomatorTests/VaultUnlockingMock.swift
+++ b/CryptomatorTests/VaultUnlockingMock.swift
@@ -1,0 +1,34 @@
+//
+//  VaultUnlockingMock.swift
+//  CryptomatorTests
+//
+//  Created by Tobias Hagemann on 21.04.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCommonCore
+import FileProvider
+import Foundation
+
+class VaultUnlockingMock: NSObject, VaultUnlocking {
+	var unlockVaultKekCallsCount = 0
+
+	let serviceName = NSFileProviderServiceName.vaultUnlocking
+
+	func unlockVault(kek: [UInt8], reply: @escaping (NSError?) -> Void) {
+		unlockVaultKekCallsCount += 1
+		reply(nil)
+	}
+
+	func unlockVault(rawKey: [UInt8], reply: @escaping (NSError?) -> Void) {
+		reply(nil)
+	}
+
+	func startBiometricalUnlock() {}
+
+	func endBiometricalUnlock() {}
+
+	func makeListenerEndpoint() throws -> NSXPCListenerEndpoint {
+		throw MockError.notMocked
+	}
+}

--- a/FileProviderExtensionUI/FileProviderCoordinator.swift
+++ b/FileProviderExtensionUI/FileProviderCoordinator.swift
@@ -178,12 +178,15 @@ class FileProviderCoordinator: Coordinator {
 		}
 		vaultCache.refreshVaultCache(for: vaultAccount, with: provider).recover { error -> Void in
 			switch error {
-			case CloudProviderError.noInternetConnection, LocalizedCloudProviderError.itemNotFound:
+			case CloudProviderError.itemNotFound, LocalizedCloudProviderError.itemNotFound:
 				break
 			case LocalizedCloudProviderError.unauthorized:
 				throw FileProviderCoordinatorError.unauthorized(vaultName: domain.displayName)
 			default:
-				throw error
+				guard error.isTransientConnectivityError else {
+					throw error
+				}
+				DDLogInfo("FileProviderCoordinator: refreshVaultCache unreachable, using cached masterkey (\(error))")
 			}
 		}.then {
 			let cachedVault = try vaultCache.getCachedVault(withVaultUID: vaultUID)

--- a/FileProviderExtensionUI/UnlockVaultViewModel.swift
+++ b/FileProviderExtensionUI/UnlockVaultViewModel.swift
@@ -316,10 +316,13 @@ class UnlockVaultViewModel {
 		}
 		return vaultCache.refreshVaultCache(for: vaultAccount, with: provider).recover { error -> Void in
 			switch error {
-			case CloudProviderError.noInternetConnection, LocalizedCloudProviderError.itemNotFound:
+			case CloudProviderError.itemNotFound, LocalizedCloudProviderError.itemNotFound:
 				break
 			default:
-				throw error
+				guard error.isTransientConnectivityError else {
+					throw error
+				}
+				DDLogInfo("UnlockVaultViewModel: refreshVaultCache unreachable, using cached masterkey (\(error))")
 			}
 		}
 	}


### PR DESCRIPTION
Completes the offline-operation story PR #446 started. #446 added the offline folder-enumeration fallback and the upload auto-retry, but the piece users hit first (the unlock screen in Files.app) still failed offline, so the fallback was unreachable in practice. This PR closes that gap: unlock now succeeds from the cached masterkey when connectivity drops, and the #446 fallback finally does what it was built to do.

What was in the way: the recover blocks in `UnlockVaultViewModel.refreshVaultCache()` and `FileProviderCoordinator.showManualLogin()` matched only `CloudProviderError.noInternetConnection`, but those errors go through `LocalizedCloudProviderDecorator` which converts them to `LocalizedCloudProviderError.noInternetConnection`. Offline unlock always fell into `default: throw error` and surfaced as "Server Unreachable" even with a fully cached masterkey. The latent type-mismatch predates #446 (commit `a4ce8c33e`, PR #161).

Both recover blocks now use `error.isTransientConnectivityError`, the same predicate `UploadTaskExecutor.handleUploadError` uses, so the full connectivity-error surface (including raw `NSURLError` variants) is covered consistently. `CloudProviderError.itemNotFound` joins `LocalizedCloudProviderError.itemNotFound` in the swallow branch. `FileProviderCoordinator`'s `unauthorized` rethrow stays untouched.

`isNoInternetConnectionError` and `isTransientConnectivityError` moved from `CryptomatorFileProvider/Middleware/ErrorMapper.swift` into a new public extension in `CryptomatorCommonCore/ErrorExtensions.swift` so `FileProviderExtensionUI` can reach them. Their tests moved to `CryptomatorCommonCoreTests/ErrorExtensionsTests.swift`; `ErrorMapperTests.swift` keeps its `toPresentableError()` coverage.

New `CryptomatorTests/UnlockVaultViewModelTests.swift` (plus a minimal `VaultUnlockingMock`) covers the recover block across the swallow/reject matrix. `UnlockVaultViewModel.swift` picks up a secondary target membership in `CryptomatorTests` so the test can reference the type directly, avoiding the appex-linkage puzzle a dedicated `FileProviderExtensionUITests` bundle would have.

To test:
1. Build and run Cryptomator on a simulator
2. Add a local File Provider Storage vault and unlock it once online
3. Close the app, enable Airplane Mode
4. In the Files app, navigate to the vault and unlock (password or biometric)
5. Unlock succeeds and the previously-enumerated folder contents appear
6. Tap a previously-cached file and verify it opens offline