### PR TITLE
Import packages as encrypted folders

### DIFF
--- a/CryptomatorFileProvider/CloudTask/CloudTask.swift
+++ b/CryptomatorFileProvider/CloudTask/CloudTask.swift
@@ -13,4 +13,22 @@ protocol CloudTask {
 	var itemMetadata: ItemMetadata { get }
 	/// Snapshot captured at task construction; survives concurrent local renames of the same row.
 	var cloudPath: CloudPath { get }
+	var onlineCollisionDisposition: OnlineCollisionDisposition { get }
+}
+
+extension CloudTask {
+	var onlineCollisionDisposition: OnlineCollisionDisposition {
+		return .renameAndRetry
+	}
+}
+
+/**
+ Whether a task may be renamed when the cloud reports that its path is already taken.
+
+ A component inside an imported package may not: its name is user data that a manifest or an internal reference can depend on,
+ so an interior collision has to fail the import instead.
+ */
+enum OnlineCollisionDisposition {
+	case renameAndRetry
+	case fail
 }

--- a/CryptomatorFileProvider/CloudTask/FolderCreationTask.swift
+++ b/CryptomatorFileProvider/CloudTask/FolderCreationTask.swift
@@ -11,8 +11,9 @@ import CryptomatorCloudAccessCore
 struct FolderCreationTask: CloudTask {
 	let itemMetadata: ItemMetadata
 	let cloudPath: CloudPath
+	var onlineCollisionDisposition: OnlineCollisionDisposition = .renameAndRetry
 
 	func with(cloudPath: CloudPath) -> FolderCreationTask {
-		return FolderCreationTask(itemMetadata: itemMetadata, cloudPath: cloudPath)
+		return FolderCreationTask(itemMetadata: itemMetadata, cloudPath: cloudPath, onlineCollisionDisposition: onlineCollisionDisposition)
 	}
 }

--- a/CryptomatorFileProvider/FileProviderAdapter.swift
+++ b/CryptomatorFileProvider/FileProviderAdapter.swift
@@ -13,6 +13,7 @@ import Dependencies
 import FileProvider
 import Foundation
 import Promises
