### PR TITLE
Coalesce concurrent startProvidingItem calls and raise download parallelism

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -459,6 +459,8 @@
 		B40000000000000000E00001 /* UnlockVaultViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10001 /* UnlockVaultViewModelTests.swift */; };
 		B40000000000000000E00002 /* VaultUnlockingMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10002 /* VaultUnlockingMock.swift */; };
 		B40000000000000000E00003 /* UnlockVaultViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AFD8C0E269304A700F77BA6 /* UnlockVaultViewModel.swift */; };
+		B40000000000000000E00004 /* FileProviderAdapterStartProvidingCoalescingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10003 /* FileProviderAdapterStartProvidingCoalescingTests.swift */; };
+		B40000000000000000E00005 /* RunningDownloadCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B40000000000000000E10004 /* RunningDownloadCache.swift */; };
 		FB6962AFC1C60F6728A7850E /* FileProviderAdapterRecoverUploadsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153B84C203850D7414DE2A66 /* FileProviderAdapterRecoverUploadsTests.swift */; };
 /* End PBXBuildFile section */
 
@@ -1100,6 +1102,8 @@
 		B3D19A432CB937BF00CD18A5 /* FileProviderCoordinatorError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderCoordinatorError.swift; sourceTree = "<group>"; };
 		B40000000000000000E10001 /* UnlockVaultViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnlockVaultViewModelTests.swift; sourceTree = "<group>"; };
 		B40000000000000000E10002 /* VaultUnlockingMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultUnlockingMock.swift; sourceTree = "<group>"; };
+		B40000000000000000E10003 /* FileProviderAdapterStartProvidingCoalescingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterStartProvidingCoalescingTests.swift; sourceTree = "<group>"; };
+		B40000000000000000E10004 /* RunningDownloadCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningDownloadCache.swift; sourceTree = "<group>"; };
 		D4BFCEFE82DA5BB518E9DA8B /* th */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = th; path = th.lproj/Intents.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1630,6 +1634,7 @@
 				153B84C203850D7414DE2A66 /* FileProviderAdapterRecoverUploadsTests.swift */,
 				4AEECD32279EAACA00C6E2B5 /* FileProviderAdapterSetFavoriteRankTests.swift */,
 				4AEECD2E279EA27300C6E2B5 /* FileProviderAdapterSetTagDataTests.swift */,
+				B40000000000000000E10003 /* FileProviderAdapterStartProvidingCoalescingTests.swift */,
 				4A5AC43A2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift */,
 				4A248230266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift */,
 				4A8F14A1266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift */,
@@ -1996,6 +2001,7 @@
 				4AEE6EE02822A33400E1B35E /* NSFileProviderItemIdentifier+Database.swift */,
 				4A0AA12A2AB8DB1800CF24FD /* PermissionProvider.swift */,
 				4AEE6EE92825716400E1B35E /* ProgressManager.swift */,
+				B40000000000000000E10004 /* RunningDownloadCache.swift */,
 				4ADD233F26737CD400374E4E /* RootFileProviderItem.swift */,
 				4A7514A02937F777002E802E /* SessionTaskRegistrator.swift */,
 				4ADC66C027A7F426002E6CC7 /* UnlockMonitor.swift */,
@@ -2705,6 +2711,7 @@
 				4A5AC43B2759399300342AA7 /* FileProviderAdapterStartProvidingItemRestrictedVersionTests.swift in Sources */,
 				4AEFF7F427145CB500D6CB99 /* LogLevelUpdatingServiceSourceTests.swift in Sources */,
 				4A248231266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift in Sources */,
+				B40000000000000000E00004 /* FileProviderAdapterStartProvidingCoalescingTests.swift in Sources */,
 				4A8F14A0266A2FD500ADBCE4 /* FileProviderAdapterGetItemTests.swift in Sources */,
 				4A24822F266FACF1002D9F59 /* FileProviderAdapterEnumerateItemTests.swift in Sources */,
 				4A4A3864253F2B1900EE3828 /* CachedFileManagerTests.swift in Sources */,
