### PR TITLE
Fix hanging WebDAV downloads by resuming transfers after File Provider registration

### DIFF
--- a/Cryptomator.xcodeproj/project.pbxproj
+++ b/Cryptomator.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		4A447E3D25BF1AD400D9520D /* FolderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A447E3C25BF1AD400D9520D /* FolderCell.swift */; };
 		4A447E4D25BF1E8B00D9520D /* FileCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A447E4C25BF1E8B00D9520D /* FileCell.swift */; };
 		4A447E5625BF1F6A00D9520D /* CloudItemCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A447E5525BF1F6A00D9520D /* CloudItemCell.swift */; };
+		4A4490022BCD449000449002 /* FileProviderAdapterResumeOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A4490012BCD449000449001 /* FileProviderAdapterResumeOrderingTests.swift */; };
 		4A49FABA271ECA530069A0CC /* ItemEnumerationTaskRecord.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A49FAB9271ECA530069A0CC /* ItemEnumerationTaskRecord.swift */; };
 		4A49FABC271ECB680069A0CC /* ItemEnumerationTaskDBManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A49FABB271ECB680069A0CC /* ItemEnumerationTaskDBManager.swift */; };
 		4A49FABE271ECDE80069A0CC /* ItemEnumerationTaskManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A49FABD271ECDE80069A0CC /* ItemEnumerationTaskManagerTests.swift */; };
@@ -674,6 +675,7 @@
 		4A447E3C25BF1AD400D9520D /* FolderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FolderCell.swift; sourceTree = "<group>"; };
 		4A447E4C25BF1E8B00D9520D /* FileCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileCell.swift; sourceTree = "<group>"; };
 		4A447E5525BF1F6A00D9520D /* CloudItemCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudItemCell.swift; sourceTree = "<group>"; };
+		4A4490012BCD449000449001 /* FileProviderAdapterResumeOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileProviderAdapterResumeOrderingTests.swift; sourceTree = "<group>"; };
 		4A49FAB9271ECA530069A0CC /* ItemEnumerationTaskRecord.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEnumerationTaskRecord.swift; sourceTree = "<group>"; };
 		4A49FABB271ECB680069A0CC /* ItemEnumerationTaskDBManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEnumerationTaskDBManager.swift; sourceTree = "<group>"; };
 		4A49FABD271ECDE80069A0CC /* ItemEnumerationTaskManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemEnumerationTaskManagerTests.swift; sourceTree = "<group>"; };
@@ -1634,6 +1636,7 @@
 				4A248230266FB799002D9F59 /* FileProviderAdapterStartProvidingItemTests.swift */,
 				4A8F14A1266A302A00ADBCE4 /* FileProviderAdapterTestCase.swift */,
 				4A8CF8C027E906D7004CE880 /* FileProviderAdapterImportDirectoryTests.swift */,
+				4A4490012BCD449000449001 /* FileProviderAdapterResumeOrderingTests.swift */,
 			);
 			path = FileProviderAdapter;
 			sourceTree = "<group>";
@@ -2743,6 +2746,7 @@
 				4AEECD39279EB1EB00C6E2B5 /* FileProviderEnumeratorTests.swift in Sources */,
 				4ADC66BF27A44558002E6CC7 /* XCTestCase+Promises.swift in Sources */,
 				4A8CF8C127E906D7004CE880 /* FileProviderAdapterImportDirectoryTests.swift in Sources */,
+				4A4490022BCD449000449002 /* FileProviderAdapterResumeOrderingTests.swift in Sources */,
 				4AB1D4F227D20510009060AB /* DocumentStorageURLProviderMock.swift in Sources */,
 				4A797F8F24AC6731007DDBE1 /* FileProviderItemTests.swift in Sources */,
 				4A9C8E0127A0104E000063E4 /* EnumerationSignalingMock.swift in Sources */,

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -417,8 +417,8 @@ public class FileProviderAdapter: FileProviderAdapterType {
 					} else {
 						DDLogInfo("Successfully registered URLSessionUploadTask for identifier: \(itemIdentifier)")
 					}
+					urlSessionTask.resume()
 				})
-				urlSessionTask.resume()
 			})
 		} catch {
 			completionHandler?(error)
@@ -788,8 +788,8 @@ public class FileProviderAdapter: FileProviderAdapterType {
 					} else {
 						DDLogInfo("Successfully registered URLSessionTask for identifier: \(identifier)")
 					}
+					urlSessionTask.resume()
 				})