+import UniformTypeIdentifiers
 
 public protocol FileProviderAdapterType: AnyObject {
 	var lastUnlockedDate: Date { get }
@@ -75,6 +76,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	private let domainIdentifier: NSFileProviderDomainIdentifier
 	private let fileCoordinator: NSFileCoordinator
 	private let taskRegistrator: SessionTaskRegistrator
+	private let deleteItemHelper: DeleteItemHelper
 	@Dependency(\.permissionProvider) private var permissionProvider
 
 	init(domainIdentifier: NSFileProviderDomainIdentifier,
@@ -100,6 +102,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		self.deletionTaskManager = deletionTaskManager
 		self.itemEnumerationTaskManager = itemEnumerationTaskManager
 		self.downloadTaskManager = downloadTaskManager
+		self.deleteItemHelper = DeleteItemHelper(itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager)
 		let factory = WorkflowFactory(provider: provider,
 		                              uploadTaskManager: uploadTaskManager,
 		                              cachedFileManager: cachedFileManager,
@@ -191,18 +194,15 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	public func importDocument(at fileURL: URL, toParentItemIdentifier parentItemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) {
 		DispatchQueue.main.async {
 			autoreleasepool {
+				if self.isPackage(at: fileURL) {
+					self.importPackage(at: fileURL, toParentItemIdentifier: parentItemIdentifier, completionHandler: completionHandler)
+					return
+				}
 				let localItemImportResult: LocalItemImportResult
 				do {
 					localItemImportResult = try self.localItemImport(fileURL: fileURL, parentIdentifier: parentItemIdentifier)
 				} catch let error as NSError {
-					if error.domain == NSFileProviderErrorDomain, error.code == NSFileProviderError.filenameCollision.rawValue {
-						DDLogInfo("FPExt: filenameCollision for: \(fileURL.lastPathComponent)")
-						return completionHandler(nil, error)
-					}
-					DDLogError("FPExt: localItemImport failed for: \(fileURL.lastPathComponent) with error: \(error)")
-					// Anything else is reported as `noSuchItem`. Returning the underlying error instead makes the
-					// Files app render "Couldn't communicate with a helper application", which says even less.
-					return completionHandler(nil, NSFileProviderError(.noSuchItem))
+					return self.reportLocalImportFailure(error, importing: fileURL.lastPathComponent, completionHandler: completionHandler)
 				}
 				let localImportHandler: (Error?) -> Void = { error in
 					if let error = error {
@@ -221,6 +221,17 @@ public class FileProviderAdapter: FileProviderAdapterType {
 				}.always {}
 			}
 		}
+	}
+
+	private func reportLocalImportFailure(_ error: NSError, importing name: String, completionHandler: (NSFileProviderItem?, Error?) -> Void) {
+		if error.domain == NSFileProviderErrorDomain, error.code == NSFileProviderError.filenameCollision.rawValue {
+			DDLogInfo("FPExt: filenameCollision for: \(name)")
+			return completionHandler(nil, error)
+		}
+		DDLogError("FPExt: local import failed for: \(name) with error: \(error)")
+		// Returning the underlying error instead makes the Files app render "Couldn't communicate with a helper
+		// application", which says even less than `noSuchItem`.
+		completionHandler(nil, NSFileProviderError(.noSuchItem))
 	}
 
 	func importDocument(at fileURL: URL, toParentItemIdentifier parentItemIdentifier: NSFileProviderItemIdentifier) -> Promise<NSFileProviderItem?> {
@@ -284,6 +295,283 @@ public class FileProviderAdapter: FileProviderAdapterType {
 			}
 		}
 		if let error = fileManagerError ?? fileCoordinatorError {
+			throw error
+		}
+	}
+
+	// MARK: Import Package
+
+	/// Reading the resource value is access to the item, so it needs the security scope just like the import itself does.
+	func isPackage(at url: URL) -> Bool {
+		let stopAccess = url.startAccessingSecurityScopedResource()
+		defer {
+			if stopAccess {
+				url.stopAccessingSecurityScopedResource()
+			}
+		}
+		if let isPackage = try? url.resourceValues(forKeys: [.isPackageKey]).isPackage {
+			return isPackage
+		}
+		// `UTType(filenameExtension:conformingTo:)` synthesizes a dynamic type when nothing declared matches, and an extension
+		// cannot tell a package directory from a flat document carrying the same extension, which iWork formats do.
+		guard let type = UTType(filenameExtension: url.pathExtension, conformingTo: .package), type.isDeclared else {
+			return false
+		}
+		return (try? itemType(at: url)) == FileAttributeType.typeDirectory
+	}
+
+	/**
+	 Imports a package by recursively importing its contents as an ordinary encrypted folder.
+
+	 The package keeps its name, including the extension, so copying it back out to a regular file system reconstitutes a
+	 working package.
+
+	 - Returns: A promise that settles once the whole subtree has been scheduled — for tests only, because the completion
+	 handler fires with the root placeholder long before that.
+	 */
+	@discardableResult
+	func importPackage(at fileURL: URL, toParentItemIdentifier parentItemIdentifier: NSFileProviderItemIdentifier, completionHandler: @escaping (NSFileProviderItem?, Error?) -> Void) -> Promise<Void> {
+		let result: LocalPackageImportResult
+		do {
+			result = try localPackageImport(fileURL: fileURL, parentIdentifier: parentItemIdentifier)
+		} catch let error as NSError {
+			reportLocalImportFailure(error, importing: fileURL.lastPathComponent, completionHandler: completionHandler)
+			return Promise(())
+		}
+		completionHandler(result.item, nil)
+		return schedulePackageFolder(result.rootNode, isRoot: true).recover { error in
+			// The item exists in the vault by now, so log its id rather than its cleartext name.
+			DDLogError("importPackage failed for item \(result.rootNode.itemMetadata.id ?? -1) with error: \(error)")
+		}
+	}
+
+	/**
+	 Imports a package locally, depth-first.
+
+	 - Precondition: A package exists at the `fileURL`.
+	 - Postcondition: No `UploadTaskRecord` was created, so a stuck upload recovery cannot upload into a package root that does not exist yet.
+	 - Postcondition: If anything failed, the whole subtree was removed again, because the completion handler has not reported success yet.
+	 */
+	func localPackageImport(fileURL: URL, parentIdentifier: NSFileProviderItemIdentifier) throws -> LocalPackageImportResult {
+		// Held across the whole walk, not just a single copy, because every descendant is read through this scope.
+		let stopAccess = fileURL.startAccessingSecurityScopedResource()
+		defer {
+			if stopAccess {
+				fileURL.stopAccessingSecurityScopedResource()
+			}
+		}
+		let parentID = try convertFileProviderItemIdentifierToInt64(parentIdentifier)
+		let name = fileURL.lastPathComponent.precomposedStringWithCanonicalMapping
+		let cloudPath = try getCloudPathForPlaceholderItem(withName: name, in: parentID, type: .folder)
+		// Stricter than `checkLocalItemCollision`, which treats a pending deletion as free: that deletion would complete later
+		// and take the freshly imported package with it.
+		if let existingItemMetadata = try itemMetadataManager.getCachedMetadata(for: cloudPath) {
+			throw NSError.fileProviderErrorForCollision(with: FileProviderItem(metadata: existingItemMetadata, domainIdentifier: domainIdentifier))
+		}
+		let rootItem = try createPlaceholderItemForFolder(withName: name, in: parentIdentifier)
+		do {
+			let children = try coordinatedPackageContents(of: fileURL, into: convertIDToItemIdentifier(rootItem.metadata.id!))
+			let rootNode = ImportedPackageNode(itemMetadata: rootItem.metadata, localURL: nil, children: children)
+			return LocalPackageImportResult(item: rootItem, rootNode: rootNode)
+		} catch {
+			rollBackPackageImport(rootMetadata: rootItem.metadata)
+			throw error
+		}
+	}
+
+	/**
+	 Walks the package inside a single coordinated read.
+
+	 File coordination treats a package as one unit, so reserving each interior file separately would let a writer commit
+	 between two of them and leave a copy whose files come from different revisions of the package.
+	 */
+	private func coordinatedPackageContents(of packageURL: URL, into parentIdentifier: NSFileProviderItemIdentifier) throws -> [ImportedPackageNode] {
+		var children: [ImportedPackageNode]?
+		var walkError: Error?
+		var fileCoordinatorError: NSError?
+		fileCoordinator.coordinate(readingItemAt: packageURL, options: .withoutChanges, error: &fileCoordinatorError) { url in
+			do {
+				try rejectSymbolicLink(itemType(at: url))
+				children = try importPackageContents(of: url, into: parentIdentifier)
+			} catch {
+				walkError = error
+			}
+		}
+		if let error = walkError ?? fileCoordinatorError {
+			throw error
+		}
+		guard let children = children else {
+			throw NSFileProviderError(.noSuchItem)
+		}
+		return children
+	}
+
+	/// Does not traverse links, so a symbolic link reports its own type here rather than its target's.
+	private func itemType(at url: URL) throws -> FileAttributeType? {
+		let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+		return attributes[FileAttributeKey.type] as? FileAttributeType
+	}
+
+	/**
+	 Rejects a symbolic link before it is walked or copied.
+
+	 A relative link copied into an isolated item directory has no valid target, and a directory link can escape the package or
+	 form a cycle. Every directory needs this immediately before its own read, root included, because `contentsOfDirectory`
+	 resolves a link and would otherwise walk whatever it points at.
+	 */
+	private func rejectSymbolicLink(_ type: FileAttributeType?) throws {
+		if type == FileAttributeType.typeSymbolicLink {
+			throw FileProviderAdapterError.symbolicLinkNotSupported
+		}
+	}
+
+	private func importPackageContents(of directoryURL: URL, into parentIdentifier: NSFileProviderItemIdentifier) throws -> [ImportedPackageNode] {
+		// Does not report AppleDouble sidecars (`._name`), so a package that carries them loses them on import.
+		let names = try FileManager.default.contentsOfDirectory(atPath: directoryURL.path)
+		return try names.sorted().map { name in
+			let childURL = directoryURL.appendingPathComponent(name)
+			let childType = try itemType(at: childURL)
+			try rejectSymbolicLink(childType)
+			switch childType {
+			case FileAttributeType.typeDirectory:
+				let folderItem = try createPlaceholderItemForFolder(withName: name, in: parentIdentifier)
+				let children = try importPackageContents(of: childURL, into: convertIDToItemIdentifier(folderItem.metadata.id!))
+				return ImportedPackageNode(itemMetadata: folderItem.metadata, localURL: nil, children: children)
+			default:
+				let fileMetadata = try createPlaceholderItemForFile(for: childURL, in: parentIdentifier)
+				let localURL = try copyPackageFile(from: childURL, itemMetadata: fileMetadata)
+				return ImportedPackageNode(itemMetadata: fileMetadata, localURL: localURL, children: [])
+			}
+		}
+	}
+
+	private func copyPackageFile(from sourceURL: URL, itemMetadata: ItemMetadata) throws -> URL {
+		let itemIdentifier = convertIDToItemIdentifier(itemMetadata.id!)
+		guard let localURL = localURLProvider.urlForItem(withPersistentIdentifier: itemIdentifier, itemName: itemMetadata.name) else {
+			throw NSFileProviderError(.noSuchItem)
+		}
+		// Uncoordinated on purpose: the whole walk already runs inside one coordinated read of the package root, and taking a
+		// second reservation per file is what would let a writer tear the copy apart.
+		try FileManager.default.createDirectory(at: localURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+		try FileManager.default.copyItem(at: sourceURL, to: localURL)
+		do {
+			try cachedFileManager.cacheLocalFileInfo(for: itemMetadata.id!, localURL: localURL, lastModifiedDate: nil)
+		} catch {
+			// The rollback finds copied bytes through their `LocalCachedFileInfo`, so without that row it would leave the
+			// cleartext behind. Nothing else ever reclaims it.
+			do {
+				try FileManager.default.removeItem(at: localURL)
+			} catch let removalError as NSError {
+				// Only domain and code: a `FileManager` error carries `NSFilePath`, which would put the item's cleartext name
+				// into a log the user can export.
+				DDLogError("Package import: cleartext left behind for item \(itemMetadata.id ?? -1), removal failed with \(removalError.domain) \(removalError.code)")
+			}
+			throw error
+		}
+		return localURL
+	}
+
+	/**
+	 Removes a partially imported package again.
+
+	 Only correct before the completion handler reported success. Afterwards the local copies may be all the user has left,
+	 because the Files app removes the source of a move as soon as the import returns.
+	 */
+	private func rollBackPackageImport(rootMetadata: ItemMetadata) {
+		do {
+			try deleteItemHelper.removeItemFromCache(rootMetadata)
+		} catch let error as NSError {
+			// Domain and code only, because a `FileManager` error names the path it failed on.
+			DDLogError("Package import: removing cached files during rollback failed with \(error.domain) \(error.code)")
+		}
+		do {
+			// Descendants go with it, because `itemMetadata.parentID` cascades. Attempted even when the cache removal failed,
+			// though it can only succeed once every `cachedFiles` row is gone — that table has no cascade rule.
+			try itemMetadataManager.removeItemMetadata(with: rootMetadata.id!)
+		} catch {
+			DDLogError("Package import: removing metadata during rollback failed with error: \(error)")
+		}
+	}
+
+	/**
+	 Creates a package folder in the cloud and only then constructs and schedules everything below it.
+
+	 Chaining on the scheduled workflow rather than on `createWorkflow` is what keeps a failed folder from ever releasing its
+	 descendants: `createWorkflow` resolves with the workflow object, before it ran, and the workflow dependency graph settles
+	 dependents regardless of whether the parent succeeded.
+	 */
+	func schedulePackageFolder(_ node: ImportedPackageNode, isRoot: Bool) -> Promise<Void> {
+		let task: FolderCreationTask
+		do {
+			let cloudPath = try itemMetadataManager.getCloudPath(for: node.itemMetadata.id!)
+			task = FolderCreationTask(itemMetadata: node.itemMetadata, cloudPath: cloudPath, onlineCollisionDisposition: isRoot ? .renameAndRetry : .fail)
+		} catch {
+			// Marked here too: this returns before the `recover` below is attached, so a folder that fails to even produce a
+			// task would otherwise stay `.isUploading` with nothing left to run it.
+			DDLogError("Package import: building the task for folder \(node.itemMetadata.id ?? -1) failed with error: \(error)")
+			markFolderAsUploadError(node.itemMetadata, error: error)
+			return Promise(error)
+		}
+		return workflowFactory.createWorkflow(for: task).then(scheduler.schedule).then { item -> Promise<Void> in
+			self.notificator?.signalUpdate(for: item)
+			return self.schedulePackageChildren(of: node)
+		}.recover { error -> Promise<Void> in
+			DDLogError("Package import: creating folder \(node.itemMetadata.id ?? -1) failed with error: \(error)")
+			self.markFolderAsUploadError(node.itemMetadata, error: error)
+			return Promise(error)
+		}
+	}
+
+	/// Sibling subtrees are independent, so one failing child neither cancels nor fails the others.
+	private func schedulePackageChildren(of node: ImportedPackageNode) -> Promise<Void> {
+		let settledChildren = node.children.map { child -> Promise<Void> in
+			let scheduled: Promise<Void>
+			if child.itemMetadata.type == .folder {
+				scheduled = schedulePackageFolder(child, isRoot: false)
+			} else {
+				scheduled = schedulePackageFileUpload(child)
+			}
+			return scheduled.recover { _ in }
+		}
+		return all(settledChildren).then { _ in }
+	}
+
+	/**
+	 Marks a folder whose creation failed after the import was already reported as successful.
+
+	 `markUploadAsError` cannot be used, because it updates an `UploadTaskRecord` first and a folder never has one.
+	 */
+	private func markFolderAsUploadError(_ itemMetadata: ItemMetadata, error: Error) {
+		do {
+			itemMetadata.statusCode = .uploadError
+			try itemMetadataManager.updateMetadata(itemMetadata)
+			let item = FileProviderItem(metadata: itemMetadata, domainIdentifier: domainIdentifier, error: error)
+			notificator?.signalUpdate(for: item)
+		} catch {
+			DDLogError("Package import: marking folder \(itemMetadata.id ?? -1) as failed itself failed with error: \(error)")
+		}
+	}
+
+	private func schedulePackageFileUpload(_ node: ImportedPackageNode) -> Promise<Void> {
+		guard let localURL = node.localURL else {
+			return Promise(FileProviderAdapterError.itemNotFound)
+		}
+		let itemIdentifier = convertIDToItemIdentifier(node.itemMetadata.id!)
+		let taskRecord: UploadTaskRecord
+		do {
+			taskRecord = try registerFileInUploadQueue(with: localURL, itemMetadata: node.itemMetadata)
+		} catch {
+			return Promise(error)
+		}
+		return uploadFile(taskRecord: taskRecord, itemIdentifier: itemIdentifier).then { item -> Void in
+			self.notificator?.signalUpdate(for: item)
+			// The upload executor recovers provider errors internally and fulfills with an error-bearing item, so a collision
+			// only becomes visible here. Nothing was renamed, which is why inspecting it after the fact is still in time.
+			guard let error = item.uploadingError as NSError?, error.domain == NSFileProviderErrorDomain,
+			      error.code == NSFileProviderError.filenameCollision.rawValue else {
+				return
+			}
+			DDLogError("Package import: item \(node.itemMetadata.id ?? -1) collided with an existing item, not retrying")
 			throw error
 		}
 	}
@@ -648,8 +936,7 @@ public class FileProviderAdapter: FileProviderAdapterType {
 		let itemMetadata = try getCachedMetadata(for: itemIdentifier)
 		// Resolve the cloud path BEFORE removeItemFromCache deletes the row — afterwards the resolver would fail.
 		let cloudPath = try itemMetadataManager.getCloudPath(for: itemMetadata.id!)
-		let deletionHelper = DeleteItemHelper(itemMetadataManager: itemMetadataManager, cachedFileManager: cachedFileManager)
-		try deletionHelper.removeItemFromCache(itemMetadata)
+		try deleteItemHelper.removeItemFromCache(itemMetadata)
 		return try deletionTaskManager.createTaskRecord(for: itemMetadata, cloudPath: cloudPath)
 	}
 
@@ -1024,6 +1311,21 @@ public class FileProviderAdapter: FileProviderAdapterType {
 	struct LocalItemImportResult {
 		let item: FileProviderItem
 		let uploadTaskRecord: UploadTaskRecord
+	}
+
+	struct LocalPackageImportResult {
+		let item: FileProviderItem
+		let rootNode: ImportedPackageNode
+	}
+
+	/**
+	 Keyed by parent rather than flattened, because each node's task is constructed inside its parent's scheduling continuation.
+	 Carries the `localURL` of a file, because `registerFileInUploadQueue` needs it later and nothing else recomputes it.
+	 */
+	struct ImportedPackageNode {
+		let itemMetadata: ItemMetadata
+		let localURL: URL?
+		let children: [ImportedPackageNode]
 	}
 
 	struct MoveItemLocallyResult {

--- a/CryptomatorFileProvider/FileProviderAdapterError.swift
+++ b/CryptomatorFileProvider/FileProviderAdapterError.swift
@@ -16,4 +16,5 @@ enum FileProviderAdapterError: Error {
 	case unsupportedItemType
 	case itemNotFound
 	case unresolvableParentChain
+	case symbolicLinkNotSupported
 }

--- a/CryptomatorFileProvider/Middleware/OnlineItemNameCollisionHandler.swift
+++ b/CryptomatorFileProvider/Middleware/OnlineItemNameCollisionHandler.swift
@@ -40,6 +40,10 @@ class OnlineItemNameCollisionHandler<T>: WorkflowMiddleware {
 			guard case CloudProviderError.itemAlreadyExists = error else {
 				throw error
 			}
+			// Must precede `cloudPathCollisionUpdate`, which already writes the renamed path onto the row.
+			guard task.onlineCollisionDisposition == .renameAndRetry else {
+				throw error
+			}
 			let refreshedTask = try self.cloudPathCollisionUpdate(for: task)
 			return nextMiddleware.execute(task: refreshedTask)
 		}

--- a/CryptomatorFileProvider/PermissionProvider.swift
+++ b/CryptomatorFileProvider/PermissionProvider.swift
@@ -28,7 +28,7 @@ public protocol PermissionProvider {
 	 - renaming
 	 - reparenting
 
-	 - Note: In case of an running upload, i.e. a creation of the folder in the cloud, the capabilities do not get restricted except if something listed above restricts all items of the vault.
+	 - Note: In case of an running upload, i.e. a creation of the folder in the cloud, renaming and reparenting are not allowed.
 
 	 The following capabilities hold for files:
 	 - reading
@@ -81,6 +81,12 @@ struct PermissionProviderImpl: PermissionProvider {
 			return FileProviderItem.readOnlyCapabilities
 		}
 		if item.type == .folder {
+			if item.statusCode == .isUploading {
+				// A rename or reparent here would be overwritten by the collision handler writing its task-derived name back to
+				// the row. Adding sub items stays allowed, because that is how the Files app copies a folder tree into the vault.
+				// Deleting stays allowed, so a folder whose creation never completes can still be removed by the user.
+				return [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting]
+			}
 			return [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting]
 		}
 		if item.statusCode == .isUploading {

--- a/CryptomatorFileProvider/PermissionProvider.swift
+++ b/CryptomatorFileProvider/PermissionProvider.swift
@@ -17,10 +17,10 @@ public protocol PermissionProvider {
 	 Returns the permission for a given `item` at a given `domain`.
 
 	 The following restrictions can apply to any item:
-	 - in case of an upload error it's only allowed to delete the item.
+	 - in case of an upload error it's only allowed to delete the item, even in a free version.
 	 - in case of a free version only reading is allowed, except if the vault belongs to Cryptomator Hub and it has an active subscription state.
 
-	 The following capabilities hold for files:
+	 The following capabilities hold for folders:
 	 - reading
 	 - adding sub items
 	 - content enumerating
@@ -28,7 +28,7 @@ public protocol PermissionProvider {
 	 - renaming
 	 - reparenting
 
-	 - Note: In case of an running upload, i.e. a creation of the folder in the cloud, renaming and reparenting are not allowed.
+	 - Note: In case of a running upload, i.e. a creation of the folder in the cloud, renaming and reparenting are not allowed.
 
 	 The following capabilities hold for files:
 	 - reading
@@ -36,7 +36,7 @@ public protocol PermissionProvider {
 	 - deleting
 	 - renaming
 	 - reparenting
-	 - Note: In case of an running upload for a file it's only allowed to read the item. To prevent additional modifications.
+	 - Note: In case of a running upload for a file it's only allowed to read the item. To prevent additional modifications.
 
 	 */
 	func getPermissions(for item: ItemMetadata, at domain: NSFileProviderDomainIdentifier) -> NSFileProviderItemCapabilities

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDirectoryTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDirectoryTests.swift
@@ -26,8 +26,8 @@ class FileProviderAdapterImportDirectoryTests: FileProviderAdapterTestCase {
 		}
 		metadataManagerMock.cachedMetadata[1] = ItemMetadata(item: .init(name: "/", cloudPath: CloudPath("/"), itemType: .folder, lastModifiedDate: nil, size: nil), withParentID: 1)
 		let provider = CloudProviderGraphMock()
-		let scheduler = WorkflowSchedulerMock(maxParallelUploads: 2, maxParallelDownloads: 2)
-		let adapter = FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: scheduler, provider: provider, coordinator: fileCoordinator, localURLProvider: localURLProviderMock, taskRegistrator: taskRegistratorMock)
+		let scheduler = createGraphScheduler()
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
 		var parentIdentifier: NSFileProviderItemIdentifier = .rootContainer
 
 		for _ in 0 ..< 5 {
@@ -49,123 +49,6 @@ class FileProviderAdapterImportDirectoryTests: FileProviderAdapterTestCase {
 		let importDocumentPromise = adapter.importDocument(at: localFileURL, toParentItemIdentifier: firstDirectoryItem.itemIdentifier)
 		wait(for: importDocumentPromise, timeout: 10.0)
 		return firstDirectoryItem
-	}
-
-	class CloudProviderGraphMock: CloudProvider {
-		var virtualCloudFileSystem = CloudFileGraphHandler()
-		var currentFiles = [String: CloudItemMetadata]()
-
-		func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
-			guard let metadata = virtualCloudFileSystem.getItem(at: cloudPath)?.metadata else {
-				return Promise(CloudProviderError.itemNotFound)
-			}
-			return Promise(metadata)
-		}
-
-		func fetchItemList(forFolderAt cloudPath: CloudPath, withPageToken pageToken: String?) -> Promise<CloudItemList> {
-			return Promise(MockError.notMocked)
-		}
-
-		func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
-			return Promise(MockError.notMocked)
-		}
-
-		func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
-			return Promise(()).delay(1.0).then { _ -> Promise<CloudItemMetadata> in
-				do {
-					let data = try Data(contentsOf: localURL)
-					let metadata = CloudItemMetadata(name: cloudPath.lastPathComponent, cloudPath: cloudPath, itemType: .file, lastModifiedDate: nil, size: data.count)
-					try self.virtualCloudFileSystem.createItem(at: cloudPath, metadata: metadata)
-					return Promise(metadata)
-				} catch {
-					return Promise(error)
-				}
-			}
-		}
-
-		func createFolder(at cloudPath: CloudPath) -> Promise<Void> {
-			let metadata = CloudItemMetadata(name: cloudPath.lastPathComponent, cloudPath: cloudPath, itemType: .folder, lastModifiedDate: nil, size: nil)
-			return Promise(()).delay(0.5).then { _ -> Promise<Void> in
-				do {
-					try self.virtualCloudFileSystem.createItem(at: cloudPath, metadata: metadata)
-				} catch {
-					return Promise(error)
-				}
-				return Promise(())
-			}
-		}
-
-		func deleteFile(at cloudPath: CloudPath) -> Promise<Void> {
-			return Promise(MockError.notMocked)
-		}
-
-		func deleteFolder(at cloudPath: CloudPath) -> Promise<Void> {
-			return Promise(MockError.notMocked)
-		}
-
-		func moveFile(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
-			return Promise(MockError.notMocked)
-		}
-
-		func moveFolder(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
-			return Promise(MockError.notMocked)
-		}
-	}
-
-	class WorkflowSchedulerMock: WorkflowScheduler {
-		let dispatchGroup = DispatchGroup()
-
-		override func schedule<T>(_ workflow: Workflow<T>) -> Promise<T> {
-			dispatchGroup.enter()
-			return super.schedule(workflow).then { value -> T in
-				self.dispatchGroup.leave()
-				return value
-			}.catch { error in
-				XCTFail("failed with error: \(error)")
-			}
-		}
-	}
-
-	class CloudFileGraphNode {
-		var children = [CloudFileGraphNode]()
-		let metadata: CloudItemMetadata
-
-		init(metadata: CloudItemMetadata) {
-			self.metadata = metadata
-		}
-	}
-
-	struct CloudFileGraphHandler {
-		let root = CloudFileGraphNode(metadata: .init(name: "/", cloudPath: CloudPath("/"), itemType: .folder, lastModifiedDate: nil, size: nil))
-
-		func createItem(at path: CloudPath, metadata: CloudItemMetadata) throws {
-			let partialPaths = path.getPartialCloudPaths().dropFirst().dropLast()
-			var currentParentNode = root
-
-			for partialPath in partialPaths {
-				guard let currentNode = currentParentNode.children.first(where: { $0.metadata.cloudPath == partialPath }) else {
-					throw CloudProviderError.parentFolderDoesNotExist
-				}
-				currentParentNode = currentNode
-			}
-			if currentParentNode.children.contains(where: { $0.metadata.cloudPath == path }) {
-				throw CloudProviderError.itemAlreadyExists
-			}
-			currentParentNode.children.append(.init(metadata: metadata))
-		}
-
-		func getItem(at path: CloudPath) -> CloudFileGraphNode? {
-			let partialPaths = path.getPartialCloudPaths().dropFirst()
-			var currentParentNode = root
-
-			for partialPath in partialPaths {
-				guard let currentNode = currentParentNode.children.first(where: { $0.metadata.cloudPath == partialPath }) else {
-					return nil
-				}
-				currentParentNode = currentNode
-			}
-			return currentParentNode
-		}
 	}
 }
 

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterImportDocumentTests.swift
@@ -9,19 +9,28 @@
 import CryptomatorCloudAccessCore
 import Dependencies
 import Foundation
-import Promises
 import XCTest
 @testable import CryptomatorCommonCore
 @testable import CryptomatorFileProvider
+@testable import Promises
 
 class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 	let itemID: Int64 = 2
+	/// Number of files in `createNestedPackage`.
+	let packageFileCount = 5
 	lazy var itemIdentifierDirectory = tmpDirectory.appendingPathComponent("\(itemID)", isDirectory: true)
 	lazy var expectedFileURL = itemIdentifierDirectory.appendingPathComponent("ItemToBeImported.txt")
 
 	override func setUpWithError() throws {
 		try super.setUpWithError()
-		localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReturnValue = itemIdentifierDirectory
+		// Per identifier, not one fixed directory for all: two same-named files in different interior folders of a package
+		// would otherwise resolve to the same URL and collide with `fileWriteFileExists`.
+		localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierClosure = { [tmpDirectory] identifier in
+			guard let itemID = identifier.databaseValue else {
+				return nil
+			}
+			return tmpDirectory!.appendingPathComponent("\(itemID)", isDirectory: true)
+		}
 	}
 
 	// MARK: LocalItemImport
@@ -35,8 +44,7 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 			let fileURL = tmpDirectory.appendingPathComponent("ItemToBeImported.txt", isDirectory: false)
 			let fileContent = "TestContent"
 			try fileContent.write(to: fileURL, atomically: true, encoding: .utf8)
-			let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-			try metadataManagerMock.cacheMetadata(rootItemMetadata)
+			try cacheRootItemMetadata()
 
 			let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
 
@@ -59,14 +67,14 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 	}
 
 	func testLocalItemImportFailsWhenNoLocalURLIsProvided() throws {
+		localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierClosure = nil
 		localURLProviderMock.itemIdentifierDirectoryURLForItemWithPersistentIdentifierReturnValue = nil
 
 		let fileURL = tmpDirectory.appendingPathComponent("ItemToBeImported.txt", isDirectory: false)
 		let fileContent = "TestContent"
 		try fileContent.write(to: fileURL, atomically: true, encoding: .utf8)
 
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try cacheRootItemMetadata()
 
 		XCTAssertThrowsError(try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)) { error in
 			guard NSFileProviderError(.noSuchItem) as NSError == error as NSError else {
@@ -86,8 +94,7 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 		try FileManager.default.createDirectory(at: expectedFileURL.deletingLastPathComponent(), withIntermediateDirectories: false)
 		let existingFileContent = "ExistingFileContent"
 		try existingFileContent.write(to: expectedFileURL, atomically: true, encoding: .utf8)
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try cacheRootItemMetadata()
 
 		XCTAssertThrowsError(try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)) { error in
 			guard case CocoaError.fileWriteFileExists = error else {
@@ -113,8 +120,7 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 	func testImportDocument() throws {
 		let expectation = XCTestExpectation()
 
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try cacheRootItemMetadata()
 
 		let fileURL = tmpDirectory.appendingPathComponent("ItemToBeImported.txt", isDirectory: false)
 		let fileContent = "TestContent"
@@ -156,29 +162,440 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 
 	// MARK: Packages
 
-	func testLocalItemImportFailsForPackage() throws {
+	func testLocalPackageImportCreatesRowsForEveryItem() throws {
+		try cacheRootItemMetadata()
 		let packageURL = try createPackage()
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
 
-		XCTAssertThrowsError(try adapter.localItemImport(fileURL: packageURL, parentIdentifier: .rootContainer)) { error in
-			guard case FileProviderAdapterError.folderUploadNotSupported = error else {
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+
+		XCTAssertEqual("Design Notes.rtfd", result.item.filename)
+		XCTAssertEqual(.folder, result.rootNode.itemMetadata.type)
+		XCTAssertEqual(["TXT.rtf"], result.rootNode.children.map { $0.itemMetadata.name })
+
+		let child = try XCTUnwrap(result.rootNode.children.first)
+		XCTAssertEqual(.file, child.itemMetadata.type)
+		let localURL = try XCTUnwrap(child.localURL)
+		XCTAssert(FileManager.default.fileExists(atPath: localURL.path))
+		XCTAssert(FileManager.default.contentsEqual(atPath: packageURL.appendingPathComponent("TXT.rtf").path, andPath: localURL.path))
+		XCTAssertEqual(localURL, try cachedFileManagerMock.cachedLocalFileInfo[XCTUnwrap(child.itemMetadata.id)]?.localURL)
+	}
+
+	func testLocalPackageImportWalksNestedPackage() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+
+		// Dot-files are part of the package and must not be skipped.
+		XCTAssertEqual([".metadata", "Attachments", "TXT.rtf"], result.rootNode.children.map { $0.itemMetadata.name })
+		let attachments = try XCTUnwrap(result.rootNode.children.first { $0.itemMetadata.name == "Attachments" })
+		XCTAssertEqual(.folder, attachments.itemMetadata.type)
+		XCTAssertNil(attachments.localURL)
+		XCTAssertEqual(["Deep", "logo.png", "note.txt"], attachments.children.map { $0.itemMetadata.name })
+
+		let deep = try XCTUnwrap(attachments.children.first { $0.itemMetadata.name == "Deep" })
+		XCTAssertEqual(["note.txt"], deep.children.map { $0.itemMetadata.name })
+
+		let deepFileID = try XCTUnwrap(deep.children.first?.itemMetadata.id)
+		let resolvedPath = try metadataManagerMock.getCloudPath(for: deepFileID)
+		XCTAssertEqual("/Design Notes.rtfd/Attachments/Deep/note.txt", resolvedPath.path)
+
+		// Same leaf name in two interior folders, so a name-keyed local URL would have collided.
+		let attachedNote = try XCTUnwrap(attachments.children.first { $0.itemMetadata.name == "note.txt" })
+		XCTAssertNotEqual(try XCTUnwrap(attachedNote.localURL), try XCTUnwrap(deep.children.first?.localURL))
+	}
+
+	/// A folder must never be handed to `registerFileInUploadQueue`, whose `precondition` would crash the extension.
+	func testPackageSchedulingNeverRegistersFolderMetadataForUpload() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+		let adapter = createPackageAdapter(provider: CloudProviderGraphMock(), scheduler: createGraphScheduler())
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+		wait(for: adapter.schedulePackageFolder(result.rootNode, isRoot: true), timeout: 30.0)
+
+		let registeredTypes = uploadTaskManagerMock.createNewTaskRecordForReceivedInvocations.map { $0.type }
+		XCTAssertEqual(packageFileCount, registeredTypes.count, "Did not register every package file")
+		XCTAssert(registeredTypes.allSatisfy { $0 == .file }, "Registered a non-file for upload: \(registeredTypes)")
+	}
+
+	/// For a move the Files app deletes the source as soon as the handler fires, so the local copies are all the user has left.
+	func testImportPackageReportsRootUpFrontAndKeepsRowsWhenTheRootFails() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let provider = CloudProviderGraphMock()
+		let scheduler = createGraphScheduler()
+		scheduler.failsTestOnRejection = false
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
+		provider.failureByCloudPath[CloudPath("/Design Notes.rtfd")] = CloudProviderError.noInternetConnection
+
+		var reportedItem: NSFileProviderItem?
+		var reportedError: Error?
+		let scheduled = adapter.importPackage(at: packageURL, toParentItemIdentifier: .rootContainer) { item, error in
+			reportedItem = item
+			reportedError = error
+		}
+
+		XCTAssertNil(reportedError)
+		XCTAssertEqual("Design Notes.rtfd", reportedItem?.filename)
+
+		wait(for: scheduled, timeout: 30.0)
+
+		let remaining = metadataManagerMock.cachedMetadata.values.filter { $0.id != NSFileProviderItemIdentifier.rootContainerDatabaseValue }
+		XCTAssertEqual(2, remaining.count, "Rolled back a subtree after success was already reported")
+		XCTAssertFalse(cachedFileManagerMock.cachedLocalFileInfo.isEmpty, "Deleted cached bytes after success was already reported")
+		let root = try XCTUnwrap(remaining.first { $0.type == .folder })
+		try assertPersisted(root, statusCode: .uploadError)
+	}
+
+	func testImportDocumentRoutesAPackageToThePackageImport() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let scheduler = createGraphScheduler()
+		let adapter = createPackageAdapter(provider: CloudProviderGraphMock(), scheduler: scheduler)
+
+		let importPromise = adapter.importDocument(at: packageURL, toParentItemIdentifier: .rootContainer)
+		wait(for: importPromise, timeout: 10.0)
+
+		let item = try XCTUnwrap(importPromise.value ?? nil) as? FileProviderItem
+		let rootItem = try XCTUnwrap(item)
+		XCTAssertEqual("Design Notes.rtfd", rootItem.filename)
+		// A package must not be routed to `localItemImport`, which rejects a directory with `folderUploadNotSupported`.
+		XCTAssertEqual(.folder, rootItem.metadata.type)
+		let children = metadataManagerMock.cachedMetadata.values.filter { $0.parentID == rootItem.metadata.id }
+		XCTAssertEqual(["TXT.rtf"], children.map { $0.name })
+
+		// The completion handler fires before scheduling, so without this the workflows would run on into the next test.
+		let expectation = XCTestExpectation()
+		DispatchQueue.global().async {
+			XCTAssertEqual(.success, scheduler.dispatchGroup.wait(timeout: .now() + 30))
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 35)
+	}
+
+	func testImportPackageReportsCollisionWithoutFlatteningIt() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let existingItemMetadata = ItemMetadata(name: "Design Notes.rtfd", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata(existingItemMetadata)
+		let adapter = createPackageAdapter(provider: CloudProviderGraphMock(), scheduler: createGraphScheduler())
+
+		var reportedError: NSError?
+		let scheduled = adapter.importPackage(at: packageURL, toParentItemIdentifier: .rootContainer) { _, error in
+			reportedError = error as NSError?
+		}
+
+		XCTAssertEqual(NSFileProviderErrorDomain, reportedError?.domain)
+		XCTAssertEqual(NSFileProviderError.filenameCollision.rawValue, reportedError?.code)
+		// Fulfilled rather than rejected, because `importDocument` discards the returned promise.
+		wait(for: scheduled, timeout: 10.0)
+	}
+
+	/// Nothing path-bearing may exist before the parent succeeded, because `recoverStuckUploads` picks up any record it finds.
+	func testLocalPackageImportCreatesNoUploadTaskRecords() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+
+		_ = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+
+		XCTAssertFalse(uploadTaskManagerMock.createNewTaskRecordForCalled)
+	}
+
+	func testLocalPackageImportFailsForSymbolicLinkToFile() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		try FileManager.default.createSymbolicLink(atPath: packageURL.appendingPathComponent("link.rtf").path, withDestinationPath: "TXT.rtf")
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)) { error in
+			guard case FileProviderAdapterError.symbolicLinkNotSupported = error else {
 				XCTFail("Throws the wrong error: \(error)")
 				return
 			}
 		}
-		XCTAssertFalse(uploadTaskManagerMock.createNewTaskRecordForCalled)
+		assertPackageImportRolledBack()
 	}
 
-	func testImportDocumentReportsPackageAsNoSuchItem() throws {
+	func testLocalPackageImportFailsForSymbolicLinkFormingDirectoryCycle() throws {
+		try cacheRootItemMetadata()
 		let packageURL = try createPackage()
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try FileManager.default.createSymbolicLink(at: packageURL.appendingPathComponent("cycle"), withDestinationURL: packageURL)
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)) { error in
+			guard case FileProviderAdapterError.symbolicLinkNotSupported = error else {
+				XCTFail("Throws the wrong error: \(error)")
+				return
+			}
+		}
+		assertPackageImportRolledBack()
+	}
+
+	func testLocalPackageImportRollsBackWholeSubtreeOnFailure() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+		// Sorted order is `Attachments` then `TXT.rtf`, so `Deep/note.txt` and `logo.png` are already imported by now.
+		try FileManager.default.createSymbolicLink(atPath: packageURL.appendingPathComponent("zz-link.rtf").path, withDestinationPath: "TXT.rtf")
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer))
+
+		assertPackageImportRolledBack()
+		XCTAssert(cachedFileManagerMock.cachedLocalFileInfo.isEmpty, "Left cached files behind: \(cachedFileManagerMock.cachedLocalFileInfo)")
+		// Removing a cached file leaves its (now empty) item directory behind, exactly as deleting an item does.
+		let itemDirectories = try FileManager.default.contentsOfDirectory(atPath: tmpDirectory.path).filter { Int64($0) != nil }
+		for itemDirectory in itemDirectories {
+			let contents = try FileManager.default.contentsOfDirectory(atPath: tmpDirectory.appendingPathComponent(itemDirectory).path)
+			XCTAssert(contents.isEmpty, "Left copied bytes behind in \(itemDirectory): \(contents)")
+		}
+	}
+
+	/// A pending deletion on the path must count as a collision, unlike in `checkLocalItemCollision`.
+	func testLocalPackageImportReportsCollisionForRootWithPendingDeletion() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let existingItemMetadata = ItemMetadata(name: "Design Notes.rtfd", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata(existingItemMetadata)
+		_ = try deletionTaskManagerMock.createTaskRecord(for: existingItemMetadata, cloudPath: CloudPath("/Design Notes.rtfd"))
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)) { error in
+			XCTAssertEqual(NSFileProviderErrorDomain, (error as NSError).domain)
+			XCTAssertEqual(NSFileProviderError.filenameCollision.rawValue, (error as NSError).code)
+		}
+	}
+
+	func testImportDocumentReportsPlainDirectoryAsNoSuchItem() throws {
+		try cacheRootItemMetadata()
+		let directoryURL = tmpDirectory.appendingPathComponent("Plain Folder", isDirectory: true)
+		try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+		try "content".write(to: directoryURL.appendingPathComponent("child.txt"), atomically: true, encoding: .utf8)
+		let cachedMetadataCount = metadataManagerMock.cachedMetadata.count
 
 		let adapter = createFullyMockedAdapter()
 
-		XCTAssertRejects(adapter.importDocument(at: packageURL, toParentItemIdentifier: .rootContainer), with: NSFileProviderError(.noSuchItem))
+		XCTAssertRejects(adapter.importDocument(at: directoryURL, toParentItemIdentifier: .rootContainer), with: NSFileProviderError(.noSuchItem))
+		XCTAssertEqual(cachedMetadataCount, metadataManagerMock.cachedMetadata.count, "Created a placeholder row for a plain directory")
 		XCTAssertFalse(uploadTaskManagerMock.createNewTaskRecordForCalled)
+	}
+
+	/**
+	 Uses a path that cannot be inspected, because for anything that exists the resource value answers first and the fallback
+	 this pins is never reached.
+	 */
+	func testUninspectableItemWithUnregisteredExtensionIsNotTreatedAsPackage() {
+		XCTAssertFalse(adapter.isPackage(at: tmpDirectory.appendingPathComponent("Gone.unregisteredext", isDirectory: true)))
+	}
+
+	func testDirectoryWithUnregisteredExtensionIsNotTreatedAsPackage() throws {
+		let directoryURL = tmpDirectory.appendingPathComponent("Archive.unregisteredext", isDirectory: true)
+		try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: false)
+
+		XCTAssertFalse(adapter.isPackage(at: directoryURL))
+	}
+
+	func testPackageIsTreatedAsPackage() throws {
+		let packageURL = try createPackage()
+
+		XCTAssert(adapter.isPackage(at: packageURL))
+	}
+
+	/// iWork writes flat documents that carry a declared package extension, so the extension alone must never decide.
+	func testFlatFileWithPackageExtensionIsNotTreatedAsPackage() throws {
+		let fileURL = tmpDirectory.appendingPathComponent("Flat.rtfd", isDirectory: false)
+		try "TestContent".write(to: fileURL, atomically: true, encoding: .utf8)
+
+		XCTAssertFalse(adapter.isPackage(at: fileURL))
+	}
+
+	/// Reaches the fallback, because the resource value cannot be read for an item that is not there.
+	func testUninspectableItemWithPackageExtensionIsNotTreatedAsPackage() {
+		XCTAssertFalse(adapter.isPackage(at: tmpDirectory.appendingPathComponent("Gone.rtfd", isDirectory: true)))
+	}
+
+	/// Rollback finds copied bytes only via their cached-file row.
+	func testLocalPackageImportRemovesCopiedBytesWhenCachingThemFails() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		cachedFileManagerMock.cacheLocalFileInfoThrowableError = CloudProviderError.noInternetConnection
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer))
+
+		let itemDirectories = try FileManager.default.contentsOfDirectory(atPath: tmpDirectory.path).filter { Int64($0) != nil }
+		for itemDirectory in itemDirectories {
+			let contents = try FileManager.default.contentsOfDirectory(atPath: tmpDirectory.appendingPathComponent(itemDirectory).path)
+			XCTAssert(contents.isEmpty, "Left cleartext behind in \(itemDirectory): \(contents)")
+		}
+		assertPackageImportRolledBack()
+	}
+
+	/// Only reachable through `localPackageImport` directly: `isPackage` reports `false` for a link, so `importDocument`
+	/// routes a symbolic link to the ordinary single-file path instead.
+	func testLocalPackageImportRejectsASymbolicLinkRoot() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let linkURL = tmpDirectory.appendingPathComponent("Link.rtfd", isDirectory: true)
+		try FileManager.default.createSymbolicLink(at: linkURL, withDestinationURL: packageURL)
+
+		XCTAssertThrowsError(try adapter.localPackageImport(fileURL: linkURL, parentIdentifier: .rootContainer)) { error in
+			guard case FileProviderAdapterError.symbolicLinkNotSupported = error else {
+				XCTFail("Throws the wrong error: \(error)")
+				return
+			}
+		}
+	}
+
+	func testLocalPackageImportNormalizesEveryPathComponentToNFC() throws {
+		try cacheRootItemMetadata()
+		let nfdFolderName = "Anha\u{0308}nge"
+		let nfcFolderName = "Anhänge"
+		let nfdFileName = "Erho\u{0308}hung.txt"
+		let nfcFileName = "Erhöhung.txt"
+		XCTAssertNotEqual(Array(nfdFolderName.utf8), Array(nfcFolderName.utf8))
+
+		let packageURL = tmpDirectory.appendingPathComponent("Design Notes.rtfd", isDirectory: true)
+		let interiorURL = packageURL.appendingPathComponent(nfdFolderName, isDirectory: true)
+		try FileManager.default.createDirectory(at: interiorURL, withIntermediateDirectories: true)
+		try "TestContent".write(to: interiorURL.appendingPathComponent(nfdFileName), atomically: true, encoding: .utf8)
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+
+		let interior = try XCTUnwrap(result.rootNode.children.first)
+		// Swift string equality treats NFD and NFC as equal, so only the bytes prove normalization happened.
+		XCTAssertEqual(Array(nfcFolderName.utf8), Array(interior.itemMetadata.name.utf8))
+		let file = try XCTUnwrap(interior.children.first)
+		XCTAssertEqual(Array(nfcFileName.utf8), Array(file.itemMetadata.name.utf8))
+		let resolvedPath = try metadataManagerMock.getCloudPath(for: XCTUnwrap(file.itemMetadata.id))
+		XCTAssertEqual(Array("/Design Notes.rtfd/\(nfcFolderName)/\(nfcFileName)".utf8), Array(resolvedPath.path.utf8))
+	}
+
+	// MARK: Package Scheduling
+
+	/**
+	 Observes task *construction* rather than scheduling, because an implementation that builds child workflows eagerly and only
+	 defers `schedule` would already have snapshotted a stale path and registered dependency state.
+	 */
+	func testFailedPackageFolderNeverConstructsTasksForItsDescendants() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+		let provider = CloudProviderGraphMock()
+		let scheduler = createGraphScheduler()
+		scheduler.failsTestOnRejection = false
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+		let attachments = try XCTUnwrap(result.rootNode.children.first { $0.itemMetadata.name == "Attachments" })
+		let logo = try XCTUnwrap(attachments.children.first { $0.itemMetadata.name == "logo.png" })
+		let deep = try XCTUnwrap(attachments.children.first { $0.itemMetadata.name == "Deep" })
+		let note = try XCTUnwrap(deep.children.first)
+		let sibling = try XCTUnwrap(result.rootNode.children.first { $0.itemMetadata.name == "TXT.rtf" })
+		provider.failureByCloudPath[CloudPath("/Design Notes.rtfd/Attachments")] = CloudProviderError.noInternetConnection
+
+		metadataManagerMock.getCloudPathForReceivedInvocations.removeAll()
+		wait(for: adapter.schedulePackageFolder(result.rootNode, isRoot: true), timeout: 30.0)
+
+		let constructedFor = Set(metadataManagerMock.getCloudPathForReceivedInvocations)
+		XCTAssertFalse(try constructedFor.contains(XCTUnwrap(deep.itemMetadata.id)), "Constructed a task for a folder below a failed folder")
+		XCTAssertFalse(try constructedFor.contains(XCTUnwrap(logo.itemMetadata.id)), "Constructed a task for a file below a failed folder")
+		XCTAssertFalse(try constructedFor.contains(XCTUnwrap(note.itemMetadata.id)), "Constructed a task for a nested file below a failed folder")
+		let registeredIDs = uploadTaskManagerMock.createNewTaskRecordForReceivedInvocations.map { $0.id! }
+		XCTAssertFalse(try registeredIDs.contains(XCTUnwrap(logo.itemMetadata.id)))
+		XCTAssertFalse(try registeredIDs.contains(XCTUnwrap(note.itemMetadata.id)))
+
+		// The sibling subtree is independent and must be unaffected.
+		XCTAssertNotNil(provider.virtualCloudFileSystem.getItem(at: CloudPath("/Design Notes.rtfd/TXT.rtf")))
+		XCTAssert(try registeredIDs.contains(XCTUnwrap(sibling.itemMetadata.id)))
+
+		// Failed after the completion handler already reported success, so the local subtree survives and is marked instead.
+		try assertPersisted(attachments.itemMetadata, statusCode: .uploadError)
+		XCTAssertNotNil(try metadataManagerMock.cachedMetadata[XCTUnwrap(deep.itemMetadata.id)])
+		XCTAssertNotNil(try metadataManagerMock.cachedMetadata[XCTUnwrap(note.itemMetadata.id)])
+		XCTAssertNotNil(try cachedFileManagerMock.cachedLocalFileInfo[XCTUnwrap(note.itemMetadata.id)])
+	}
+
+	func testCollidingPackageRootIsRenamedAndImportSucceeds() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let provider = CloudProviderGraphMock()
+		try provider.virtualCloudFileSystem.createItem(at: CloudPath("/Design Notes.rtfd"), metadata: .init(name: "Design Notes.rtfd", cloudPath: CloudPath("/Design Notes.rtfd"), itemType: .folder, lastModifiedDate: nil, size: nil))
+		let adapter = createPackageAdapter(provider: provider, scheduler: createGraphScheduler())
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+		wait(for: adapter.schedulePackageFolder(result.rootNode, isRoot: true), timeout: 30.0)
+
+		let renamedName = result.rootNode.itemMetadata.name
+		XCTAssertNotEqual("Design Notes.rtfd", renamedName)
+		XCTAssert(renamedName.hasPrefix("Design Notes ("), "Unexpected collision name: \(renamedName)")
+		XCTAssert(renamedName.hasSuffix(").rtfd"), "Unexpected collision name: \(renamedName)")
+		try assertPersisted(result.rootNode.itemMetadata, name: renamedName, statusCode: .isUploaded)
+		// Nothing was written into the folder that was already there.
+		XCTAssert(try XCTUnwrap(provider.virtualCloudFileSystem.getItem(at: CloudPath("/Design Notes.rtfd"))).children.isEmpty)
+		XCTAssertNotNil(provider.virtualCloudFileSystem.getItem(at: CloudPath("/\(renamedName)/TXT.rtf")))
+
+		// Without a signal per node the subtree only shows up on the next enumeration.
+		let signalledNames = fileProviderItemUpdateDelegateMock.signalUpdateForReceivedInvocations.map { $0.filename }
+		XCTAssert(signalledNames.contains(renamedName), "Never signalled the package root: \(signalledNames)")
+		XCTAssert(signalledNames.contains("TXT.rtf"), "Never signalled the package child: \(signalledNames)")
+	}
+
+	/// Renaming a component inside a package changes user data, so an interior collision has to fail rather than rename.
+	func testCollidingInteriorPackageFolderFailsWithoutRenamingAnything() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createNestedPackage()
+		let provider = CloudProviderGraphMock()
+		let scheduler = createGraphScheduler()
+		scheduler.failsTestOnRejection = false
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
+		provider.failureByCloudPath[CloudPath("/Design Notes.rtfd/Attachments")] = CloudProviderError.itemAlreadyExists
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+		let attachments = try XCTUnwrap(result.rootNode.children.first { $0.itemMetadata.name == "Attachments" })
+		wait(for: adapter.schedulePackageFolder(result.rootNode, isRoot: true), timeout: 30.0)
+
+		try assertPersisted(attachments.itemMetadata, name: "Attachments", statusCode: .uploadError)
+		// The root's own files still upload; only `Attachments` must be missing, and nothing like `Attachments (1)` may appear.
+		let packageChildren = try XCTUnwrap(provider.virtualCloudFileSystem.getItem(at: CloudPath("/Design Notes.rtfd"))).children.map { $0.metadata.name }
+		XCTAssertEqual([".metadata", "TXT.rtf"], packageChildren.sorted(), "A collision-generated interior object was created remotely")
+	}
+
+	func testCreateDirectoryOutsideAPackageStillRenamesOnCollision() throws {
+		try cacheRootItemMetadata()
+		let provider = CloudProviderGraphMock()
+		try provider.virtualCloudFileSystem.createItem(at: CloudPath("/Reports"), metadata: .init(name: "Reports", cloudPath: CloudPath("/Reports"), itemType: .folder, lastModifiedDate: nil, size: nil))
+		let scheduler = createGraphScheduler()
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
+
+		let createDirectoryPromise = adapter.createDirectory(withName: "Reports", inParentItemIdentifier: .rootContainer)
+		wait(for: createDirectoryPromise, timeout: 10.0)
+		let item = try XCTUnwrap(createDirectoryPromise.value ?? nil) as? FileProviderItem
+		let placeholderItem = try XCTUnwrap(item)
+		let expectation = XCTestExpectation()
+		DispatchQueue.global().async {
+			XCTAssertEqual(.success, scheduler.dispatchGroup.wait(timeout: .now() + 30))
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 35)
+
+		let renamedName = placeholderItem.metadata.name
+		XCTAssertNotEqual("Reports", renamedName)
+		XCTAssert(renamedName.hasPrefix("Reports ("), "Unexpected collision name: \(renamedName)")
+	}
+
+	/// A file upload never reaches the collision handler, so it is never renamed; the orchestration only classifies the result.
+	func testCollidingPackageFileSurfacesAsFilenameCollision() throws {
+		try cacheRootItemMetadata()
+		let packageURL = try createPackage()
+		let provider = CloudProviderGraphMock()
+		let scheduler = createGraphScheduler()
+		let adapter = createPackageAdapter(provider: provider, scheduler: scheduler)
+		provider.failureByCloudPath[CloudPath("/Design Notes.rtfd/TXT.rtf")] = CloudProviderError.itemAlreadyExists
+
+		let result = try adapter.localPackageImport(fileURL: packageURL, parentIdentifier: .rootContainer)
+		let child = try XCTUnwrap(result.rootNode.children.first)
+		wait(for: adapter.schedulePackageFolder(result.rootNode, isRoot: true), timeout: 30.0)
+
+		try assertPersisted(child.itemMetadata, name: "TXT.rtf", statusCode: .uploadError)
+		let recordedError = uploadTaskManagerMock.updateTaskRecordWithLastFailedUploadDateUploadErrorCodeUploadErrorDomainReceivedInvocations.last
+		XCTAssertEqual(NSFileProviderErrorDomain, recordedError?.uploadErrorDomain)
+		XCTAssertEqual(NSFileProviderError.filenameCollision.rawValue, recordedError?.uploadErrorCode)
+		XCTAssertNotEqual(NSFileProviderError.serverUnreachable.rawValue, recordedError?.uploadErrorCode)
 	}
 
 	// MARK: ItemChanged