@@ -3134,6 +3141,7 @@
 				4AEBE8BC2653F2FD0031487F /* ReparentTaskExecutor.swift in Sources */,
 				4AA782D7282A7779001A71E3 /* CacheManagingServiceSource.swift in Sources */,
 				4AEE6EEA2825716400E1B35E /* ProgressManager.swift in Sources */,
+				B40000000000000000E00005 /* RunningDownloadCache.swift in Sources */,
 				747F2F2C2587BC260072FB30 /* DeletionTaskDBManager.swift in Sources */,
 				4A74DBB1282132EC00A332C4 /* FileProviderAction.swift in Sources */,
 				747F2F2D2587BC260072FB30 /* FileProviderItemList.swift in Sources */,

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -75,6 +75,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	private let domainIdentifier: NSFileProviderDomainIdentifier
 	private let fileCoordinator: NSFileCoordinator
 	private let taskRegistrator: SessionTaskRegistrator
+	private let runningDownloadCache = RunningDownloadCache()
 	@Dependency(\.permissionProvider) private var permissionProvider
 
 	init(domainIdentifier: NSFileProviderDomainIdentifier,
@@ -662,16 +663,18 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		guard let identifier = localURLProvider.persistentIdentifierForItem(at: url) else {
 			return Promise(NSFileProviderError(.noSuchItem))
 		}
-		if FileManager.default.fileExists(atPath: url.path) {
-			return localFileIsCurrent(with: identifier).then { isCurrent in
-				if isCurrent {
-					return Promise(())
-				} else {
-					return self.startProvidingItemWithOutdatedLocalFile(identifier: identifier, url: url)
+		return runningDownloadCache.getOrCreate(for: identifier) {
+			if FileManager.default.fileExists(atPath: url.path) {
+				return self.localFileIsCurrent(with: identifier).then { isCurrent in
+					if isCurrent {
+						return Promise(())
+					} else {
+						return self.startProvidingItemWithOutdatedLocalFile(identifier: identifier, url: url)
+					}
 				}
+			} else {
+				return self.downloadFile(with: identifier, to: url)
 			}
-		} else {
-			return downloadFile(with: identifier, to: url)
 		}
 	}
 

--- a/CryptomatorFileProvider/FileProviderAdapterManager.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterManager.swift
@@ -194,7 +194,7 @@ public class FileProviderAdapterManager: FileProviderAdapterProviding {
 		                                  deletionTaskManager: deletionTaskManager,
 		                                  itemEnumerationTaskManager: itemEnumerationTaskManager,
 		                                  downloadTaskManager: downloadTaskManager,
-		                                  scheduler: WorkflowScheduler(maxParallelUploads: 2, maxParallelDownloads: 2),
+		                                  scheduler: WorkflowScheduler(maxParallelUploads: 2, maxParallelDownloads: 4),
 		                                  provider: cloudProvider,
 		                                  coordinator: fileCoordinator,
 		                                  notificator: notificator,

--- a/CryptomatorFileProvider/RunningDownloadCache.swift
+++ b/CryptomatorFileProvider/RunningDownloadCache.swift
@@ -1,0 +1,40 @@
+//
+//  RunningDownloadCache.swift
+//  CryptomatorFileProvider
+//
+//  Created by Tobias Hagemann on 28.05.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CocoaLumberjackSwift
+import FileProvider
+import Foundation
+import Promises
+
+/**
+ Coalesces concurrent in-flight downloads for the same identifier onto a single shared `Promise<Void>`.
+
+ iOS Files.app can invoke `startProvidingItem` multiple times for the same identifier in rapid succession during a tap-burst.
+ Without coalescing each call creates a fresh `DownloadTask`, consumes a scheduler slot and issues a duplicate GET, which
+ contributes to the file provider extension exceeding its XPC budget.
+ */
+class RunningDownloadCache {
+	private let queue = DispatchQueue(label: "RunningDownloadCache")
+	private var inFlight = [NSFileProviderItemIdentifier: Promise<Void>]()
+
+	func getOrCreate(for identifier: NSFileProviderItemIdentifier, factory: () -> Promise<Void>) -> Promise<Void> {
+		return queue.sync {
+			if let existing = inFlight[identifier] {
+				DDLogDebug("RunningDownloadCache: coalesced hit for \(identifier)")
+				return existing
+			}
+			DDLogDebug("RunningDownloadCache: miss for \(identifier)")
+			let promise = factory()
+			inFlight[identifier] = promise
+			promise.always(on: queue) { [weak self] in
+				self?.inFlight[identifier] = nil
+			}
+			return promise
+		}
+	}
+}

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingCoalescingTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterStartProvidingCoalescingTests.swift
@@ -1,0 +1,153 @@
+//
+//  FileProviderAdapterStartProvidingCoalescingTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Tobias Hagemann on 28.05.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import Promises
+import XCTest
+@testable import CryptomatorFileProvider
+
+class FileProviderAdapterStartProvidingCoalescingTests: FileProviderAdapterTestCase {
+	private let itemID: Int64 = 2
+	private let cloudPath = CloudPath("/File 1")
+	private lazy var itemMetadata = ItemMetadata(id: itemID, name: "File 1", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: cloudPath, isPlaceholderItem: false)
+	private lazy var itemDirectory = tmpDirectory.appendingPathComponent("/\(itemID)")
+	private lazy var url = itemDirectory.appendingPathComponent("File 1")
+
+	private let otherItemID: Int64 = 3
+	private let otherCloudPath = CloudPath("/File 2")
+	private lazy var otherItemMetadata = ItemMetadata(id: otherItemID, name: "File 2", type: .file, size: 14, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: otherCloudPath, isPlaceholderItem: false)
+	private lazy var otherItemDirectory = tmpDirectory.appendingPathComponent("/\(otherItemID)")
+	private lazy var otherURL = otherItemDirectory.appendingPathComponent("File 2")
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		try metadataManagerMock.cacheMetadata(itemMetadata)
+		try FileManager.default.createDirectory(at: itemDirectory, withIntermediateDirectories: false)
+		try metadataManagerMock.cacheMetadata(otherItemMetadata)
+		try FileManager.default.createDirectory(at: otherItemDirectory, withIntermediateDirectories: false)
+	}
+
+	// MARK: - Same-identifier coalescing
+
+	func testConcurrentCallsForSameIdentifierAreCoalesced() {
+		cloudProviderMock.pendingDownloadPromise = Promise<Void>.pending()
+
+		let expectation1 = XCTestExpectation(description: "first completion handler fires")
+		let expectation2 = XCTestExpectation(description: "second completion handler fires")
+
+		adapter.startProvidingItem(at: url) { error in
+			XCTAssertNil(error)
+			expectation1.fulfill()
+		}
+		adapter.startProvidingItem(at: url) { error in
+			XCTAssertNil(error)
+			expectation2.fulfill()
+		}
+
+		cloudProviderMock.pendingDownloadPromise?.fulfill(())
+
+		wait(for: [expectation1, expectation2], timeout: 5.0)
+
+		XCTAssertEqual(1, cloudProviderMock.downloadFileCallsCount)
+	}
+
+	func testConcurrentCallsForSameIdentifierFanOutSharedRejection() {
+		cloudProviderMock.pendingDownloadPromise = Promise<Void>.pending()
+
+		let expectation1 = XCTestExpectation(description: "first completion handler fires")
+		let expectation2 = XCTestExpectation(description: "second completion handler fires")
+
+		var error1: Error?
+		var error2: Error?
+		adapter.startProvidingItem(at: url) { error in
+			error1 = error
+			expectation1.fulfill()
+		}
+		adapter.startProvidingItem(at: url) { error in
+			error2 = error
+			expectation2.fulfill()
+		}
+
+		cloudProviderMock.pendingDownloadPromise?.reject(CloudProviderError.unauthorized)
+
+		wait(for: [expectation1, expectation2], timeout: 5.0)
+
+		XCTAssertEqual(1, cloudProviderMock.downloadFileCallsCount)
+		XCTAssertNotNil(error1)
+		XCTAssertNotNil(error2)
+		XCTAssertEqual((error1 as NSError?)?.domain, (error2 as NSError?)?.domain)
+		XCTAssertEqual((error1 as NSError?)?.code, (error2 as NSError?)?.code)
+	}
+
+	// MARK: - Cache cleanup after settlement
+
+	func testRejectedCallClearsCacheSoSubsequentCallTriggersFreshDownload() {
+		cloudProviderMock.pendingDownloadPromise = Promise<Void>.pending()
+
+		let expectation1 = XCTestExpectation(description: "first completion handler fires")
+		adapter.startProvidingItem(at: url) { _ in
+			expectation1.fulfill()
+		}
+
+		cloudProviderMock.pendingDownloadPromise?.reject(CloudProviderError.unauthorized)
+		wait(for: [expectation1], timeout: 5.0)
+
+		cloudProviderMock.pendingDownloadPromise = nil
+
+		let expectation2 = XCTestExpectation(description: "second completion handler fires")
+		adapter.startProvidingItem(at: url) { _ in
+			expectation2.fulfill()
+		}
+		wait(for: [expectation2], timeout: 5.0)
+
+		XCTAssertEqual(2, cloudProviderMock.downloadFileCallsCount)
+	}
+
+	func testResolvedCallClearsCacheSoSubsequentCallIssuesNewRequest() throws {
+		cloudProviderMock.pendingDownloadPromise = Promise<Void>.pending()
+
+		let expectation1 = XCTestExpectation(description: "first completion handler fires")
+		adapter.startProvidingItem(at: url) { _ in
+			expectation1.fulfill()
+		}
+
+		cloudProviderMock.pendingDownloadPromise?.fulfill(())
+		wait(for: [expectation1], timeout: 5.0)
+
+		cloudProviderMock.pendingDownloadPromise = nil
+		try FileManager.default.removeItem(at: url)
+
+		let expectation2 = XCTestExpectation(description: "second completion handler fires")
+		adapter.startProvidingItem(at: url) { _ in
+			expectation2.fulfill()
+		}
+		wait(for: [expectation2], timeout: 5.0)
+
+		XCTAssertEqual(2, cloudProviderMock.downloadFileCallsCount)
+	}
+
+	// MARK: - Cross-identifier independence
+
+	func testConcurrentCallsForDifferentIdentifiersExecuteIndependently() {
+		let expectation1 = XCTestExpectation(description: "first item's completion handler fires")
+		let expectation2 = XCTestExpectation(description: "second item's completion handler fires")
+
+		adapter.startProvidingItem(at: url) { error in
+			XCTAssertNil(error)
+			expectation1.fulfill()
+		}
+		adapter.startProvidingItem(at: otherURL) { error in
+			XCTAssertNil(error)
+			expectation2.fulfill()
+		}
+
+		wait(for: [expectation1, expectation2], timeout: 5.0)
+
+		XCTAssertEqual(2, cloudProviderMock.downloadFileCallsCount)
+	}
+}

--- a/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMock.swift
@@ -51,6 +51,11 @@ class CustomCloudProviderMock: CloudProvider {
 
 	var everyOperationShouldFailWithError: Error?
 
+	var downloadFileCallsCount: Int = 0
+
+	/// When non-nil, `downloadFile` writes the local file first, then returns this Promise instead of resolving immediately.
+	var pendingDownloadPromise: Promise<Void>?
+
 	func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
 		if let error = everyOperationShouldFailWithError {
 			return Promise(error)
@@ -99,11 +104,15 @@ class CustomCloudProviderMock: CloudProvider {
 	func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		precondition(!localURL.hasDirectoryPath)
+		downloadFileCallsCount += 1
 		if let data = files[cloudPath.path] {
 			do {
 				try data!.write(to: localURL, options: .withoutOverwriting)
 			} catch {
 				return Promise(error)
+			}
+			if let pendingDownloadPromise = pendingDownloadPromise {
+				return pendingDownloadPromise
 			}
 			return Promise(())
 		} else {

--- a/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMock.swift
+++ b/CryptomatorFileProviderTests/Mocks/CustomCloudProviderMock.swift
@@ -51,10 +51,18 @@ class CustomCloudProviderMock: CloudProvider {
 
 	var everyOperationShouldFailWithError: Error?
 
-	var downloadFileCallsCount: Int = 0
+	private let stateQueue = DispatchQueue(label: "CustomCloudProviderMock.state")
+	private var _downloadFileCallsCount: Int = 0
+	var downloadFileCallsCount: Int {
+		stateQueue.sync { _downloadFileCallsCount }
+	}
 
+	private var _pendingDownloadPromise: Promise<Void>?
 	/// When non-nil, `downloadFile` writes the local file first, then returns this Promise instead of resolving immediately.
-	var pendingDownloadPromise: Promise<Void>?
+	var pendingDownloadPromise: Promise<Void>? {
+		get { stateQueue.sync { _pendingDownloadPromise } }
+		set { stateQueue.sync { _pendingDownloadPromise = newValue } }
+	}
 
 	func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
 		if let error = everyOperationShouldFailWithError {
@@ -104,7 +112,10 @@ class CustomCloudProviderMock: CloudProvider {
 	func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
 		precondition(localURL.isFileURL)
 		precondition(!localURL.hasDirectoryPath)
-		downloadFileCallsCount += 1
+		let pendingDownloadPromise: Promise<Void>? = stateQueue.sync {
+			_downloadFileCallsCount += 1
+			return _pendingDownloadPromise
+		}
 		if let data = files[cloudPath.path] {
 			do {
 				try data!.write(to: localURL, options: .withoutOverwriting)


### PR DESCRIPTION
Fixes #449.

When a user multi-selects many files in Files.app, iOS issues `startProvidingItem` in rapid succession and, in some cases, fires the same identifier multiple times within a burst. With `maxParallelDownloads: 2` and one workflow slot per call (duplicate or not), the pending completion-handler queue can blow past the iOS XPC budget and the extension gets killed: "Couldn't communicate with a helper application." Reported on WebDAV but the symptom is provider-agnostic.

Two changes together close the gap:

1. **Raise `maxParallelDownloads` to 4.** Uploads stay at 2; downloads share the foreground URLSession with uploads, and `URLSession.httpMaximumConnectionsPerHost` defaults to 6, so 2+4 fits under the ceiling. Applies to every provider.
2. **Add `RunningDownloadCache`.** Per-`NSFileProviderItemIdentifier` `Promise<Void>` coalescer behind a serial queue. `startProvidingItem(at:URL)` wraps its body in `runningDownloadCache.getOrCreate(for:identifier:factory:)`, so duplicate calls during a burst share a single underlying download (or single freshness PROPFIND on the local-fresh branch). Cleanup runs on the same serial queue via `Promise.always(on:)`, so subsequent calls for the same identifier observe the cleared entry deterministically.

## Flow

```mermaid
sequenceDiagram
    participant iOS as iOS Files.app
    participant Adapter as FileProviderAdapter
    participant Cache as RunningDownloadCache
    participant Cloud as CloudProvider
    iOS->>Adapter: startProvidingItem(id=226, url)
    Adapter->>Cache: getOrCreate(226)
    Cache->>Cloud: downloadFile (miss)
    iOS->>Adapter: startProvidingItem(id=226, url)
    Adapter->>Cache: getOrCreate(226)
    Cache-->>Adapter: existing Promise (hit)
    Cloud-->>Cache: resolved
    Cache-->>iOS: both callers complete
```

## Test plan

- [x] `bundle exec fastlane test --env freemium` (CryptomatorFileProvider scheme): 274/274 pass, including 5 new coalescing tests covering hit, rejection fan-out, cleanup after reject, cleanup after resolve, and per-identifier independence.
- [ ] Manual smoke on WebDAV (where the bug was reported): multi-select 20+ PDFs, confirm no XPC-timeout alert and no extension respawn burst in the fileprovider log.
- [ ] Spot-check at least one other provider (e.g., Dropbox) for the same tap-burst behavior.