-				urlSessionTask.resume()
 			})
 		} catch {
 			return Promise(error)

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterResumeOrderingTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterResumeOrderingTests.swift
@@ -1,0 +1,103 @@
+//
+//  FileProviderAdapterResumeOrderingTests.swift
+//  CryptomatorFileProviderTests
+//
+//  Created by Tobias Hagemann on 17.06.26.
+//  Copyright © 2026 Skymatic GmbH. All rights reserved.
+//
+
+import CryptomatorCloudAccessCore
+import FileProvider
+import Foundation
+import XCTest
+@testable import CryptomatorCommonCore
+@testable import CryptomatorFileProvider
+
+/// A WebDAV transfer task must be resumed only *after* `NSFileProviderManager.register(_:forItemWithIdentifier:)`
+/// completes. Resuming beforehand starts the transfer before the system is tracking it, which loses progress
+/// reporting and can leave the File Provider hanging (issue #449). Registration must still resume on failure so a
+/// transfer is never silently dropped (issue #272).
+final class FileProviderAdapterResumeOrderingTests: FileProviderAdapterTestCase {
+	private let downloadIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 2)
+	private let uploadIdentifier = NSFileProviderItemIdentifier(domainIdentifier: .test, itemID: 3)
+
+	override func setUpWithError() throws {
+		try super.setUpWithError()
+		metadataManagerMock.cachedMetadata[2] = ItemMetadata(id: 2, name: "download.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, cloudPath: CloudPath("/download.txt"), isPlaceholderItem: false)
+		metadataManagerMock.cachedMetadata[3] = ItemMetadata(id: 3, name: "upload.txt", type: .file, size: 100, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, cloudPath: CloudPath("/upload.txt"), isPlaceholderItem: false)
+	}
+
+	// MARK: - Download
+
+	func testDownloadResumesTaskOnlyAfterRegistrationCompletes() throws {
+		let adapter = createFullyMockedAdapter()
+		let task = ResumeRecordingURLSessionTask()
+		_ = adapter.downloadFile(with: downloadIdentifier, to: URL(fileURLWithPath: "/dev/null"))
+		let onURLSessionTaskCreation = try XCTUnwrap(downloadTaskManagerMock.lastOnURLSessionTaskCreation)
+
+		onURLSessionTaskCreation(task)
+
+		XCTAssertTrue(taskRegistratorMock.registerForItemWithIdentifierCompletionHandlerCalled)
+		XCTAssertEqual(task.resumeCallCount, 0, "the download must not be resumed before registration completes")
+
+		let completion = try XCTUnwrap(taskRegistratorMock.registerForItemWithIdentifierCompletionHandlerReceivedArguments?.completion)
+		completion(nil)
+		XCTAssertEqual(task.resumeCallCount, 1)
+	}
+
+	func testDownloadResumesTaskEvenWhenRegistrationFails() throws {
+		let adapter = createFullyMockedAdapter()
+		let task = ResumeRecordingURLSessionTask()
+		_ = adapter.downloadFile(with: downloadIdentifier, to: URL(fileURLWithPath: "/dev/null"))
+		let onURLSessionTaskCreation = try XCTUnwrap(downloadTaskManagerMock.lastOnURLSessionTaskCreation)
+
+		onURLSessionTaskCreation(task)
+		let completion = try XCTUnwrap(taskRegistratorMock.registerForItemWithIdentifierCompletionHandlerReceivedArguments?.completion)
+		completion(NSError(domain: "test", code: 1))
+
+		XCTAssertEqual(task.resumeCallCount, 1, "a failed registration must still resume the download")
+	}
+
+	// MARK: - Upload
+
+	func testUploadResumesTaskOnlyAfterRegistrationCompletes() throws {
+		let adapter = createFullyMockedAdapter()
+		let task = ResumeRecordingURLSessionTask()
+		let taskRecord = UploadTaskRecord(correspondingItem: 3, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil, uploadStartedAt: Date())
+
+		_ = adapter.uploadFile(taskRecord: taskRecord, itemIdentifier: uploadIdentifier)
+		let onURLSessionTaskCreation = try XCTUnwrap(uploadTaskManagerMock.getTaskForOnURLSessionTaskCreationReceivedArguments?.onURLSessionTaskCreation)
+
+		onURLSessionTaskCreation(task)
+		XCTAssertEqual(task.resumeCallCount, 0, "the upload must not be resumed before registration completes")
+
+		let completion = try XCTUnwrap(taskRegistratorMock.registerForItemWithIdentifierCompletionHandlerReceivedArguments?.completion)
+		completion(nil)
+		XCTAssertEqual(task.resumeCallCount, 1)
+	}
+
+	func testUploadResumesTaskEvenWhenRegistrationFails() throws {
+		let adapter = createFullyMockedAdapter()
+		let task = ResumeRecordingURLSessionTask()
+		let taskRecord = UploadTaskRecord(correspondingItem: 3, lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil, uploadStartedAt: Date())
+
+		_ = adapter.uploadFile(taskRecord: taskRecord, itemIdentifier: uploadIdentifier)
+		let onURLSessionTaskCreation = try XCTUnwrap(uploadTaskManagerMock.getTaskForOnURLSessionTaskCreationReceivedArguments?.onURLSessionTaskCreation)
+
+		onURLSessionTaskCreation(task)
+		let completion = try XCTUnwrap(taskRegistratorMock.registerForItemWithIdentifierCompletionHandlerReceivedArguments?.completion)
+		completion(NSError(domain: "test", code: 1))
+
+		XCTAssertEqual(task.resumeCallCount, 1, "a failed registration must still resume the upload")
+	}
+}
+
+private final class ResumeRecordingURLSessionTask: URLSessionTask, @unchecked Sendable {
+	private(set) var resumeCallCount = 0
+
+	override func resume() {
+		resumeCallCount += 1
+	}
+
+	override func cancel() {}
+}

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
@@ -352,8 +352,10 @@ class CloudTaskExecutorTestCase: XCTestCase {
 
 	class DownloadTaskManagerMock: DownloadTaskManager {
 		var removedTasks = [DownloadTaskRecord]()
+		var lastOnURLSessionTaskCreation: URLSessionTaskCreationClosure?
 
 		func createTask(for item: ItemMetadata, replaceExisting: Bool, localURL: URL, onURLSessionTaskCreation: CryptomatorFileProvider.URLSessionTaskCreationClosure?) throws -> DownloadTask {
+			lastOnURLSessionTaskCreation = onURLSessionTaskCreation
 			let taskRecord = DownloadTaskRecord(correspondingItem: item.id!, replaceExisting: replaceExisting, localURL: localURL)
 			return DownloadTask(taskRecord: taskRecord, itemMetadata: item, onURLSessionTaskCreation: onURLSessionTaskCreation)
 		}


### PR DESCRIPTION
Fixes #449.

In Files.app, tapping a WebDAV file to open it never downloads or opens: the spinner just spins forever. Some users also see "Couldn't communicate with a helper application" when they tap the stuck item again, and locking/unlocking the vault clears it temporarily. Reported on 2.8.3 through 3.1.0.

Root cause: `FileProviderAdapter` resumed the transfer's `URLSessionTask` before `NSFileProviderManager.register(_:forItemWithIdentifier:)` had completed. That ordering shipped in 2.8.0 (ec9703bd), as a side effect of the #272 upload fix in #438, which moved `resume()` out of the registration completion handler. Starting the transfer before the system has registered it can leave the File Provider hanging.

The fix moves `urlSessionTask.resume()` back inside the registration completion handler, on both the success and error branches, so a transfer still always resumes even when registration fails (the guarantee #272 needed). Applied to both the download and upload paths.

## Flow

```mermaid
sequenceDiagram
  participant FP as FileProviderAdapter
  participant M as NSFileProviderManager
  participant T as URLSessionTask
  FP->>M: register(task, forItemWithIdentifier:)
  M-->>FP: completion (success or error)
  FP->>T: resume()
```

iOS side only, no cloud-access-swift change.

Validated on a physical device (iOS 26.5): the hang no longer reproduces. New regression tests (`FileProviderAdapterResumeOrderingTests`) cover the download and upload paths for both the success-ordering and registration-failure cases, and the `CryptomatorFileProvider` suite is green.

Out of scope: re-tapping a still-downloading file triggers the unimplemented `stopProvidingItem` and crashes the extension. That's a separate, pre-existing bug, not addressed here.