@@ -231,8 +648,7 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 		cloudProviderMock.deleteFileAtReturnValue = deleteItemPromise
 		cloudProviderMock.uploadFileFromToReplaceExistingReturnValue = uploadItemPromise
 
-		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+		try cacheRootItemMetadata()
 
 		let itemFolderURL = tmpDirectory.appendingPathComponent("\(itemID)", isDirectory: true)
 		try FileManager.default.createDirectory(at: itemFolderURL, withIntermediateDirectories: true)
@@ -309,8 +725,7 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 			let fileURL = tmpDirectory.appendingPathComponent(nfdName, isDirectory: false)
 			try "test".write(to: fileURL, atomically: true, encoding: .utf8)
 
-			let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
-			try metadataManagerMock.cacheMetadata(rootItemMetadata)
+			try cacheRootItemMetadata()
 
 			let result = try adapter.localItemImport(fileURL: fileURL, parentIdentifier: .rootContainer)
 
@@ -325,6 +740,36 @@ class FileProviderAdapterImportDocumentTests: FileProviderAdapterTestCase {
 		try FileManager.default.createDirectory(at: packageURL, withIntermediateDirectories: false)
 		try "TestContent".write(to: packageURL.appendingPathComponent("TXT.rtf"), atomically: true, encoding: .utf8)
 		return packageURL
+	}
+
+	/**
+	 A nested package, so that parent-before-child chaining is actually exercised.
+
+	 Package types that are nested by nature tend to be declared by apps a stock simulator does not have, which would make the
+	 package check reject them for reasons unrelated to what is under test, so a nested `.rtfd` stands in for them.
+	 */
+	private func createNestedPackage() throws -> URL {
+		let packageURL = tmpDirectory.appendingPathComponent("Design Notes.rtfd", isDirectory: true)
+		let attachmentsURL = packageURL.appendingPathComponent("Attachments", isDirectory: true)
+		let deepURL = attachmentsURL.appendingPathComponent("Deep", isDirectory: true)
+		try FileManager.default.createDirectory(at: deepURL, withIntermediateDirectories: true)
+		try "Metadata".write(to: packageURL.appendingPathComponent(".metadata"), atomically: true, encoding: .utf8)
+		try "TestContent".write(to: packageURL.appendingPathComponent("TXT.rtf"), atomically: true, encoding: .utf8)
+		try "Logo".write(to: attachmentsURL.appendingPathComponent("logo.png"), atomically: true, encoding: .utf8)
+		try "Attached note".write(to: attachmentsURL.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+		try "Note".write(to: deepURL.appendingPathComponent("note.txt"), atomically: true, encoding: .utf8)
+		return packageURL
+	}
+
+	private func cacheRootItemMetadata() throws {
+		let rootItemMetadata = ItemMetadata(id: NSFileProviderItemIdentifier.rootContainerDatabaseValue, name: "Home", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploaded, isPlaceholderItem: false)
+		try metadataManagerMock.cacheMetadata(rootItemMetadata)
+	}
+
+	private func assertPackageImportRolledBack(file: StaticString = #filePath, line: UInt = #line) {
+		let remaining = metadataManagerMock.cachedMetadata.values.filter { $0.id != NSFileProviderItemIdentifier.rootContainerDatabaseValue }
+		XCTAssert(remaining.isEmpty, "Left metadata behind: \(remaining.map { $0.name })", file: file, line: line)
+		XCTAssertFalse(uploadTaskManagerMock.createNewTaskRecordForCalled, file: file, line: line)
 	}
 
 	private func assertLocalURLProviderCalledWithItemID() {

--- a/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
+++ b/CryptomatorFileProviderTests/FileProviderAdapter/FileProviderAdapterTestCase.swift
@@ -69,6 +69,147 @@ class FileProviderAdapterTestCase: CloudTaskExecutorTestCase {
 		}
 	}
 
+	class CloudProviderGraphMock: CloudProvider {
+		var virtualCloudFileSystem = CloudFileGraphHandler()
+		/// Fails a single node without failing its siblings.
+		var failureByCloudPath = [CloudPath: Error]()
+
+		func fetchItemMetadata(at cloudPath: CloudPath) -> Promise<CloudItemMetadata> {
+			guard let metadata = virtualCloudFileSystem.getItem(at: cloudPath)?.metadata else {
+				return Promise(CloudProviderError.itemNotFound)
+			}
+			return Promise(metadata)
+		}
+
+		func fetchItemList(forFolderAt cloudPath: CloudPath, withPageToken pageToken: String?) -> Promise<CloudItemList> {
+			return Promise(MockError.notMocked)
+		}
+
+		func downloadFile(from cloudPath: CloudPath, to localURL: URL, onTaskCreation: ((URLSessionDownloadTask?) -> Void)?) -> Promise<Void> {
+			return Promise(MockError.notMocked)
+		}
+
+		func uploadFile(from localURL: URL, to cloudPath: CloudPath, replaceExisting: Bool, onTaskCreation: ((URLSessionUploadTask?) -> Void)?) -> Promise<CloudItemMetadata> {
+			if let error = failureByCloudPath[cloudPath] {
+				return Promise(error)
+			}
+			return Promise(()).delay(1.0).then { _ -> Promise<CloudItemMetadata> in
+				do {
+					let data = try Data(contentsOf: localURL)
+					let metadata = CloudItemMetadata(name: cloudPath.lastPathComponent, cloudPath: cloudPath, itemType: .file, lastModifiedDate: nil, size: data.count)
+					try self.virtualCloudFileSystem.createItem(at: cloudPath, metadata: metadata)
+					return Promise(metadata)
+				} catch {
+					return Promise(error)
+				}
+			}
+		}
+
+		func createFolder(at cloudPath: CloudPath) -> Promise<Void> {
+			if let error = failureByCloudPath[cloudPath] {
+				return Promise(error)
+			}
+			let metadata = CloudItemMetadata(name: cloudPath.lastPathComponent, cloudPath: cloudPath, itemType: .folder, lastModifiedDate: nil, size: nil)
+			return Promise(()).delay(0.5).then { _ -> Promise<Void> in
+				do {
+					try self.virtualCloudFileSystem.createItem(at: cloudPath, metadata: metadata)
+				} catch {
+					return Promise(error)
+				}
+				return Promise(())
+			}
+		}
+
+		func deleteFile(at cloudPath: CloudPath) -> Promise<Void> {
+			return Promise(MockError.notMocked)
+		}
+
+		func deleteFolder(at cloudPath: CloudPath) -> Promise<Void> {
+			return Promise(MockError.notMocked)
+		}
+
+		func moveFile(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
+			return Promise(MockError.notMocked)
+		}
+
+		func moveFolder(from sourceCloudPath: CloudPath, to targetCloudPath: CloudPath) -> Promise<Void> {
+			return Promise(MockError.notMocked)
+		}
+	}
+
+	class GraphWorkflowSchedulerMock: WorkflowScheduler {
+		let dispatchGroup = DispatchGroup()
+		/// Off for tests that inject a failure.
+		var failsTestOnRejection = true
+
+		override func schedule<T>(_ workflow: Workflow<T>) -> Promise<T> {
+			dispatchGroup.enter()
+			return super.schedule(workflow).catch { error in
+				if self.failsTestOnRejection {
+					XCTFail("failed with error: \(error)")
+				}
+			}.always {
+				// Left in `always`, so an expected rejection settles the group instead of hanging the wait.
+				self.dispatchGroup.leave()
+			}
+		}
+	}
+
+	class CloudFileGraphNode {
+		var children = [CloudFileGraphNode]()
+		let metadata: CloudItemMetadata
+
+		init(metadata: CloudItemMetadata) {
+			self.metadata = metadata
+		}
+	}
+
+	struct CloudFileGraphHandler {
+		let root = CloudFileGraphNode(metadata: .init(name: "/", cloudPath: CloudPath("/"), itemType: .folder, lastModifiedDate: nil, size: nil))
+
+		func createItem(at path: CloudPath, metadata: CloudItemMetadata) throws {
+			let partialPaths = path.getPartialCloudPaths().dropFirst().dropLast()
+			var currentParentNode = root
+
+			for partialPath in partialPaths {
+				guard let currentNode = currentParentNode.children.first(where: { $0.metadata.cloudPath == partialPath }) else {
+					throw CloudProviderError.parentFolderDoesNotExist
+				}
+				currentParentNode = currentNode
+			}
+			if currentParentNode.children.contains(where: { $0.metadata.cloudPath == path }) {
+				throw CloudProviderError.itemAlreadyExists
+			}
+			currentParentNode.children.append(.init(metadata: metadata))
+		}
+
+		func getItem(at path: CloudPath) -> CloudFileGraphNode? {
+			let partialPaths = path.getPartialCloudPaths().dropFirst()
+			var currentParentNode = root
+
+			for partialPath in partialPaths {
+				guard let currentNode = currentParentNode.children.first(where: { $0.metadata.cloudPath == partialPath }) else {
+					return nil
+				}
+				currentParentNode = currentNode
+			}
+			return currentParentNode
+		}
+	}
+
+	func createGraphScheduler() -> GraphWorkflowSchedulerMock {
+		return GraphWorkflowSchedulerMock(maxParallelUploads: 2, maxParallelDownloads: 2)
+	}
+
+	/// Unlike `createFullyMockedAdapter`, its workflows really run against the virtual cloud.
+	func createPackageAdapter(provider: CloudProviderGraphMock, scheduler: GraphWorkflowSchedulerMock) -> FileProviderAdapter {
+		return withDependencies {
+			$0.fullVersionChecker = fullVersionCheckerMock
+		} operation: {
+			FileProviderAdapter(domainIdentifier: .test, uploadTaskManager: uploadTaskManagerMock, cachedFileManager: cachedFileManagerMock, itemMetadataManager: metadataManagerMock, reparentTaskManager: reparentTaskManagerMock, deletionTaskManager: deletionTaskManagerMock, itemEnumerationTaskManager: itemEnumerationTaskManagerMock, downloadTaskManager: downloadTaskManagerMock, scheduler: scheduler, provider: provider, coordinator: fileCoordinator, notificator: fileProviderItemUpdateDelegateMock, localURLProvider: localURLProviderMock, taskRegistrator: taskRegistratorMock)
+		}
+	}
+
 	func createFullyMockedAdapter() -> FileProviderAdapter {
 		return withDependencies {
 			$0.fullVersionChecker = fullVersionCheckerMock

--- a/CryptomatorFileProviderTests/Middleware/OnlineItemNameCollisionHandlerTests.swift
+++ b/CryptomatorFileProviderTests/Middleware/OnlineItemNameCollisionHandlerTests.swift
@@ -124,6 +124,66 @@ class OnlineItemNameCollisionHandlerTests: XCTestCase {
 		wait(for: [expectation], timeout: 5.0)
 	}
 
+	func testNoRenameForFailDisposition() throws {
+		let expectation = XCTestExpectation()
+		var executedCloudPaths = [CloudPath]()
+		let workflowMock = WorkflowMiddlewareMock<Void> { task in
+			executedCloudPaths.append(task.cloudPath)
+			return Promise(CloudProviderError.itemAlreadyExists)
+		}
+		let itemMetadata = ItemMetadata(name: "Attachments", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, isPlaceholderItem: true)
+		try itemMetadataManager.cacheMetadata(itemMetadata)
+		middleware.setNext(AnyWorkflowMiddleware(workflowMock))
+		let sampleCloudPath = CloudPath("/Attachments")
+		middleware.execute(task: FolderCreationTask(itemMetadata: itemMetadata, cloudPath: sampleCloudPath, onlineCollisionDisposition: .fail)).then {
+			XCTFail("Promise fulfilled")
+		}.catch { error in
+			guard case CloudProviderError.itemAlreadyExists = error else {
+				XCTFail("Promise rejected with wrong error: \(error)")
+				return
+			}
+			// The retry is what creates the renamed object remotely, so it must not have happened at all.
+			XCTAssertEqual([sampleCloudPath], executedCloudPaths)
+			guard let itemID = itemMetadata.id, let cachedItemMetadata = try? self.itemMetadataManager.getCachedMetadata(for: itemID) else {
+				XCTFail("ItemMetadata not found in DB")
+				return
+			}
+			XCTAssertEqual("Attachments", cachedItemMetadata.name)
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+	}
+
+	/// The middleware is also installed for uploads and reparents, which never opt out and must keep renaming.
+	func testTaskWithoutOwnDispositionStillRenames() throws {
+		let expectation = XCTestExpectation()
+		let originalCloudPath = CloudPath("/foo.txt")
+		var executedCloudPaths = [CloudPath]()
+		let workflowMock = WorkflowMiddlewareMock<Void> { task in
+			executedCloudPaths.append(task.cloudPath)
+			if task.cloudPath == originalCloudPath {
+				return Promise(CloudProviderError.itemAlreadyExists)
+			}
+			return Promise(())
+		}
+		let itemMetadata = ItemMetadata(name: "foo.txt", type: .file, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, isPlaceholderItem: true)
+		try itemMetadataManager.cacheMetadata(itemMetadata)
+		let taskRecord = try UploadTaskRecord(correspondingItem: XCTUnwrap(itemMetadata.id), lastFailedUploadDate: nil, uploadErrorCode: nil, uploadErrorDomain: nil, uploadStartedAt: Date())
+		let task = UploadTask(taskRecord: taskRecord, itemMetadata: itemMetadata, cloudPath: originalCloudPath, onURLSessionTaskCreation: nil)
+		XCTAssertEqual(.renameAndRetry, task.onlineCollisionDisposition)
+		middleware.setNext(AnyWorkflowMiddleware(workflowMock))
+		middleware.execute(task: task).then {
+			XCTAssertEqual(2, executedCloudPaths.count, "Did not retry under a collision-free path")
+			XCTAssertNotEqual(originalCloudPath, executedCloudPaths.last)
+		}.catch { error in
+			XCTFail("Promise failed with error: \(error)")
+		}.always {
+			expectation.fulfill()
+		}
+		wait(for: [expectation], timeout: 5.0)
+	}
+
 	func testNoRetryForDifferentError() throws {
 		let expectation = XCTestExpectation()
 		let workflowMock = WorkflowMiddlewareMock<Void> { _ in

--- a/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
+++ b/CryptomatorFileProviderTests/Middleware/TaskExecutor/CloudTaskExecutorTestCase.swift
@@ -44,6 +44,21 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		try FileManager.default.removeItem(at: tmpDirectory)
 	}
 
+	/// Asserts against the values written to the metadata store, not against the live object.
+	func assertPersisted(_ itemMetadata: ItemMetadata, name: String? = nil, statusCode: ItemStatus, file: StaticString = #filePath, line: UInt = #line) throws {
+		let id = try XCTUnwrap(itemMetadata.id, "Item has no id", file: file, line: line)
+		let snapshot = try XCTUnwrap(metadataManagerMock.persistedSnapshots[id], "Item \(id) was never written to the metadata store", file: file, line: line)
+		XCTAssertEqual(statusCode, snapshot.statusCode, "Persisted a different status", file: file, line: line)
+		if let name = name {
+			XCTAssertEqual(name, snapshot.name, "Persisted a different name", file: file, line: line)
+		}
+	}
+
+	struct PersistedMetadata: Equatable {
+		let name: String
+		let statusCode: ItemStatus
+	}
+
 	class MetadataManagerMock: ItemMetadataManager {
 		var cachedMetadata = [Int64: ItemMetadata]()
 		var removedMetadataID = [Int64]()
@@ -51,6 +66,23 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		var workingSetMetadata = [ItemMetadata]()
 		var setTagData = [Int64: Data?]()
 		var setFavoriteRank = [Int64: Int64?]()
+		/// A `CloudTask` resolves its path when it is constructed, so this records task construction rather than scheduling.
+		var getCloudPathForReceivedInvocations = [Int64]()
+		/**
+		 Field values as they were at the moment of the write.
+
+		 `cachedMetadata` hands back the very `ItemMetadata` instances production mutates, and the real manager decodes fresh
+		 objects from GRDB — so an assertion against the live instance passes even when the write never happened or ran before
+		 the mutation.
+		 */
+		private(set) var persistedSnapshots = [Int64: PersistedMetadata]()
+
+		private func recordSnapshot(of metadata: ItemMetadata) {
+			guard let id = metadata.id else {
+				return
+			}
+			persistedSnapshots[id] = PersistedMetadata(name: metadata.name, statusCode: metadata.statusCode)
+		}
 
 		func cacheMetadata(_ metadata: ItemMetadata) throws {
 			if let cachedItemMetadata = try childOfFolder(parentID: metadata.parentID, name: metadata.name), cachedItemMetadata.id != NSFileProviderItemIdentifier.rootContainerDatabaseValue {
@@ -60,6 +92,7 @@ class CloudTaskExecutorTestCase: XCTestCase {
 				metadata.favoriteRank = cachedItemMetadata.favoriteRank
 				metadata.lastEnumeratedAt = cachedItemMetadata.lastEnumeratedAt
 				cachedMetadata[cachedItemMetadata.id!] = metadata
+				recordSnapshot(of: metadata)
 				return
 			}
 			if let itemID = metadata.id {
@@ -69,6 +102,7 @@ class CloudTaskExecutorTestCase: XCTestCase {
 				metadata.id = itemID
 				cachedMetadata[itemID] = metadata
 			}
+			recordSnapshot(of: metadata)
 		}
 
 		func getCachedMetadata(for identifier: Int64) throws -> ItemMetadata? {
@@ -80,6 +114,7 @@ class CloudTaskExecutorTestCase: XCTestCase {
 			if let id = metadata.id {
 				cachedMetadata[id] = metadata
 			}
+			recordSnapshot(of: metadata)
 		}
 
 		func cacheMetadata(_ itemMetadataList: [ItemMetadata]) throws {
@@ -89,6 +124,7 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		}
 
 		func getCloudPath(for id: Int64) throws -> CloudPath {
+			getCloudPathForReceivedInvocations.append(id)
 			let rootID = NSFileProviderItemIdentifier.rootContainerDatabaseValue
 			if id == rootID {
 				return CloudPath("/")
@@ -224,6 +260,7 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		func clearCache() throws {}
 
 		var cachedLocalFileInfo = [Int64: LocalCachedFileInfo]()
+		var cacheLocalFileInfoThrowableError: Error?
 		var removeCachedFile = [Int64]()
 
 		func getLocalCachedFileInfo(for identifier: Int64) throws -> LocalCachedFileInfo? {
@@ -235,6 +272,9 @@ class CloudTaskExecutorTestCase: XCTestCase {
 		}
 
 		func cacheLocalFileInfo(for identifier: Int64, localURL: URL, lastModifiedDate: Date?) throws {
+			if let error = cacheLocalFileInfoThrowableError {
+				throw error
+			}
 			cachedLocalFileInfo[identifier] = LocalCachedFileInfo(lastModifiedDate: lastModifiedDate, correspondingItem: identifier, localLastModifiedDate: Date(), localURL: localURL)
 		}
 

--- a/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
+++ b/CryptomatorFileProviderTests/PermissionProviderImplTests.swift
@@ -14,6 +14,7 @@ import XCTest
 
 final class PermissionProviderImplTests: XCTestCase {
 	private static let defaultFolderCapabilities: NSFileProviderItemCapabilities = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting, .allowsRenaming, .allowsReparenting]
+	private static let uploadingFolderCapabilities: NSFileProviderItemCapabilities = [.allowsAddingSubItems, .allowsContentEnumerating, .allowsReading, .allowsDeleting]
 	private var fullVersionCheckerMock: FullVersionCheckerMock!
 	private var hubRepositoryMock: HubRepositoryMock!
 
@@ -38,7 +39,7 @@ final class PermissionProviderImplTests: XCTestCase {
 		}
 	}
 
-	func testUploadingFolderDoesNotRestrictCapabilities() {
+	func testUploadingFolderCannotBeRenamedOrReparented() {
 		withDependencies {
 			$0.hubRepository = hubRepositoryMock
 			$0.fullVersionChecker = fullVersionCheckerMock
@@ -48,7 +49,7 @@ final class PermissionProviderImplTests: XCTestCase {
 			let cloudPath = CloudPath("/test")
 			let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, isPlaceholderItem: false)
 			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
-			XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+			XCTAssertEqual(Self.uploadingFolderCapabilities, actualCapabilities)
 		}
 	}
 
@@ -156,7 +157,7 @@ final class PermissionProviderImplTests: XCTestCase {
 		}
 	}
 
-	func testUploadingFolderDoesNotRestrictCapabilitiesForActiveHubSubsription() {
+	func testUploadingFolderCannotBeRenamedOrReparentedForActiveHubSubsription() {
 		withDependencies {
 			$0.hubRepository = hubRepositoryMock
 			$0.fullVersionChecker = fullVersionCheckerMock
@@ -167,7 +168,7 @@ final class PermissionProviderImplTests: XCTestCase {
 			let cloudPath = CloudPath("/test")
 			let metadata = ItemMetadata(id: 2, name: "test", type: .folder, size: nil, parentID: NSFileProviderItemIdentifier.rootContainerDatabaseValue, lastModifiedDate: nil, statusCode: .isUploading, isPlaceholderItem: false)
 			let actualCapabilities = PermissionProviderImpl().getPermissions(for: metadata, at: .test)
-			XCTAssertEqual(Self.defaultFolderCapabilities, actualCapabilities)
+			XCTAssertEqual(Self.uploadingFolderCapabilities, actualCapabilities)
 		}
 	}
 


### PR DESCRIPTION
Copying a package into a vault has never worked. Files hands packages to the File Provider extension as directories, and `createPlaceholderItemForFile` rejects every `typeDirectory` with `folderUploadNotSupported`, so an `.rtfd` or iWork bundle fails with "The file doesn't exist." Copying a folder that contains one is worse: the plain files land, the package is skipped, and the single error names only the enclosing folder.

This imports packages recursively as ordinary encrypted folders. Inside the vault a package looks like a folder named `Design Notes.rtfd`, which is what it is on disk. Copying it back out reconstitutes a working package, since a directory with a registered package extension is the package. Verified on device: copied in, browsed, copied back out, opened in Quick Look.

Packages are not presented as documents inside the vault, so they can't be opened in place. Desktop does present them, since Finder derives package-ness from the extension and a mounted vault is an ordinary volume to it. Matching that here needs a package-level aggregate: one root item, one real on-disk package directory, one package operation. Shipping only the presentation half gives you something that looks like a document and opens empty, which is worse than just showing a folder.

## Flow

```mermaid
sequenceDiagram
  participant Files as Files.app
  participant A as FileProviderAdapter
  participant S as WorkflowScheduler
  participant C as Cloud
  Files->>A: importDocument(packageURL)
  A->>A: walk tree, copy bytes, create rows
  A-->>Files: completionHandler(root placeholder)
  A->>S: schedule createFolder for root
  S->>C: createFolder()
  C-->>S: ok
  A->>S: schedule children inside parent's continuation
  S->>C: createFolder() / uploadFile()
```

The ordering matters. The completion handler fires with the root placeholder before any network work, and each node's task, upload record and workflow are built inside its parent's scheduled continuation. A folder that fails never lets its descendants reach the cloud, and sibling subtrees stay independent.

Four decisions worth flagging:

- **Interior collisions fail the import instead of renaming.** Renaming a component inside a package changes user data a manifest or internal reference may depend on. The root still renames like any other item.
- **A symlink anywhere in the package fails the import** rather than being skipped. A relative link copied into an isolated item directory has no valid target, and a directory link can escape the package or cycle.
- **Rollback happens only before the completion handler fires.** #430 reports moving packages in, and Files deletes the source once the handler returns, so any later failure marks the folder and keeps the local bytes.
- **Uploading folders lose renaming and reparenting**, since the collision handler can overwrite a user rename during the remote-create window. Adding sub-items stays allowed, which is how Files copies a folder tree in.

Closes #141, closes #430.

